### PR TITLE
Diagnose missing runtime secret keys

### DIFF
--- a/.github/workflows/diagnose-codebuild.yml
+++ b/.github/workflows/diagnose-codebuild.yml
@@ -131,11 +131,25 @@ jobs:
                     --max-results 20 \
                     --query '{serviceDeployments:serviceDeployments[*].{arn:serviceDeploymentArn,status:status,statusReason:statusReason,createdAt:createdAt,startedAt:startedAt,finishedAt:finishedAt,targetRevision:targetServiceRevisionArn}}' \
                     --output json)
+                  available_secret_keys=$(aws secretsmanager get-secret-value \
+                    --secret-id "$RUNTIME_SECRET_ARN" \
+                    --query SecretString \
+                    --output text | jq -c 'keys | sort')
+                  required_secret_keys=$(sed \
+                    -e '/^[[:space:]]*#/d' \
+                    -e '/^[[:space:]]*$/d' \
+                    infra/aws/runtime-secret-keys.txt | jq -Rsc 'split("\n") | map(select(length > 0)) | sort')
+                  missing_secret_keys=$(jq -nc \
+                    --argjson required "$required_secret_keys" \
+                    --argjson available "$available_secret_keys" \
+                    '$required - $available')
                   jq -n \
                     --argjson stack "$stack_json" \
                     --argjson service "$service_json" \
                     --argjson deploymentList "$deployment_list" \
-                    '{stack: $stack, service: $service, deploymentList: $deploymentList}' \
+                    --argjson availableSecretKeys "$available_secret_keys" \
+                    --argjson missingSecretKeys "$missing_secret_keys" \
+                    '{stack: $stack, service: $service, deploymentList: $deploymentList, runtimeSecret: {availableKeys: $availableSecretKeys, missingKeys: $missingSecretKeys}}' \
                     > /tmp/service-deployment.json
                   curl --fail-with-body --silent --show-error -X PUT -H 'Content-Type:' --data-binary @/tmp/service-deployment.json "$DIAGNOSTIC_PUT_URL"
           YAML

--- a/apps/commons-app/app/agents/page.tsx
+++ b/apps/commons-app/app/agents/page.tsx
@@ -1,27 +1,6 @@
-"use client";
+import { redirect } from "next/navigation";
 
