### PR TITLE
Match the diagnostic upload signature

### DIFF
--- a/.github/workflows/diagnose-codebuild.yml
+++ b/.github/workflows/diagnose-codebuild.yml
@@ -103,6 +103,7 @@ jobs:
           printf '{"preflight":true}\n' > /tmp/service-deployment-preflight.json
           curl --fail-with-body --silent --show-error \
             -X PUT \
+            -H 'Content-Type:' \
             --data-binary @/tmp/service-deployment-preflight.json \
             "$put_url"
           aws s3 cp "s3://${DIAGNOSTIC_BUCKET}/${diagnostic_key}" - >/dev/null
@@ -136,7 +137,7 @@ jobs:
                     --argjson deploymentList "$deployment_list" \
                     '{stack: $stack, service: $service, deploymentList: $deploymentList}' \
                     > /tmp/service-deployment.json
-                  curl --fail-with-body --silent --show-error -X PUT --data-binary @/tmp/service-deployment.json "$DIAGNOSTIC_PUT_URL"
+                  curl --fail-with-body --silent --show-error -X PUT -H 'Content-Type:' --data-binary @/tmp/service-deployment.json "$DIAGNOSTIC_PUT_URL"
           YAML
           )
 


### PR DESCRIPTION
## Summary
- suppress curl’s implicit form content type on signed diagnostic uploads
- match the exact headers used to generate the S3 PUT signature

## Evidence
The authenticated preflight returned `SignatureDoesNotMatch`; S3’s string-to-sign showed curl had added `application/x-www-form-urlencoded` while the presigned request had no content type.

## Validation
- `actionlint .github/workflows/diagnose-codebuild.yml` (when available)
- `git diff --check`