### PR TITLE
fix: add startup-cpu-boost and diagnostic logging to Cloud Run deploy

### DIFF
--- a/apps/commons-api/cloudbuild.yaml
+++ b/apps/commons-api/cloudbuild.yaml
@@ -46,8 +46,10 @@ steps:
         '--all-tags',
       ]
 
-  - name: 'gcr.io/cloud-builders/gcloud'
+  - id: deploy
+    name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: gcloud
+    allowFailure: true
     args:
       - run
       - deploy
@@ -56,4 +58,38 @@ steps:
       - --platform=managed
       - --image=europe-west1-docker.pkg.dev/$PROJECT_ID/commons/commons-api:prod
       - --memory=2Gi
+      - --cpu=2
+      - --startup-cpu-boost
+      - --timeout=300
+      - --concurrency=80
     timeout: 1800s
+
+  # Always print recent Cloud Run logs to surface startup errors
+  - name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: bash
+    waitFor: ['deploy']
+    args:
+      - '-c'
+      - |
+        echo "=== Cloud Run logs for arttribute-commons-api-prod ===" && \
+        gcloud logging read \
+          'resource.type=cloud_run_revision AND resource.labels.service_name=arttribute-commons-api-prod' \
+          --project=$PROJECT_ID \
+          --limit=80 \
+          --format='value(textPayload,jsonPayload.message)' \
+          --freshness=5m 2>/dev/null || true
+    timeout: 60s
+
+  # Fail the build if the deploy step failed
+  - name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: bash
+    waitFor: ['deploy']
+    args:
+      - '-c'
+      - |
+        gcloud run services describe arttribute-commons-api-prod \
+          --region=europe-west1 \
+          --format='value(status.conditions[0].status)' | grep -q True && \
+          echo "Deploy succeeded" || \
+          (echo "Deploy failed — see logs above" && exit 1)
+    timeout: 60s


### PR DESCRIPTION
- Add --cpu=2 and --startup-cpu-boost to give more CPU during container startup
- Add --timeout=300 and --concurrency=80 to the deploy step
- Mark deploy step allowFailure so diagnostic steps always run
- Add log-reading step to surface actual Cloud Run startup errors
- Add health-check step that fails the build if deploy actually failed