### PR TITLE
Serve the plan catalog publicly and stop /plans dead-spinning

### DIFF
--- a/apps/commons-api-gateway/src/index.ts
+++ b/apps/commons-api-gateway/src/index.ts
@@ -120,6 +120,17 @@ export function createGatewayApp() {
       c.req.path,
     ),
   );
+  // Plan and top-up pricing is public marketing data with no user context. The
+  // /plans page renders it for signed-out visitors, so it must not sit behind
+  // the credential check below.
+  app.get("/v1/billing/catalog", (c) =>
+    publicProxy(
+      c,
+      "agent-commons",
+      process.env.AGENT_COMMONS_INTERNAL_URL,
+      c.req.path,
+    ),
+  );
   // Stripe posts webhooks with no Commons credential (it authenticates via the
   // stripe-signature header, verified downstream). Pass it through publicly,
   // preserving the raw body for signature verification.

--- a/apps/commons-app/components/billing/plans-grid.tsx
+++ b/apps/commons-app/components/billing/plans-grid.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useSession } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -50,49 +51,139 @@ export function PlansGrid({
   dense?: boolean;
   showTopups?: boolean;
 }) {
+  const { status: sessionStatus } = useSession();
+  const signedIn = sessionStatus === "authenticated";
   const [sub, setSub] = useState<Subscription | null>(null);
   const [catalog, setCatalog] = useState<Catalog | null>(null);
+  const [status, setStatus] = useState<"loading" | "ready" | "error">(
+    "loading",
+  );
   const [busy, setBusy] = useState<string | null>(null);
 
   const load = useCallback(async () => {
-    try {
-      const [subRes, catalogRes] = await Promise.all([
-        fetch("/api/billing/subscription", { cache: "no-store" }),
-        fetch("/api/billing/catalog", { cache: "no-store" }),
-      ]);
-      setSub((await subRes.json().catch(() => ({})))?.data ?? null);
-      setCatalog((await catalogRes.json().catch(() => ({})))?.data ?? null);
-    } catch {
-      /* noop */
+    setStatus("loading");
+    // The catalog is public; the subscription is not. A signed-out visitor gets
+    // a 401 on the latter and still sees pricing, so only the catalog decides
+    // whether this component can render at all.
+    const [subRes, catalogRes] = await Promise.allSettled([
+      fetch("/api/billing/subscription", { cache: "no-store" }),
+      fetch("/api/billing/catalog", { cache: "no-store" }),
+    ]);
+    if (subRes.status === "fulfilled" && subRes.value.ok) {
+      const json = await subRes.value.json().catch(() => ({}));
+      setSub(json?.data ?? null);
+    } else {
+      setSub(null);
     }
+    if (catalogRes.status === "fulfilled" && catalogRes.value.ok) {
+      const json = await catalogRes.value.json().catch(() => ({}));
+      const data = json?.data ?? null;
+      if (data?.plans?.length) {
+        setCatalog(data);
+        setStatus("ready");
+        return;
+      }
+    }
+    setStatus("error");
   }, []);
 
   useEffect(() => {
     void load();
   }, [load]);
 
-  async function checkout(path: string, body: unknown, tag: string) {
-    setBusy(tag);
-    try {
-      const res = await fetch(path, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
-      const json = await res.json().catch(() => ({}));
-      if (json?.data?.url) window.location.href = json.data.url as string;
-      else setBusy(null);
-    } catch {
-      setBusy(null);
+  const checkout = useCallback(
+    async (kind: "sub" | "topup", key: string) => {
+      const tag = `${kind}-${key}`;
+      setBusy(tag);
+      try {
+        const res = await fetch(
+          kind === "sub"
+            ? "/api/billing/checkout/subscription"
+            : "/api/billing/checkout/topup",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(
+              kind === "sub" ? { planKey: key } : { packKey: key },
+            ),
+          },
+        );
+        const json = await res.json().catch(() => ({}));
+        if (json?.data?.url) {
+          window.location.href = json.data.url as string;
+          return;
+        }
+        // A session can lapse between page load and click. Send the user
+        // through sign-in and resume the same purchase on the way back.
+        if (res.status === 401) {
+          const resume = `/plans?checkout=${kind}:${key}`;
+          window.location.href = `/login?callbackUrl=${encodeURIComponent(resume)}`;
+          return;
+        }
+        setBusy(null);
+      } catch {
+        setBusy(null);
+      }
+    },
+    [],
+  );
+
+  /**
+   * Begin a purchase. Signed-out visitors are sent to sign-in with a callback
+   * that reopens /plans and picks the purchase back up automatically.
+   */
+  function startCheckout(kind: "sub" | "topup", key: string) {
+    if (!signedIn) {
+      setBusy(`${kind}-${key}`);
+      const resume = `/plans?checkout=${kind}:${key}`;
+      window.location.href = `/login?callbackUrl=${encodeURIComponent(resume)}`;
+      return;
     }
+    void checkout(kind, key);
   }
+
+  // Resume a purchase the visitor started before signing in. Reading the query
+  // off `location` rather than useSearchParams keeps this component usable
+  // outside a Suspense boundary (it also renders inside the upgrade dialog).
+  const resumed = useRef(false);
+  useEffect(() => {
+    if (resumed.current || !signedIn) return;
+    const params = new URLSearchParams(window.location.search);
+    const intent = params.get("checkout");
+    if (!intent) return;
+    const [kind, key] = intent.split(":");
+    if ((kind !== "sub" && kind !== "topup") || !key) return;
+    resumed.current = true;
+    // Drop the param first so a declined checkout does not loop on reload.
+    params.delete("checkout");
+    const query = params.toString();
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${query ? `?${query}` : ""}`,
+    );
+    void checkout(kind, key);
+  }, [signedIn, checkout]);
 
   const currentPlan = sub?.planKey ?? "free";
 
-  if (!catalog) {
+  if (status === "loading") {
     return (
       <div className="flex h-40 items-center justify-center">
         <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (status === "error" || !catalog) {
+    return (
+      <div className="flex h-40 flex-col items-center justify-center gap-3 text-center">
+        <p className="text-sm text-muted-foreground">
+          Plans could not be loaded right now.
+        </p>
+        <Button variant="outline" size="sm" onClick={() => void load()}>
+          Try again
+        </Button>
       </div>
     );
   }
@@ -169,13 +260,7 @@ export function PlansGrid({
                     className="w-full"
                     variant={copy.highlight ? "default" : "outline"}
                     disabled={busy !== null}
-                    onClick={() =>
-                      checkout(
-                        "/api/billing/checkout/subscription",
-                        { planKey: plan.key },
-                        `sub-${plan.key}`,
-                      )
-                    }
+                    onClick={() => startCheckout("sub", plan.key)}
                   >
                     {busy === `sub-${plan.key}` ? (
                       <Loader2 className="h-4 w-4 animate-spin" />
@@ -213,13 +298,7 @@ export function PlansGrid({
                   size="sm"
                   className="mt-4 w-full"
                   disabled={busy !== null}
-                  onClick={() =>
-                    checkout(
-                      "/api/billing/checkout/topup",
-                      { packKey: t.key },
-                      `topup-${t.key}`,
-                    )
-                  }
+                  onClick={() => startCheckout("topup", t.key)}
                 >
                   {busy === `topup-${t.key}` ? (
                     <Loader2 className="h-4 w-4 animate-spin" />

--- a/apps/commons-app/components/providers/flags-provider.tsx
+++ b/apps/commons-app/components/providers/flags-provider.tsx
@@ -8,6 +8,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { useSession } from "next-auth/react";
 
 export interface FlagEvaluation {
   key: string;
@@ -32,10 +33,19 @@ const FlagsContext = createContext<FlagsContextValue>({
  * re-randomization — a user sees the same variant everywhere.
  */
 export function FlagsProvider({ children }: { children: ReactNode }) {
+  const { status } = useSession();
   const [flags, setFlags] = useState<Record<string, FlagEvaluation>>({});
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    if (status === "loading") return;
+    // Flags are evaluated per user, so there is nothing to ask for while signed
+    // out — skipping the call keeps public pages free of 401 console noise.
+    if (status !== "authenticated") {
+      setFlags({});
+      setLoading(false);
+      return;
+    }
     let cancelled = false;
     (async () => {
       try {
@@ -53,7 +63,7 @@ export function FlagsProvider({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [status]);
 
   const value = useMemo(() => ({ flags, loading }), [flags, loading]);
   return <FlagsContext.Provider value={value}>{children}</FlagsContext.Provider>;


### PR DESCRIPTION
## Problem

`https://www.agentcommons.io/plans` shows an endless loading spinner in production. Staging is unaffected.

## Root cause

`api.agentcommons.io` is the Hono gateway, which authenticates **every** `/v1/*` request before the request ever reaches the Nest app. The `@Public()` decorator on `BillingController.getCatalog()` therefore never applied, and `/v1/billing/catalog` answered `401 authentication_error` in production.

Staging has no gateway in front of it, which is the entire reason the page only fails on www:

```
api.agentcommons.io/v1/billing/catalog  -> 401 authentication_error
staging                                  -> 200 (full plan list)
```

The 401s on `/api/flags` and `/api/billing/subscription` visible in the console are expected behaviour for a signed-out visitor and were already handled gracefully. The catalog 401 is what broke the page: `PlansGrid` rendered `if (!catalog) return <spinner/>` with no error branch, so any failure spun forever.

## Changes

- **Gateway**: `/v1/billing/catalog` joins the public allowlist next to the OAuth and Stripe-webhook routes. It is static pricing data with no user context.
- **PlansGrid**: `loading` / `ready` / `error` are now distinct states with a retry action, so a failed catalog fetch can never dead-spin again. A signed-out 401 on the subscription request no longer blocks pricing from rendering.
- **Signed-out checkout**: picking a plan while signed out now routes through sign-in and resumes the same purchase on return to `/plans`, instead of silently hitting a 401.
- **FlagsProvider**: skips `/api/flags` while signed out, removing the 401 console noise on public pages.

## Verification

- `tsc --noEmit` clean in both `commons-app` and `commons-api-gateway`
- `next build` green (92/92 static pages)

## Deploy note

The gateway change only reaches production once the `Deploy commons-platform to AWS` pipeline is green — the last run on `main` (PR #242) failed, so production is still serving the PR #232 gateway build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)