### PR TITLE
Social embeds for commons-app + platform deploy probe fix

### DIFF
--- a/.github/workflows/deploy-commons-platform-aws.yml
+++ b/.github/workflows/deploy-commons-platform-aws.yml
@@ -41,37 +41,11 @@ jobs:
           role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      # The platform (identity + gateway) has no staging twin — only
-      # commons-platform-production exists — so every staging push used to fail
-      # on a missing CodeBuild project. Skip with a notice instead, but only
-      # outside production: if the production project ever goes missing that is
-      # a real emergency and must stay a hard failure.
-      # Remove this once staging is bootstrapped (see
-      # infra/aws/STAGING-PRODUCTION-RUNBOOK.md step 2).
-      - name: Resolve deployment target
-        id: target
-        run: |
-          project="${{ vars.AWS_PLATFORM_CODEBUILD_PROJECT || 'commons-platform-production' }}"
-          found=$(aws codebuild batch-get-projects --names "$project" \
-            --query 'length(projects)' --output text 2>/dev/null || echo 0)
-          echo "project=$project" >> "$GITHUB_OUTPUT"
-          if [ "$found" = "1" ]; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.ref_name }}" = "main" ]; then
-            echo "::error::Production CodeBuild project '$project' not found."
-            exit 1
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No CodeBuild project '$project' for ${{ github.ref_name }} — skipping platform deploy. The staging platform is not bootstrapped; see infra/aws/STAGING-PRODUCTION-RUNBOOK.md step 2."
-          fi
-
       - name: Package source
-        if: steps.target.outputs.exists == 'true'
         run: git archive --format=zip --output=source.zip HEAD
 
       - name: Upload source to AWS
         id: source
-        if: steps.target.outputs.exists == 'true'
         run: |
           version_id=$(aws s3api put-object \
             --bucket "${{ vars.AWS_SOURCE_BUCKET }}" \
@@ -80,19 +54,40 @@ jobs:
             --query VersionId --output text)
           echo "version_id=$version_id" >> "$GITHUB_OUTPUT"
 
+      # The platform (identity + gateway) has no staging twin — only
+      # commons-platform-production exists — so every staging push used to fail
+      # on a missing CodeBuild project, and a permanently red deploy trains
+      # everyone to ignore it. Treat that one error as a skip, but only outside
+      # production: a missing production project is a real emergency.
+      # The deploy role can StartBuild but not BatchGetProjects, so this asks
+      # forgiveness rather than permission — probing first fails on IAM.
+      # Remove once staging is bootstrapped (STAGING-PRODUCTION-RUNBOOK.md §2).
       - name: Start CodeBuild deployment
         id: build
-        if: steps.target.outputs.exists == 'true'
         run: |
+          project="${{ vars.AWS_PLATFORM_CODEBUILD_PROJECT || 'commons-platform-production' }}"
+          set +e
           build_id=$(aws codebuild start-build \
-            --project-name "${{ steps.target.outputs.project }}" \
+            --project-name "$project" \
             --source-version "${{ steps.source.outputs.version_id }}" \
             --environment-variables-override name=DEPLOY_IDENTITY,value=true,type=PLAINTEXT \
-            --query 'build.id' --output text)
+            --query 'build.id' --output text 2>start-build.err)
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            cat start-build.err >&2
+            if [ "${{ github.ref_name }}" != "main" ] \
+               && grep -q "Project cannot be found" start-build.err; then
+              echo "skipped=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::No CodeBuild project '$project' for ${{ github.ref_name }} — skipping platform deploy. The staging platform is not bootstrapped; see infra/aws/STAGING-PRODUCTION-RUNBOOK.md step 2."
+              exit 0
+            fi
+            exit "$status"
+          fi
           echo "id=$build_id" >> "$GITHUB_OUTPUT"
 
       - name: Wait for deployment
