### PR TITLE
fix(billing): move plan-card widening and brand logo to /plans

### DIFF
--- a/apps/commons-app/app/plans/page.tsx
+++ b/apps/commons-app/app/plans/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -122,8 +123,8 @@ export default function PlansPage() {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Minimal top bar with back button */}
-      <div className="sticky top-0 z-10 flex items-center gap-2 px-4 py-3">
+      {/* Minimal top bar: back button left, brand top right */}
+      <div className="sticky top-0 z-10 flex items-center justify-between bg-background/95 px-4 py-3 backdrop-blur">
         <button
           onClick={goBack}
           aria-label="Back"
@@ -131,9 +132,16 @@ export default function PlansPage() {
         >
           <ArrowLeft className="h-5 w-5" />
         </button>
+        <Image
+          src="/logo.jpg"
+          alt="Agent Commons"
+          width={110}
+          height={28}
+          className="mr-2 shrink-0"
+        />
       </div>
 
-      <div className="mx-auto max-w-5xl px-6 pb-20">
+      <div className="mx-auto max-w-6xl px-6 pb-20">
         <div className="text-center">
           <h1 className="text-2xl font-semibold sm:text-3xl">Choose your plan</h1>
           <p className="mt-2 text-sm text-muted-foreground">

--- a/apps/commons-app/app/settings/billing/page.tsx
+++ b/apps/commons-app/app/settings/billing/page.tsx
@@ -13,7 +13,7 @@ export default function BillingPage() {
     <div className="h-screen overflow-hidden bg-background">
       <div className="flex h-screen">
         <DashboardSideBar username={walletAddress} />
-        <div className="flex-1 min-w-0 overflow-y-auto">
+        <div className="flex-1 min-w-0 overflow-y-auto px-6 py-10">
           <BillingPanel />
         </div>
       </div>

--- a/apps/commons-app/components/billing/billing-panel.tsx
+++ b/apps/commons-app/components/billing/billing-panel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -158,22 +157,8 @@ export function BillingPanel() {
     : null;
 
   return (
-    <div className="mx-auto max-w-5xl px-6 py-10">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-xl font-semibold">Billing &amp; credits</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Credits cover model usage and agent computer time.
-          </p>
-        </div>
-        <Image
-          src="/logo.jpg"
-          alt="Agent Commons"
-          width={110}
-          height={28}
-          className="shrink-0"
-        />
-      </div>
+    <div className="mx-auto max-w-2xl space-y-8">
+      <h1 className="text-xl font-semibold">Billing</h1>
 
       {/* Current plan */}
       <div className="flex items-start justify-between">


### PR DESCRIPTION
The wider cards and Agent Commons logo belonged on the dedicated /plans page, not the billing view:
- /plans: container widened to max-w-6xl (slightly wider plan cards) and the Agent Commons logo added to the top right of the sticky bar
- Billing panel: restored to its original compact look (no logo, max-w-2xl); the standalone /settings/billing page supplies its own padding instead