### PR TITLE
Open plans directly when computer features need payment

### DIFF
--- a/apps/commons-api/src/agent/agent.controller.ts
+++ b/apps/commons-api/src/agent/agent.controller.ts
@@ -35,7 +35,11 @@ import { omit } from 'lodash';
 import { OwnerGuard, OwnerOnly } from '~/modules/auth';
 import { RuntimeDispatcherService } from './runtime/runtime-dispatcher.service';
 import { RuntimeManagementService } from './runtime/runtime-management.service';
-import { normalizeRuntimeType } from './runtime/runtime.types';
+import {
+  isManagedRuntime,
+  normalizeRuntimeType,
+} from './runtime/runtime.types';
+import { ComputerService } from '~/computer';
 import { CopilotUiContext } from './copilot-platform-guide';
 
 interface RunBody {
@@ -70,6 +74,7 @@ export class AgentController {
     private readonly pinata: PinataService,
     private readonly runtimeDispatcher: RuntimeDispatcherService,
     private readonly runtimes: RuntimeManagementService,
+    private readonly computers: ComputerService,
   ) {}
 
   @Post()
@@ -96,6 +101,12 @@ export class AgentController {
             workspaceId: principal.workspaceId ?? body.workspaceId,
           }
         : body;
+    if (isManagedRuntime(ownedBody.runtimeType)) {
+      await this.computers.assertComputerPlan(
+        (ownedBody.ownerUserId ?? ownedBody.owner) as string | undefined,
+        'This runtime runs on a dedicated agent computer, which requires a paid plan. Upgrade to Plus or higher to create it.',
+      );
+    }
     let agent = await this.agent.createAgent({
       value: ownedBody as InferInsertModel<typeof schema.agent>,
       commonsOwned: body.commonsOwned,

--- a/apps/commons-api/src/agent/runtime/runtime-management.service.ts
+++ b/apps/commons-api/src/agent/runtime/runtime-management.service.ts
@@ -98,6 +98,13 @@ export class RuntimeManagementService {
         `Unsupported agent runtime: ${String(runtimeType)}`,
       );
     }
+    // Gate before any mutation so a free-plan switch never half-applies.
+    if (runtimeType !== 'native') {
+      await this.computers.assertComputerPlan(
+        agent.ownerUserId ?? agent.owner,
+        'This runtime runs on a dedicated agent computer, which requires a paid plan. Upgrade to Plus or higher to use it.',
+      );
+    }
     const runtimeConfig = this.normalizeConfig(
       input.config ?? (agent.runtimeConfig as RuntimeConfig),
       runtimeType,

--- a/apps/commons-api/src/computer/computer.service.ts
+++ b/apps/commons-api/src/computer/computer.service.ts
@@ -172,6 +172,30 @@ export class ComputerService {
   ) {}
 
   /**
+   * Plan gate shared with flows that create computer-backed agents (managed
+   * runtimes). Throws a 402 `upgrade_required` when the owner's plan has no
+   * computer access so clients can open the plans dialog.
+   */
+  async assertComputerPlan(
+    ownerId: string | null | undefined,
+    message = 'Agent computers require a paid plan. Upgrade to Plus or higher to use computer features.',
+  ): Promise<void> {
+    if (process.env.BILLING_ENFORCEMENT === 'false') return;
+    if (!ownerId) return; // unowned/legacy agents are not gated
+    const ent = await this.entitlements.getEntitlements(ownerId);
+    if (!ent.computerUse) {
+      throw new HttpException(
+        {
+          code: 'upgrade_required',
+          feature: 'computer_use',
+          message,
+        },
+        HttpStatus.PAYMENT_REQUIRED,
+      );
+    }
+  }
+
+  /**
    * Enforce the caller's subscription entitlements before starting a computer.
    * Free plans cannot use computers at all; paid plans are limited to their
    * allowed resource profiles and a max concurrent-computer count. Gated behind
@@ -190,18 +214,8 @@ export class ComputerService {
     const ownerId = agent.ownerUserId ?? agent.owner;
     if (!ownerId) return; // unowned/legacy agents are not gated
 
+    await this.assertComputerPlan(ownerId);
     const ent = await this.entitlements.getEntitlements(ownerId);
-    if (!ent.computerUse) {
-      throw new HttpException(
-        {
-          code: 'upgrade_required',
-          feature: 'computer_use',
-          message:
-            'Agent computers require a paid plan. Upgrade to Plus or higher to use computer features.',
-        },
-        HttpStatus.PAYMENT_REQUIRED,
-      );
-    }
     if (!ent.allowedProfiles.includes(resourceProfile as ComputeProfile)) {
       throw new HttpException(
         {

--- a/apps/commons-app/app/plans/page.tsx
+++ b/apps/commons-app/app/plans/page.tsx
@@ -1,91 +1,18 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { cn } from "@/lib/utils";
-import { ArrowLeft, Check, Loader2 } from "lucide-react";
-
-type PlanKey = "free" | "plus" | "pro" | "max";
-
-interface Subscription {
-  planKey: PlanKey;
-  planName: string;
-}
-
-interface CatalogPlan {
-  key: PlanKey;
-  name: string;
-  priceUsd: number;
-  monthlyCredits: number;
-  entitlements: {
-    maxComputerAgents: number;
-    maxConcurrentComputers: number;
-    maxConcurrentRuns: number;
-    allowedProfiles: string[];
-  };
-}
-
-interface Catalog {
-  plans: CatalogPlan[];
-  topups: Array<{ key: string; credits: number; priceUsd: number }>;
-}
-
-const PLAN_COPY: Record<PlanKey, { tagline: string; highlight?: boolean }> = {
-  free: { tagline: "Start building and earn credits" },
-  plus: { tagline: "For everyday builders", highlight: true },
-  pro: { tagline: "For power users" },
-  max: { tagline: "For teams and heavier workloads" },
-};
+import { ArrowLeft } from "lucide-react";
+import { PlansGrid } from "@/components/billing/plans-grid";
 
 export default function PlansPage() {
   const router = useRouter();
-  const [sub, setSub] = useState<Subscription | null>(null);
-  const [catalog, setCatalog] = useState<Catalog | null>(null);
-  const [busy, setBusy] = useState<string | null>(null);
-
-  const load = useCallback(async () => {
-    try {
-      const [subRes, catalogRes] = await Promise.all([
-        fetch("/api/billing/subscription", { cache: "no-store" }),
-        fetch("/api/billing/catalog", { cache: "no-store" }),
-      ]);
-      setSub((await subRes.json().catch(() => ({})))?.data ?? null);
-      setCatalog((await catalogRes.json().catch(() => ({})))?.data ?? null);
-    } catch {
-      /* noop */
-    }
-  }, []);
-
-  useEffect(() => {
-    void load();
-  }, [load]);
-
-  async function checkout(path: string, body: unknown, tag: string) {
-    setBusy(tag);
-    try {
-      const res = await fetch(path, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
-      const json = await res.json().catch(() => ({}));
-      if (json?.data?.url) window.location.href = json.data.url as string;
-      else setBusy(null);
-    } catch {
-      setBusy(null);
-    }
-  }
 
   function goBack() {
     // Return to wherever the user came from; fall back to home.
     if (window.history.length > 1) router.back();
     else router.push("/");
   }
-
-  const currentPlan = sub?.planKey ?? "free";
 
   return (
     <div className="min-h-screen bg-background">
@@ -118,134 +45,8 @@ export default function PlansPage() {
           </p>
         </div>
 
-        {/* Plans */}
-        <div className="mt-10 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
-          {(catalog?.plans ?? []).map((plan) => {
-            const isCurrent = plan.key === currentPlan;
-            const copy = PLAN_COPY[plan.key];
-            const features = [
-              "Unlimited agents",
-              plan.monthlyCredits
-                ? `${plan.monthlyCredits.toLocaleString()} monthly credits`
-                : "Daily and achievement credits",
-              plan.entitlements.maxComputerAgents
-                ? `${plan.entitlements.maxComputerAgents} persistent computer ${plan.entitlements.maxComputerAgents === 1 ? "slot" : "slots"}`
-                : "No persistent computer",
-              `${plan.entitlements.maxConcurrentRuns} parallel agent runs`,
-            ];
-            return (
-              <div
-                key={plan.key}
-                className={cn(
-                  "relative flex flex-col rounded-2xl border p-6",
-                  copy.highlight && "border-indigo-300 shadow-sm",
-                  isCurrent && "ring-2 ring-indigo-400",
-                )}
-              >
-                {copy.highlight && !isCurrent && (
-                  <span className="absolute -top-2.5 left-6 rounded-full bg-indigo-500 px-2.5 py-0.5 text-[11px] font-medium text-white">
-                    Popular
-                  </span>
-                )}
-                <div className="flex items-center justify-between">
-                  <span className="text-lg font-medium">{plan.name}</span>
-                  {isCurrent && <Badge variant="secondary">Current</Badge>}
-                </div>
-                <p className="mt-0.5 text-xs text-muted-foreground">
-                  {copy.tagline}
-                </p>
-                <div className="mt-4 flex items-baseline gap-1">
-                  <span className="text-3xl font-semibold">
-                    ${plan.priceUsd}
-                  </span>
-                  <span className="text-sm text-muted-foreground">/mo</span>
-                </div>
-                <div className="mt-1 text-xs text-muted-foreground">
-                  {plan.monthlyCredits
-                    ? `${plan.monthlyCredits.toLocaleString()} credits / mo`
-                    : "Earn credits as you use the platform"}
-                </div>
-
-                <ul className="mt-5 flex-1 space-y-2">
-                  {features.map((f) => (
-                    <li key={f} className="flex items-start gap-2 text-sm">
-                      <Check className="mt-0.5 h-4 w-4 shrink-0 text-indigo-500" />
-                      <span>{f}</span>
-                    </li>
-                  ))}
-                </ul>
-
-                <div className="mt-6">
-                  {plan.key === "free" || isCurrent ? (
-                    <Button variant="outline" className="w-full" disabled>
-                      {isCurrent ? "Current plan" : "Free"}
-                    </Button>
-                  ) : (
-                    <Button
-                      className="w-full"
-                      variant={copy.highlight ? "default" : "outline"}
-                      disabled={busy !== null}
-                      onClick={() =>
-                        checkout(
-                          "/api/billing/checkout/subscription",
-                          { planKey: plan.key },
-                          `sub-${plan.key}`,
-                        )
-                      }
-                    >
-                      {busy === `sub-${plan.key}` ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        `Upgrade to ${plan.name}`
-                      )}
-                    </Button>
-                  )}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-
-        {/* One-time top-ups */}
-        <div className="mt-14">
-          <div className="text-center">
-            <h2 className="text-lg font-medium">Need more credits?</h2>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Buy a one-time top-up on any plan.
-            </p>
-          </div>
-          <div className="mx-auto mt-6 grid max-w-2xl grid-cols-1 gap-4 sm:grid-cols-3">
-            {(catalog?.topups ?? []).map((t) => (
-              <div
-                key={t.key}
-                className="flex flex-col items-center rounded-xl border p-5 text-center"
-              >
-                <div className="text-2xl font-semibold">${t.priceUsd}</div>
-                <div className="mt-1 text-xs text-muted-foreground">
-                  {t.credits.toLocaleString()} credits
-                </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="mt-4 w-full"
-                  disabled={busy !== null}
-                  onClick={() =>
-                    checkout(
-                      "/api/billing/checkout/topup",
-                      { packKey: t.key },
-                      `topup-${t.key}`,
-                    )
-                  }
-                >
-                  {busy === `topup-${t.key}` ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    "Buy"
-                  )}
-                </Button>
-              </div>
-            ))}
-          </div>
+        <div className="mt-10">
+          <PlansGrid showTopups />
         </div>
       </div>
     </div>

--- a/apps/commons-app/app/studio/agents/create/page.tsx
+++ b/apps/commons-app/app/studio/agents/create/page.tsx
@@ -17,6 +17,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useAuth } from "@/context/AuthContext";
+import {
+  UpgradeDialog,
+  upgradePromptFrom,
+  type UpgradePrompt,
+} from "@/components/billing/upgrade-dialog";
 import type { AgentRuntimeType } from "@/types/agent";
 
 interface RegistryModel {
@@ -66,6 +71,9 @@ export default function CreateAgentPage() {
   });
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [upgradePrompt, setUpgradePrompt] = useState<UpgradePrompt | null>(
+    null,
+  );
 
   useEffect(() => {
     fetch("/api/models")
@@ -130,6 +138,12 @@ export default function CreateAgentPage() {
         }),
       });
       const data = await res.json().catch(() => ({}));
+      const upgrade = upgradePromptFrom(res.status, data);
+      if (upgrade) {
+        setUpgradePrompt(upgrade);
+        setCreating(false);
+        return;
+      }
       if (!res.ok) {
         throw new Error(
           data?.message || data?.error || "Failed to create agent",
@@ -159,6 +173,13 @@ export default function CreateAgentPage() {
         </Button>
         <PageTitle title="Create New Agent" />
       </div>
+
+      <UpgradeDialog
+        prompt={upgradePrompt}
+        onOpenChange={(open) => {
+          if (!open) setUpgradePrompt(null);
+        }}
+      />
 
       <div className="min-h-0 flex-1 overflow-y-auto">
         <form

--- a/apps/commons-app/components/agents/agent-runtime-surface.tsx
+++ b/apps/commons-app/components/agents/agent-runtime-surface.tsx
@@ -20,6 +20,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  UpgradeDialog,
+  upgradePromptFrom,
+  type UpgradePrompt,
+} from "@/components/billing/upgrade-dialog";
 
 type RuntimeState = {
   runtimeType: "native" | "openclaw" | "hermes" | "custom";
@@ -40,6 +45,9 @@ export function AgentRuntimeSurface({ agentId }: { agentId: string }) {
   const [loading, setLoading] = useState(true);
   const [action, setAction] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [upgradePrompt, setUpgradePrompt] = useState<UpgradePrompt | null>(
+    null,
+  );
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -83,6 +91,11 @@ export function AgentRuntimeSurface({ agentId }: { agentId: string }) {
         method: "POST",
       });
       const payload = await response.json();
+      const upgrade = upgradePromptFrom(response.status, payload);
+      if (upgrade) {
+        setUpgradePrompt(upgrade);
+        return;
+      }
       if (!response.ok)
         throw new Error(
           payload?.message || payload?.error || `Could not ${name} runtime`,
@@ -107,6 +120,11 @@ export function AgentRuntimeSurface({ agentId }: { agentId: string }) {
         body: JSON.stringify({ runtimeType, deploy: runtimeType !== "native" }),
       });
       const payload = await response.json();
+      const upgrade = upgradePromptFrom(response.status, payload);
+      if (upgrade) {
+        setUpgradePrompt(upgrade);
+        return;
+      }
       if (!response.ok)
         throw new Error(
           payload?.message || payload?.error || "Could not update runtime",
@@ -141,6 +159,12 @@ export function AgentRuntimeSurface({ agentId }: { agentId: string }) {
 
   return (
     <div className="grid gap-4">
+      <UpgradeDialog
+        prompt={upgradePrompt}
+        onOpenChange={(open) => {
+          if (!open) setUpgradePrompt(null);
+        }}
+      />
       {error && (
         <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
           <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" />

--- a/apps/commons-app/components/billing/plans-grid.tsx
+++ b/apps/commons-app/components/billing/plans-grid.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { Check, Loader2 } from "lucide-react";
+
+type PlanKey = "free" | "plus" | "pro" | "max";
+
+interface Subscription {
+  planKey: PlanKey;
+  planName: string;
+}
+
+interface CatalogPlan {
+  key: PlanKey;
+  name: string;
+  priceUsd: number;
+  monthlyCredits: number;
+  entitlements: {
+    maxComputerAgents: number;
+    maxConcurrentComputers: number;
+    maxConcurrentRuns: number;
+    allowedProfiles: string[];
+  };
+}
+
+interface Catalog {
+  plans: CatalogPlan[];
+  topups: Array<{ key: string; credits: number; priceUsd: number }>;
+}
+
+const PLAN_COPY: Record<PlanKey, { tagline: string; highlight?: boolean }> = {
+  free: { tagline: "Start building and earn credits" },
+  plus: { tagline: "For everyday builders", highlight: true },
+  pro: { tagline: "For power users" },
+  max: { tagline: "For teams and heavier workloads" },
+};
+
+/**
+ * Self-contained plan picker: loads the catalog + current subscription and
+ * sends the user straight into Stripe checkout on upgrade. Used by the /plans
+ * page and by the upgrade dialog that paywalled features open inline.
+ */
+export function PlansGrid({
+  dense = false,
+  showTopups = false,
+}: {
+  dense?: boolean;
+  showTopups?: boolean;
+}) {
+  const [sub, setSub] = useState<Subscription | null>(null);
+  const [catalog, setCatalog] = useState<Catalog | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const [subRes, catalogRes] = await Promise.all([
+        fetch("/api/billing/subscription", { cache: "no-store" }),
+        fetch("/api/billing/catalog", { cache: "no-store" }),
+      ]);
+      setSub((await subRes.json().catch(() => ({})))?.data ?? null);
+      setCatalog((await catalogRes.json().catch(() => ({})))?.data ?? null);
+    } catch {
+      /* noop */
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function checkout(path: string, body: unknown, tag: string) {
+    setBusy(tag);
+    try {
+      const res = await fetch(path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (json?.data?.url) window.location.href = json.data.url as string;
+      else setBusy(null);
+    } catch {
+      setBusy(null);
+    }
+  }
+
+  const currentPlan = sub?.planKey ?? "free";
+
+  if (!catalog) {
+    return (
+      <div className="flex h-40 items-center justify-center">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        className={cn(
+          "grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4",
+          dense && "gap-3",
+        )}
+      >
+        {(catalog.plans ?? []).map((plan) => {
+          const isCurrent = plan.key === currentPlan;
+          const copy = PLAN_COPY[plan.key];
+          const features = [
+            "Unlimited agents",
+            plan.monthlyCredits
+              ? `${plan.monthlyCredits.toLocaleString()} monthly credits`
+              : "Daily and achievement credits",
+            plan.entitlements.maxComputerAgents
+              ? `${plan.entitlements.maxComputerAgents} persistent computer ${plan.entitlements.maxComputerAgents === 1 ? "slot" : "slots"}`
+              : "No persistent computer",
+            `${plan.entitlements.maxConcurrentRuns} parallel agent runs`,
+          ];
+          return (
+            <div
+              key={plan.key}
+              className={cn(
+                "relative flex flex-col rounded-2xl border p-6",
+                dense && "p-4",
+                copy.highlight && "border-indigo-300 shadow-sm",
+                isCurrent && "ring-2 ring-indigo-400",
+              )}
+            >
+              {copy.highlight && !isCurrent && (
+                <span className="absolute -top-2.5 left-6 rounded-full bg-indigo-500 px-2.5 py-0.5 text-[11px] font-medium text-white">
+                  Popular
+                </span>
+              )}
+              <div className="flex items-center justify-between">
+                <span className="text-lg font-medium">{plan.name}</span>
+                {isCurrent && <Badge variant="secondary">Current</Badge>}
+              </div>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {copy.tagline}
+              </p>
+              <div className="mt-4 flex items-baseline gap-1">
+                <span className="text-3xl font-semibold">${plan.priceUsd}</span>
+                <span className="text-sm text-muted-foreground">/mo</span>
+              </div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                {plan.monthlyCredits
+                  ? `${plan.monthlyCredits.toLocaleString()} credits / mo`
+                  : "Earn credits as you use the platform"}
+              </div>
+
+              <ul className={cn("mt-5 flex-1 space-y-2", dense && "mt-4")}>
+                {features.map((f) => (
+                  <li key={f} className="flex items-start gap-2 text-sm">
+                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-indigo-500" />
+                    <span>{f}</span>
+                  </li>
+                ))}
+              </ul>
+
+              <div className={cn("mt-6", dense && "mt-4")}>
+                {plan.key === "free" || isCurrent ? (
+                  <Button variant="outline" className="w-full" disabled>
+                    {isCurrent ? "Current plan" : "Free"}
+                  </Button>
+                ) : (
+                  <Button
+                    className="w-full"
+                    variant={copy.highlight ? "default" : "outline"}
+                    disabled={busy !== null}
+                    onClick={() =>
+                      checkout(
+                        "/api/billing/checkout/subscription",
+                        { planKey: plan.key },
+                        `sub-${plan.key}`,
+                      )
+                    }
+                  >
+                    {busy === `sub-${plan.key}` ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      `Upgrade to ${plan.name}`
+                    )}
+                  </Button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {showTopups && (
+        <div className="mt-14">
+          <div className="text-center">
+            <h2 className="text-lg font-medium">Need more credits?</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Buy a one-time top-up on any plan.
+            </p>
+          </div>
+          <div className="mx-auto mt-6 grid max-w-2xl grid-cols-1 gap-4 sm:grid-cols-3">
+            {(catalog.topups ?? []).map((t) => (
+              <div
+                key={t.key}
+                className="flex flex-col items-center rounded-xl border p-5 text-center"
+              >
+                <div className="text-2xl font-semibold">${t.priceUsd}</div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  {t.credits.toLocaleString()} credits
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="mt-4 w-full"
+                  disabled={busy !== null}
+                  onClick={() =>
+                    checkout(
+                      "/api/billing/checkout/topup",
+                      { packKey: t.key },
+                      `topup-${t.key}`,
+                    )
+                  }
+                >
+                  {busy === `topup-${t.key}` ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    "Buy"
+                  )}
+                </Button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/commons-app/components/billing/upgrade-dialog.tsx
+++ b/apps/commons-app/components/billing/upgrade-dialog.tsx
@@ -1,16 +1,13 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
   DialogDescription,
-  DialogFooter,
 } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { Sparkles } from "lucide-react";
+import { PlansGrid } from "@/components/billing/plans-grid";
 
 export interface UpgradePrompt {
   code: string; // 'upgrade_required' | 'limit_reached'
@@ -18,6 +15,10 @@ export interface UpgradePrompt {
   message?: string;
 }
 
+/**
+ * Paywall dialog: shows the plans inline so the user can start checkout
+ * immediately instead of being bounced through an error message first.
+ */
 export function UpgradeDialog({
   prompt,
   onOpenChange,
@@ -25,42 +26,25 @@ export function UpgradeDialog({
   prompt: UpgradePrompt | null;
   onOpenChange: (open: boolean) => void;
 }) {
-  const router = useRouter();
   const open = prompt !== null;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-5xl">
         <DialogHeader>
-          <div className="mb-1 flex h-9 w-9 items-center justify-center rounded-full bg-indigo-100 text-indigo-600">
-            <Sparkles className="h-4 w-4" />
-          </div>
           <DialogTitle>
             {prompt?.code === "limit_reached"
               ? "Plan limit reached"
-              : "Upgrade required"}
+              : "Upgrade to continue"}
           </DialogTitle>
           <DialogDescription>
             {prompt?.message ??
-              "This feature is part of a paid plan. Upgrade to continue."}
+              "This feature is part of a paid plan. Pick a plan to continue."}
           </DialogDescription>
         </DialogHeader>
-        <DialogFooter className="mt-2">
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Not now
-          </Button>
-          <Button
-            onClick={() => {
-              onOpenChange(false);
-              const feature = prompt?.feature
-                ? `?feature=${encodeURIComponent(prompt.feature)}`
-                : "";
-              router.push(`/settings/billing${feature}`);
-            }}
-          >
-            View plans
-          </Button>
-        </DialogFooter>
+        <div className="pt-2">
+          <PlansGrid dense />
+        </div>
       </DialogContent>
     </Dialog>
   );
@@ -79,8 +63,13 @@ export function upgradePromptFrom(
   if (code === "upgrade_required" || code === "limit_reached") {
     return {
       code,
-      feature: body?.feature,
-      message: typeof body?.message === "string" ? body.message : undefined,
+      feature: body?.feature ?? body?.message?.feature,
+      message:
+        typeof body?.message === "string"
+          ? body.message
+          : typeof body?.message?.message === "string"
+            ? body.message.message
+            : undefined,
     };
   }
   // Generic 402 (e.g. insufficient credits) still surfaces an upgrade path.

--- a/apps/commons-app/components/computers/agent-computer-surface.tsx
+++ b/apps/commons-app/components/computers/agent-computer-surface.tsx
@@ -243,6 +243,11 @@ export function AgentComputerSurface({
         body: JSON.stringify(computerConfigPatch(draft)),
       });
       const payload = await response.json();
+      const upgrade = upgradePromptFrom(response.status, payload);
+      if (upgrade) {
+        setUpgradePrompt(upgrade);
+        return;
+      }
       if (!response.ok) throw new Error(errorMessage(payload, "Could not save config"));
       const nextConfig = normalizeComputerConfig(payload.data);
       setConfig(nextConfig);
@@ -287,6 +292,11 @@ export function AgentComputerSurface({
         body: JSON.stringify({ enabled: true }),
       });
       const payload = await response.json();
+      const upgrade = upgradePromptFrom(response.status, payload);
+      if (upgrade) {
+        setUpgradePrompt(upgrade);
+        return;
+      }
       if (!response.ok) throw new Error(errorMessage(payload, "Could not enable computer"));
       const nextConfig = normalizeComputerConfig(payload.data);
       setConfig(nextConfig);


### PR DESCRIPTION
Paywalled computer flows now open the plan picker with one-click checkout instead of a dead-end error message. The upgrade dialog embeds the plans grid (shared with /plans), and the 402 upgrade_required path now also covers enabling computer config, runtime deploy/switch, and creating OpenClaw/Hermes/custom agents — which the API now gates before creating or mutating anything, so free-plan attempts no longer leave half-configured agents behind.