-        if: steps.target.outputs.exists == 'true'
+        if: steps.build.outputs.skipped != 'true'
         run: |
           while true; do
             status=$(aws codebuild batch-get-builds \

--- a/apps/commons-app/app/layout.tsx
+++ b/apps/commons-app/app/layout.tsx
@@ -43,12 +43,20 @@ export const metadata: Metadata = {
     url: getAppBaseUrl(),
     title: "Agent Commons — build, deploy, and orchestrate AI agents",
     description: SITE_DESCRIPTION,
+    images: [
+      {
+        url: "/og",
+        width: 1200,
+        height: 630,
+        alt: "Agent Commons — build, deploy, and orchestrate AI agents",
+      },
+    ],
   },
   twitter: {
     card: "summary_large_image",
     title: "Agent Commons — build, deploy, and orchestrate AI agents",
     description: SITE_DESCRIPTION,
-    images: ["/opengraph-image"],
+    images: ["/og"],
   },
 };
 

--- a/apps/commons-app/app/layout.tsx
+++ b/apps/commons-app/app/layout.tsx
@@ -11,6 +11,7 @@ import { GlobalSearchProvider } from "@/context/SearchContext";
 import { FloatingCommonsCopilot } from "@/components/copilot/floating-commons-copilot";
 import { auth } from "@/auth";
 import type { Session } from "next-auth";
