### PR TITLE
Cover the gateway's public-route list in CI, and stop the false staging deploy failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,10 @@ jobs:
 
       - name: Test packages
         run: pnpm --filter './packages/*' run test --passWithNoTests
+
+      # The gateway fronts every /v1/* request and decides what is reachable
+      # without a credential, but nothing here used to exercise it — a broken
+      # public-route list reached production unnoticed. Staging cannot catch
+      # this either: it has no gateway in front of it.
+      - name: Test API gateway
+        run: pnpm --filter commons-api-gateway run test

--- a/.github/workflows/deploy-commons-platform-aws.yml
+++ b/.github/workflows/deploy-commons-platform-aws.yml
@@ -41,11 +41,37 @@ jobs:
           role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
+      # The platform (identity + gateway) has no staging twin — only
+      # commons-platform-production exists — so every staging push used to fail
+      # on a missing CodeBuild project. Skip with a notice instead, but only
+      # outside production: if the production project ever goes missing that is
+      # a real emergency and must stay a hard failure.
+      # Remove this once staging is bootstrapped (see
+      # infra/aws/STAGING-PRODUCTION-RUNBOOK.md step 2).
+      - name: Resolve deployment target
+        id: target
+        run: |
+          project="${{ vars.AWS_PLATFORM_CODEBUILD_PROJECT || 'commons-platform-production' }}"
+          found=$(aws codebuild batch-get-projects --names "$project" \
+            --query 'length(projects)' --output text 2>/dev/null || echo 0)
+          echo "project=$project" >> "$GITHUB_OUTPUT"
+          if [ "$found" = "1" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref_name }}" = "main" ]; then
+            echo "::error::Production CodeBuild project '$project' not found."
+            exit 1
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No CodeBuild project '$project' for ${{ github.ref_name }} — skipping platform deploy. The staging platform is not bootstrapped; see infra/aws/STAGING-PRODUCTION-RUNBOOK.md step 2."
+          fi
+
       - name: Package source
+        if: steps.target.outputs.exists == 'true'
         run: git archive --format=zip --output=source.zip HEAD
 
       - name: Upload source to AWS
         id: source
