### PR TITLE
fix(commons-api): stop the bogus "undefined computer profile" upgrade error

### DIFF
--- a/apps/commons-api/src/computer/computer.service.spec.ts
+++ b/apps/commons-api/src/computer/computer.service.spec.ts
@@ -228,6 +228,55 @@ describe('ComputerService', () => {
     ).toThrow(BadRequestException);
   });
 
+  it('enables a computer against the effective profile when the patch omits one', async () => {
+    // Reproduces the "undefined computer profile" upgrade error: the UI enable
+    // toggle sends only `{ enabled: true }`, so the normalized patch carries no
+    // resourceProfile. The entitlement check must fall back to the persisted
+    // profile ('standard') instead of validating `undefined`.
+    const getEntitlements = jest.fn().mockResolvedValue({
+      computerUse: true,
+      allowedProfiles: ['starter', 'standard'],
+      maxComputerAgents: 1,
+      maxConcurrentComputers: 1,
+      modelTiers: ['standard'],
+      maxConcurrentRuns: 4,
+    });
+    (service as any).entitlements = { getEntitlements };
+
+    jest
+      .spyOn(service as any, 'assertAgent')
+      .mockResolvedValue({ agentId: 'agent_1', ownerUserId: 'user_1' });
+    jest.spyOn(service, 'getConfig').mockResolvedValue({
+      configId: 'cfg_1',
+      agentId: 'agent_1',
+      enabled: false,
+      resourceProfile: 'standard',
+      resourceMode: 'elastic',
+      storageLimit: '20Gi',
+    } as any);
+    jest.spyOn(service as any, 'assertComputerSlot').mockResolvedValue(undefined);
+    jest.spyOn(service, 'getAssignedComputer').mockResolvedValue(null as any);
+
+    const returning = jest
+      .fn()
+      .mockResolvedValue([
+        { configId: 'cfg_1', enabled: true, resourceProfile: 'standard' },
+      ]);
+    db.update.mockReturnValue({
+      set: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnValue({ returning }),
+      }),
+    });
+
+    await expect(
+      service.updateConfig('agent_1', { enabled: true }),
+    ).resolves.toEqual(
+      expect.objectContaining({ enabled: true, resourceProfile: 'standard' }),
+    );
+    // Enforcement still ran — the paid plan was actually consulted.
+    expect(getEntitlements).toHaveBeenCalledWith('user_1');
+  });
+
   it('persists stop intent and supplies the legacy fleet fallback', async () => {
     const previousFleetId = process.env.COMMON_OS_FLEET_ID;
     process.env.COMMON_OS_FLEET_ID = 'fleet_1';

--- a/apps/commons-api/src/computer/computer.service.ts
+++ b/apps/commons-api/src/computer/computer.service.ts
@@ -335,7 +335,16 @@ export class ComputerService {
     const current = await this.getConfig(agentId);
     const next = this.normalizeConfigPatch(patch, current);
     if (next.enabled) {
-      await this.assertComputeEntitlement(agent, next.resourceProfile, false);
+      // A plain enable toggle (`{ enabled: true }`) carries no resourceProfile,
+      // so validate against the effective profile — the one the computer will
+      // actually run with — not the (possibly absent) patched value. Otherwise
+      // the entitlement check receives `undefined` and reports the bogus
+      // "undefined" computer profile even for a fully paid plan.
+      await this.assertComputeEntitlement(
+        agent,
+        next.resourceProfile ?? current.resourceProfile,
+        false,
+      );
       if (!current.enabled) await this.assertComputerSlot(agent);
     }
 


### PR DESCRIPTION
## Problem

Paid users hit **"The \"undefined\" computer profile is not included in your plan. Upgrade for higher-tier compute."** when enabling a computer for their agent, despite an active subscription that includes computer use.

## Root cause

The UI enable toggle sends only `{ enabled: true }`. On the backend, `normalizeConfigPatch` returns just the keys present in the patch, so `next.resourceProfile` was `undefined`. `updateConfig` passed that straight into `assertComputeEntitlement`, so `allowedProfiles.includes(undefined)` was false and it threw the upgrade error with the literal string `"undefined"`.

The plan gate (`assertComputerPlan`) had already passed — i.e. the subscription was correctly recognized as paid. Only the *profile* lookup failed, on a value that should never have been `undefined`. This affected every paid user turning a computer on without explicitly re-selecting a profile.

## Fix

Validate against the **effective** profile: fall back to the persisted config's `resourceProfile` (`.default('standard').notNull()`, allowed on all paid plans) when the patch omits one. The `startComputer` path already used a full config and was unaffected.

## Tests

Adds a regression test covering the plain `{ enabled: true }` enable path — fails before the fix (throws `PAYMENT_REQUIRED`), passes after. Full `computer.service.spec.ts` suite green (9/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)