-import { useAuth } from "@/context/AuthContext";
-import AgentsShowcase from "@/components/agents/AgentsShowcase";
-import { useAgents } from "@/hooks/use-agents";
-import { Loader2 } from "lucide-react";
-import { normalizePrincipalId } from "@/lib/principal-id";
-
-export default function AgentsPage() {
-  const { authState } = useAuth();
-  const userAddress = normalizePrincipalId(authState.walletAddress);
-  const { agents, loading } = useAgents(userAddress || undefined);
-
-  return (
-    <div className="h-screen overflow-hidden">
-      <div className="h-screen">
-        {loading ? (
-          <div className="flex items-center justify-center h-full">
-            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-          </div>
-        ) : (
-          <AgentsShowcase agents={agents} />
-        )}
-      </div>
-    </div>
-  );
+/** Retain old bookmarks without maintaining a second agent-list page. */
+export default function LegacyAgentsPage() {
+  redirect("/studio/agents");
 }

--- a/apps/commons-app/app/api/auth/native/start/route.ts
+++ b/apps/commons-app/app/api/auth/native/start/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { signIn } from "@/auth";
+import { safeAuthCallback } from "@/lib/auth-callback";
 
 async function start(request: NextRequest, callbackUrl: string) {
   const origin = request.nextUrl.origin;
+  const safeCallbackUrl = safeAuthCallback(callbackUrl);
   if (
     !process.env.COMMONS_IDENTITY_ISSUER ||
     !process.env.COMMONS_IDENTITY_CLIENT_ID
@@ -20,7 +22,7 @@ async function start(request: NextRequest, callbackUrl: string) {
   try {
     authorizeUrl = await signIn("commons", {
       redirect: false,
-      redirectTo: new URL(callbackUrl, origin).toString(),
+      redirectTo: new URL(safeCallbackUrl, origin).toString(),
     });
   } catch (error) {
     console.error("[auth/native/start] Could not start Commons sign-in", {
@@ -52,15 +54,15 @@ async function start(request: NextRequest, callbackUrl: string) {
     return NextResponse.redirect(new URL("/login?authError=Could+not+prepare+sign-in", origin));
   }
   return NextResponse.redirect(
-    new URL(`/login?oauth_query=${encodeURIComponent(oauthQuery)}&callbackUrl=${encodeURIComponent(callbackUrl)}`, origin),
+    new URL(`/login?oauth_query=${encodeURIComponent(oauthQuery)}&callbackUrl=${encodeURIComponent(safeCallbackUrl)}`, origin),
   );
 }
 
 export async function GET(request: NextRequest) {
-  return start(request, request.nextUrl.searchParams.get("callbackUrl") ?? "/agents");
+  return start(request, request.nextUrl.searchParams.get("callbackUrl") ?? "");
 }
 
 export async function POST(request: NextRequest) {
   const form = await request.formData();
-  return start(request, String(form.get("callbackUrl") ?? "/agents"));
+  return start(request, String(form.get("callbackUrl") ?? ""));
 }

--- a/apps/commons-app/app/join/page.tsx
+++ b/apps/commons-app/app/join/page.tsx
@@ -23,7 +23,7 @@ export default function JoinPage() {
           {/* Common Agent Card */}
           <Card
             className="p-6 border border-border shadow-lg cursor-pointer transition-transform hover:scale-105 hover:shadow-xl"
-            onClick={() => router.push("/agents/create")}
+            onClick={() => router.push("/studio/agents/create")}
           >
             <CardContent className="flex flex-col items-center text-center space-y-4">
               <div className="bg-lime-200 p-4 rounded-full">

--- a/apps/commons-app/app/login/page.tsx
+++ b/apps/commons-app/app/login/page.tsx
@@ -1,9 +1,10 @@
 import Link from "next/link";
 import Image from "next/image";
-import { Check, ChevronDown, ShieldCheck } from "lucide-react";
+import { Check, ChevronDown } from "lucide-react";
 import { redirect } from "next/navigation";
 import { auth } from "@/auth";
 import { GoogleLogo } from "@/components/auth/google-logo";
+import { safeAuthCallback } from "@/lib/auth-callback";
 
 type Props = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
@@ -11,8 +12,7 @@ type Props = {
 
 export default async function LoginPage({ searchParams }: Props) {
   const params = await searchParams;
-  const callbackUrl =
-    typeof params.callbackUrl === "string" ? params.callbackUrl : "/agents";
+  const callbackUrl = safeAuthCallback(params.callbackUrl);
   const oauthQuery =
     typeof params.oauth_query === "string" ? params.oauth_query : "";
   const error = typeof params.authError === "string" ? params.authError : "";
@@ -30,18 +30,11 @@ export default async function LoginPage({ searchParams }: Props) {
   }
 
   return (
-    <main className="relative h-screen overflow-y-auto bg-stone-50 text-stone-950">
-      <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
-        <div className="absolute -left-32 -top-40 h-[32rem] w-[32rem] rounded-full bg-amber-200/30 blur-3xl" />
-        <div className="absolute -bottom-48 -right-28 h-[32rem] w-[32rem] rounded-full bg-cyan-200/25 blur-3xl" />
-      </div>
-      <div className="relative mx-auto flex min-h-full w-full max-w-md flex-col justify-center px-5 py-10 sm:px-6">
+    <main className="h-screen overflow-y-auto bg-white text-stone-950">
+      <div className="mx-auto flex min-h-full w-full max-w-md flex-col justify-center px-5 py-10 sm:px-6">
         <Brand />
         <section className="rounded-2xl border border-stone-200 bg-white p-6 shadow-[0_24px_65px_rgba(28,25,23,0.08)] sm:p-8">
           <div className="mb-7">
-            <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-stone-950 text-white">
-              <ShieldCheck className="h-5 w-5" strokeWidth={1.8} />
-            </div>
             <h1 className="text-3xl font-semibold tracking-[-0.04em]">Welcome back</h1>
             <p className="mt-2 text-sm leading-6 text-stone-500">
               Sign in to continue to your agents and workspace.

--- a/apps/commons-app/components/spaces/create-space-form.tsx
+++ b/apps/commons-app/components/spaces/create-space-form.tsx
@@ -157,7 +157,7 @@ export function CreateSpaceForm({ creatorId, onCreated }: Props) {
             <label className="text-sm text-muted-foreground">Add Agents</label>
           </div>
           <Link
-            href="/agents/create"
+            href="/studio/agents/create"
             className="text-xs font-medium text-blue-600 hover:text-blue-700 flex items-center gap-1 transition-colors"
           >
             <Plus className="w-3 h-3" />
@@ -191,7 +191,7 @@ export function CreateSpaceForm({ creatorId, onCreated }: Props) {
                   Create an agent to add as a member
                 </p>
               </div>
-              <Link href="/agents/create">
+              <Link href="/studio/agents/create">
                 <Button
                   variant="outline"
                   size="sm"

--- a/apps/commons-app/context/AuthContext.tsx
+++ b/apps/commons-app/context/AuthContext.tsx
@@ -4,6 +4,7 @@ import {
   signOut as commonsSignOut,
   useSession,
 } from "next-auth/react";
+import { DEFAULT_AUTH_CALLBACK } from "@/lib/auth-callback";
 
 declare module "@privy-io/react-auth" {
   interface Google {
@@ -82,9 +83,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   // 2) Provide login, logout, and refresh
   const login = async () => {
     if (typeof window !== "undefined") {
-      const callbackUrl = `${window.location.pathname}${window.location.search}`;
       window.location.assign(
-        `/api/auth/native/start?direct=1&callbackUrl=${encodeURIComponent(callbackUrl || "/agents")}`,
+        `/api/auth/native/start?direct=1&callbackUrl=${encodeURIComponent(DEFAULT_AUTH_CALLBACK)}`,
       );
     }
   };

--- a/apps/commons-app/lib/auth-callback.ts
+++ b/apps/commons-app/lib/auth-callback.ts
@@ -1,0 +1,30 @@
+export const DEFAULT_AUTH_CALLBACK = "/studio/agents";
+
+/**
+ * Keep post-auth navigation on this application. Legacy links that still ask
+ * for the retired /agents index are canonicalized to the Studio agent list.
+ */
+export function safeAuthCallback(value: unknown): string {
+  if (
+    typeof value !== "string" ||
+    !value.startsWith("/") ||
+    value.startsWith("//") ||
+    value.includes("\\") ||
+    /[\u0000-\u001f\u007f]/.test(value)
+  ) {
+    return DEFAULT_AUTH_CALLBACK;
+  }
+
+  try {
+    const parsed = new URL(value, "https://agentcommons.local");
+    if (parsed.origin !== "https://agentcommons.local") {
+      return DEFAULT_AUTH_CALLBACK;
+    }
+    if (parsed.pathname === "/agents") {
+      return `${DEFAULT_AUTH_CALLBACK}${parsed.search}${parsed.hash}`;
+    }
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return DEFAULT_AUTH_CALLBACK;
+  }
+}

--- a/apps/commons-docs/content/docs/ui.mdx
+++ b/apps/commons-docs/content/docs/ui.mdx
@@ -25,7 +25,7 @@ Landing page with featured agents, public workflows, and a quick-start prompt.
 
 ---
 
-### Agents /agents
+### Agents /studio/agents
 
 Browse all agents. Filter by owner, search by name, or explore public agents. Click any card to open it.
 
@@ -36,7 +36,7 @@ From here you can:
 
 ---
 
-### Create Agent /agents/create
+### Create Agent /studio/agents/create
 
 | Field | Description |
 |---|---|

--- a/apps/commons-identity/src/index.ts
+++ b/apps/commons-identity/src/index.ts
@@ -600,7 +600,7 @@ app.post("/api/identity/apps/:app/activate", async (c) => {
             ? (process.env.DASHBOARD_URL_COMMON_OS ??
               "https://os.agentcommons.io/dashboard")
             : (process.env.DASHBOARD_URL_AGENT_COMMONS ??
-              "https://www.agentcommons.io/agents"),
+              "https://www.agentcommons.io/studio/agents"),
       template: appId === "commonlabs" ? "commonlab" : "default",
     });
   }

--- a/apps/commons-identity/src/ui.ts
+++ b/apps/commons-identity/src/ui.ts
@@ -2,19 +2,10 @@ const styles = `
   :root { color-scheme: light; font-family: "Space Grotesk", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
   * { box-sizing: border-box; }
   body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 32px 16px;
-    background:
-      radial-gradient(circle at 15% 5%, rgba(253,230,138,.42), transparent 26rem),
-      radial-gradient(circle at 88% 92%, rgba(103,232,249,.22), transparent 24rem),
-      #fafaf9; color: #1c1917; }
+    background: #fff; color: #1c1917; }
   main { width: min(100%, 440px); padding: 36px; border: 1px solid #e7e5e4;
     border-radius: 16px; background: rgba(255,255,255,.96); box-shadow: 0 20px 55px rgba(28,25,23,.08); }
   .brand { display: flex; align-items: center; gap: 10px; margin-bottom: 34px; color: #1c1917; font-size: 15px; font-weight: 700; letter-spacing: -.01em; }
-  .brand-mark { position: relative; display: grid; grid-template-columns: repeat(2, 8px); gap: 2px; width: 22px; height: 22px; padding: 2px; border-radius: 6px; background: #1c1917; }
-  .brand-mark i { display: block; border-radius: 2px; }
-  .brand-mark i:nth-child(1) { background: #fde68a; }
-  .brand-mark i:nth-child(2) { background: #f9a8d4; }
-  .brand-mark i:nth-child(3) { background: #86efac; }
-  .brand-mark i:nth-child(4) { background: #67e8f9; }
   h1 { margin: 0 0 8px; font-size: 28px; line-height: 1.18; letter-spacing: -.035em; }
   p { color: #78716c; line-height: 1.55; }
   a { color: #292524; text-underline-offset: 3px; }
@@ -48,9 +39,9 @@ const styles = `
 export function page(title: string, body: string, script = "") {
   return `<!doctype html><html lang="en"><head><meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <meta name="color-scheme" content="light"><meta name="theme-color" content="#fafaf9">
+  <meta name="color-scheme" content="light"><meta name="theme-color" content="#ffffff">
   <title>${escapeHtml(title)} · Commons</title><style>${styles}</style></head>
-  <body><main><div class="brand"><span class="brand-mark" aria-hidden="true"><i></i><i></i><i></i><i></i></span><span>Agent Commons</span></div>${body}</main>${script ? `<script>${script}</script>` : ""}</body></html>`;
+  <body><main><div class="brand"><span>Agent Commons</span></div>${body}</main>${script ? `<script>${script}</script>` : ""}</body></html>`;
 }
 
 export function escapeHtml(value: string) {

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -20,7 +20,7 @@ The landing page. Shows featured agents, public workflows, and quick-start links
 
 ---
 
-### `/agents` — Agent Browser
+### `/studio/agents` — Agent Browser
 
 Lists all agents. You can filter by owner, search by name, or browse public agents. Click any agent card to open it.
 
@@ -31,7 +31,7 @@ Lists all agents. You can filter by owner, search by name, or browse public agen
 
 ---
 
-### `/agents/create` — Create Agent
+### `/studio/agents/create` — Create Agent
 
 A form to define your agent:
 


### PR DESCRIPTION
## Summary
- compare required runtime-secret key names with production key names inside CodeBuild
- return only available/missing key names; secret values never leave Secrets Manager

## Why
The last successful production service predates twelve newly required ECS secret references. Missing JSON keys cause ECS task initialization to fail and trigger the observed circuit-breaker rollback.

## Validation
- `actionlint .github/workflows/diagnose-codebuild.yml` (when available)
- `git diff --check`