+        if: steps.target.outputs.exists == 'true'
         run: |
           version_id=$(aws s3api put-object \
             --bucket "${{ vars.AWS_SOURCE_BUCKET }}" \
@@ -56,15 +82,17 @@ jobs:
 
       - name: Start CodeBuild deployment
         id: build
+        if: steps.target.outputs.exists == 'true'
         run: |
           build_id=$(aws codebuild start-build \
-            --project-name "${{ vars.AWS_PLATFORM_CODEBUILD_PROJECT || 'commons-platform-production' }}" \
+            --project-name "${{ steps.target.outputs.project }}" \
             --source-version "${{ steps.source.outputs.version_id }}" \
             --environment-variables-override name=DEPLOY_IDENTITY,value=true,type=PLAINTEXT \
             --query 'build.id' --output text)
           echo "id=$build_id" >> "$GITHUB_OUTPUT"
 
       - name: Wait for deployment
+        if: steps.target.outputs.exists == 'true'
         run: |
           while true; do
             status=$(aws codebuild batch-get-builds \

--- a/apps/commons-api-gateway/scripts/smoke.ts
+++ b/apps/commons-api-gateway/scripts/smoke.ts
@@ -1,18 +1,72 @@
 process.env.COMMONS_GATEWAY_NO_LISTEN = "true";
 process.env.RATE_LIMIT_PER_MINUTE = "10";
+// Leaving the upstream unset makes the public-route assertions below
+// self-evident: a route that reaches `publicProxy` answers 503
+// ("not configured"), which is only possible if it skipped the credential
+// check. Anything still gated answers 401 before proxying.
+delete process.env.AGENT_COMMONS_INTERNAL_URL;
+delete process.env.COMMON_OS_INTERNAL_URL;
 export {};
 
 const { createGatewayApp } = await import("../src/index.js");
 const app = createGatewayApp();
 
-const health = await app.request("/health");
-const unauthorized = await app.request("/v1/agents");
-if (health.status !== 200 || unauthorized.status !== 401) {
-  throw new Error("Gateway smoke test failed");
+const failures: string[] = [];
+
+async function expectStatus(
+  label: string,
+  request: Promise<Response> | Response,
+  expected: number,
+) {
+  const response = await request;
+  if (response.status !== expected) {
+    failures.push(
+      `${label}: expected ${expected}, got ${response.status}`,
+    );
+  }
 }
+
+await expectStatus("GET /health", app.request("/health"), 200);
+
+/**
+ * Routes that must answer without a Commons credential.
+ *
+ * The gateway authenticates every other `/v1/*` request before the upstream
+ * Nest app is reached, so marking a handler `@Public()` downstream has no
+ * effect on its own — the route has to be listed here too. Production served
+ * a 401 plan catalog to signed-out visitors for exactly this reason, which
+ * left /plans spinning forever. Keep this list and the gateway in step.
+ */
+const publicRoutes: Array<[string, RequestInit?]> = [
+  ["/v1/billing/catalog"],
+  ["/v1/oauth/providers"],
+  ["/v1/oauth/providers/google"],
+  ["/v1/oauth/callback/google"],
+  ["/v1/billing/webhook", { method: "POST" }],
+];
+
+for (const [path, init] of publicRoutes) {
+  await expectStatus(`public ${init?.method ?? "GET"} ${path}`, app.request(path, init), 503);
+}
+
+/** Routes that carry user data and must stay behind the credential check. */
+const protectedRoutes = [
+  "/v1/agents",
+  "/v1/flags",
+  "/v1/billing/subscription",
+  "/v1/billing/entitlements",
+];
+
+for (const path of protectedRoutes) {
+  await expectStatus(`protected GET ${path}`, app.request(path), 401);
+}
+
+if (failures.length > 0) {
+  console.error("Gateway smoke test failed:");
+  for (const failure of failures) console.error(`  - ${failure}`);
+  process.exit(1);
+}
+
 console.log(
-  JSON.stringify({
-    health: await health.json(),
-    unauthorized: await unauthorized.json(),
-  }),
+  `Gateway smoke test passed (${publicRoutes.length} public, ${protectedRoutes.length} protected routes verified).`,
 );


### PR DESCRIPTION
Follow-up to #244, which fixed the 401 plan catalog in production. Two pre-existing gaps that let that bug ship and hide.

## 1. The gateway had no test coverage

The gateway authenticates every `/v1/*` request before the upstream Nest app is reached, so marking a handler `@Public()` downstream does nothing unless the route is *also* listed in the gateway. Two things let that reach production unnoticed:

- **CI only built and tested `./packages/*`** — the gateway lives in `apps/`, so its existing smoke test never ran.
- **Staging has no gateway in front of it**, so staging cannot fail against this class of bug by construction. That is why `/plans` worked on staging and spun forever on www.

`scripts/smoke.ts` now asserts both halves of the contract: the five public routes answer without a credential, and the user-scoped routes still `401`. Leaving `AGENT_COMMONS_INTERNAL_URL` unset makes the public assertions self-evident — reaching the proxy yields `503 service_unavailable`, only reachable past the credential check.

Verified by reverting the catalog route, which reproduces the production symptom exactly:

```
Gateway smoke test failed:
  - public GET /v1/billing/catalog: expected 503, got 401
```

## 2. The staging platform deploy failed on every push

Only `commons-platform-production` exists, so every staging push died instantly on `Project cannot be found: commons-platform-staging`. A permanently red deploy trains everyone to ignore it — part of why the genuinely failed production run on 07-19 went unnoticed.

The workflow now resolves the target up front and skips with a notice when the project is absent, **but only outside production** — a missing production project stays a hard failure.

This does not give staging a gateway; it only stops the false alarm. Standing up the real staging platform is runbook step 2, and the correctness blind spot is now covered by the CI test above.

## Verification (real CI, not local)

- CI run `29737894607`: `Gateway smoke test passed (5 public, 4 protected routes verified).`
- Platform deploy on staging `29737894680`: **success in 16s** (was failing in ~19s), with
  `::notice::No CodeBuild project 'commons-platform-staging' for staging — skipping platform deploy.`
- `length(projects)` against live AWS: `1` for production, `0` for staging — production still deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)