+import { getAppBaseUrl } from "@/lib/app-url";
 
 const spaceGrotesk = Space_Grotesk({
   weight: ["400", "500", "600", "700"],
@@ -25,10 +26,30 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const SITE_DESCRIPTION =
+  "Create, deploy, and manage AI agents — and whole teams of them. Agent computers, workflows, integrations, and every major model, in one place.";
+
 export const metadata: Metadata = {
-  title: "Agent Commons",
-  description:
-    "Create, deploy, and manage AI agents and whole teams of them. Agent computers, workflows, integrations, and every major model in one place.",
+  metadataBase: new URL(getAppBaseUrl()),
+  title: {
+    default: "Agent Commons",
+    template: "%s · Agent Commons",
+  },
+  description: SITE_DESCRIPTION,
+  applicationName: "Agent Commons",
+  openGraph: {
+    type: "website",
+    siteName: "Agent Commons",
+    url: getAppBaseUrl(),
+    title: "Agent Commons — build, deploy, and orchestrate AI agents",
+    description: SITE_DESCRIPTION,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Agent Commons — build, deploy, and orchestrate AI agents",
+    description: SITE_DESCRIPTION,
+    images: ["/opengraph-image"],
+  },
 };
 
 export default async function RootLayout({

--- a/apps/commons-app/app/og/route.tsx
+++ b/apps/commons-app/app/og/route.tsx
@@ -2,20 +2,20 @@ import { ImageResponse } from "next/og";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
-export const alt = "Agent Commons — build, deploy, and orchestrate AI agents";
-export const size = {
-  width: 1200,
-  height: 630,
-};
-export const contentType = "image/png";
+// Prerendered to a static PNG at build time (no runtime filesystem access),
+// and referenced explicitly from metadata so the social-embed image URL always
+// resolves against `metadataBase` (the canonical domain) rather than the
+// per-deployment *.vercel.app URL.
+export const dynamic = "force-static";
 
-// Local brand assets, inlined as data URIs so `next/og` can rasterize them.
+const size = { width: 1200, height: 630 };
+
 async function loadAsset(publicPath: string, mime: string) {
   const buf = await readFile(join(process.cwd(), "public", publicPath));
   return `data:${mime};base64,${buf.toString("base64")}`;
 }
 
-export default async function Image() {
+export async function GET() {
   const wordmark = await loadAsset("logo.jpg", "image/jpeg");
 
   return new ImageResponse(

--- a/apps/commons-app/app/opengraph-image.tsx
+++ b/apps/commons-app/app/opengraph-image.tsx
@@ -1,0 +1,87 @@
+import { ImageResponse } from "next/og";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export const alt = "Agent Commons — build, deploy, and orchestrate AI agents";
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const contentType = "image/png";
+
+// Local brand assets, inlined as data URIs so `next/og` can rasterize them.
+async function loadAsset(publicPath: string, mime: string) {
+  const buf = await readFile(join(process.cwd(), "public", publicPath));
+  return `data:${mime};base64,${buf.toString("base64")}`;
+}
+
+export default async function Image() {
+  const wordmark = await loadAsset("logo.jpg", "image/jpeg");
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          background: "#ffffff",
+          color: "#0f172a",
+          padding: 80,
+          fontFamily: "Arial, sans-serif",
+        }}
+      >
+        {/* Agent Commons wordmark */}
+        <div style={{ display: "flex" }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={wordmark} height={224} alt="Agent Commons" />
+        </div>
+
+        {/* Tagline + supporting line */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
+          <div
+            style={{
+              maxWidth: 1010,
+              fontSize: 60,
+              lineHeight: 1.05,
+              fontWeight: 700,
+              letterSpacing: -1.5,
+            }}
+          >
+            Build, deploy, and orchestrate teams of AI agents.
+          </div>
+          <div
+            style={{
+              display: "flex",
+              gap: 16,
+              fontSize: 27,
+              color: "#475569",
+            }}
+          >
+            <span>Agent computers</span>
+            <span>·</span>
+            <span>Workflows</span>
+            <span>·</span>
+            <span>Integrations</span>
+            <span>·</span>
+            <span>Every major model</span>
+          </div>
+        </div>
+
+        {/* Brand-gradient accent bar */}
+        <div
+          style={{
+            height: 12,
+            width: 420,
+            borderRadius: 999,
+            background:
+              "linear-gradient(90deg, #FDE68A 0%, #F9A8D4 30%, #D8B4FE 52%, #86EFAC 78%, #67E8F9 100%)",
+          }}
+        />
+      </div>
+    ),
+    size
+  );
+}

--- a/apps/commons-app/lib/app-url.ts
+++ b/apps/commons-app/lib/app-url.ts
@@ -1,0 +1,22 @@
+/**
+ * Canonical base URL for the app, used for `metadataBase` and social-embed
+ * absolute URLs. Prefers an explicit env override, then the Vercel-provided
+ * production/deployment host, and finally the well-known production domain.
+ */
+export function getAppBaseUrl() {
+  const explicitUrl =
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    process.env.AUTH_URL ||
+    process.env.NEXTAUTH_URL;
+  if (explicitUrl) return explicitUrl.replace(/\/+$/, "");
+
+  if (process.env.VERCEL_PROJECT_PRODUCTION_URL) {
+    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
+  }
+
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+
+  return "https://www.agentcommons.io";
+}

--- a/apps/commons-app/next.config.ts
+++ b/apps/commons-app/next.config.ts
@@ -51,6 +51,11 @@ const nextConfig = {
     ],
   },
   experimental: {},
+  // Ensure the brand wordmark is bundled into the social-embed (opengraph-image)
+  // serverless function so `readFile` resolves in production, not just in dev.
+  outputFileTracingIncludes: {
+    "/opengraph-image": ["./public/logo.jpg"],
+  },
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/apps/commons-app/next.config.ts
+++ b/apps/commons-app/next.config.ts
@@ -51,10 +51,10 @@ const nextConfig = {
     ],
   },
   experimental: {},
-  // Ensure the brand wordmark is bundled into the social-embed (opengraph-image)
-  // serverless function so `readFile` resolves in production, not just in dev.
+  // Ensure the brand wordmark is bundled with the social-embed image route so
+  // `readFile` resolves in production even if the route is ever server-rendered.
   outputFileTracingIncludes: {
-    "/opengraph-image": ["./public/logo.jpg"],
+    "/og": ["./public/logo.jpg"],
   },
   eslint: {
     ignoreDuringBuilds: true,


### PR DESCRIPTION
Promotes staging → production.

## 1. Clean social embeds for commons-app (`3cb471d`)
Rich link previews on WhatsApp, X/Twitter, Facebook, Instagram, LinkedIn, Slack, Discord and other socials — matching what commons-courses already ships.

- `app/opengraph-image.tsx`: a clean 1200×630 brand card — the Agent Commons gradient wordmark, tagline ("Build, deploy, and orchestrate teams of AI agents."), feature tags, and a brand-gradient accent bar on white. **Prerenders to a static asset at build time**, so there's no runtime filesystem dependency in production.
- Full OpenGraph + Twitter (`summary_large_image`) metadata + `metadataBase` in the root layout.
- `getAppBaseUrl()` helper for the canonical site URL.

Verified locally: `/opengraph-image` renders a valid 1200×630 PNG, all `og:*` / `twitter:*` meta tags emit correctly, and the production build marks the route `○ (Static)`.

## 2. Platform deploy probe fix (`1c51484`)
Already on staging — a validated CI fix so the platform deploy no longer turns production red on an IAM AccessDenied, while a genuinely missing production CodeBuild project stays a hard failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)