### PR TITLE
Align educator copilot UI and PDF course creation

### DIFF
--- a/apps/commons-api/src/files/files.service.ts
+++ b/apps/commons-api/src/files/files.service.ts
@@ -94,8 +94,24 @@ const DEFAULT_MAX_TEXT_CHARS = 250_000;
 const DEFAULT_PREVIEW_CHARS = 2_000;
 const DEFAULT_MAX_READ_CHARS = 12_000;
 const ABSOLUTE_MAX_READ_CHARS = 50_000;
-const DEFAULT_PDF_RENDER_PAGES = 12;
+const DEFAULT_PDF_RENDER_PAGES = 24;
+const DEFAULT_PDF_EMBEDDED_IMAGE_PAGES = 40;
+const DEFAULT_PDF_EMBEDDED_IMAGES_PER_PAGE = 4;
+const DEFAULT_PDF_EMBEDDED_IMAGE_MIN_PIXELS = 40_000;
 const DEFAULT_SIGNED_URL_SECONDS = 60 * 30;
+
+export function rawImageChannels(
+  width: number,
+  height: number,
+  byteLength: number,
+): 1 | 3 | 4 | null {
+  const pixels = width * height;
+  if (!Number.isFinite(pixels) || pixels <= 0) return null;
+  if (byteLength === pixels) return 1;
+  if (byteLength === pixels * 3) return 3;
+  if (byteLength === pixels * 4) return 4;
+  return null;
+}
 
 @Injectable()
 export class FilesService {
@@ -372,7 +388,7 @@ export class FilesService {
     if (context.includeImageParts) {
       const maxImageParts = clamp(Number(context.maxImageParts ?? 4), 0, 8);
       const visualArtifacts = artifacts.filter((artifact) =>
-        ['image', 'pdf_page_image'].includes(artifact.role),
+        ['image', 'pdf_embedded_image', 'pdf_page_image'].includes(artifact.role),
       );
       for (const artifact of visualArtifacts.slice(0, maxImageParts)) {
         imageParts.push({
@@ -691,6 +707,14 @@ export class FilesService {
       Number(process.env.AGENT_FILE_PDF_TEXT_PAGES ?? 120),
     );
     const pageTexts: string[] = [];
+    const artifacts: ExtractedArtifact[] = [];
+    const embeddedImagePages = Math.min(
+      pdf.numPages,
+      Number(
+        process.env.AGENT_FILE_PDF_EMBEDDED_IMAGE_PAGES ??
+          DEFAULT_PDF_EMBEDDED_IMAGE_PAGES,
+      ),
+    );
     for (let pageNumber = 1; pageNumber <= maxTextPages; pageNumber += 1) {
       const page = await pdf.getPage(pageNumber);
       const textContent = await page.getTextContent();
@@ -701,9 +725,23 @@ export class FilesService {
         .replace(/\s+/g, ' ')
         .trim();
       if (text) pageTexts.push(`--- Page ${pageNumber} ---\n${text}`);
+      if (pageNumber <= embeddedImagePages) {
+        const pageImages = await this.extractPdfPageImages(
+          pdfjs,
+          page,
+          pageNumber,
+        ).catch((error) => {
+          this.logger.warn(
+            `Could not extract embedded images from PDF page ${pageNumber}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+          return [];
+        });
+        artifacts.push(...pageImages);
+      }
     }
 
-    const artifacts: ExtractedArtifact[] = [];
     const renderPages = Math.min(
       pdf.numPages,
       Number(process.env.AGENT_FILE_PDF_RENDER_PAGES ?? DEFAULT_PDF_RENDER_PAGES),
@@ -739,11 +777,100 @@ export class FilesService {
       metadata: {
         pages: pdf.numPages,
         textPagesExtracted: maxTextPages,
-        renderedPages: artifacts.length,
+        embeddedImages: artifacts.filter(
+          (artifact) => artifact.kind === 'pdf_embedded_image',
+        ).length,
+        renderedPages: artifacts.filter(
+          (artifact) => artifact.kind === 'pdf_page_image',
+        ).length,
       },
       artifacts,
       status: text || artifacts.length ? 'ready' : 'partial',
     };
+  }
+
+  private async extractPdfPageImages(
+    pdfjs: any,
+    page: any,
+    pageNumber: number,
+  ): Promise<ExtractedArtifact[]> {
+    const operatorList = await page.getOperatorList();
+    const imageOperators = new Set([
+      pdfjs.OPS.paintImageXObject,
+      pdfjs.OPS.paintInlineImageXObject,
+    ]);
+    const maxImages = Number(
+      process.env.AGENT_FILE_PDF_EMBEDDED_IMAGES_PER_PAGE ??
+        DEFAULT_PDF_EMBEDDED_IMAGES_PER_PAGE,
+    );
+    const minPixels = Number(
+      process.env.AGENT_FILE_PDF_EMBEDDED_IMAGE_MIN_PIXELS ??
+        DEFAULT_PDF_EMBEDDED_IMAGE_MIN_PIXELS,
+    );
+    const seen = new Set<string>();
+    const artifacts: ExtractedArtifact[] = [];
+
+    for (let index = 0; index < operatorList.fnArray.length; index += 1) {
+      if (!imageOperators.has(operatorList.fnArray[index])) continue;
+      const argument = operatorList.argsArray[index]?.[0];
+      const identity = typeof argument === 'string' ? argument : `inline-${index}`;
+      if (seen.has(identity)) continue;
+      seen.add(identity);
+
+      const image =
+        typeof argument === 'string'
+          ? await this.resolvePdfImageObject(page, argument)
+          : argument;
+      const width = Number(image?.width ?? 0);
+      const height = Number(image?.height ?? 0);
+      const data = image?.data;
+      if (
+        !width ||
+        !height ||
+        width * height < minPixels ||
+        !data ||
+        !ArrayBuffer.isView(data)
+      ) {
+        continue;
+      }
+      const channels = rawImageChannels(width, height, data.byteLength);
+      if (!channels) continue;
+
+      const output = await sharp(Buffer.from(data.buffer, data.byteOffset, data.byteLength), {
+        raw: { width, height, channels },
+      })
+        .png({ compressionLevel: 8 })
+        .toBuffer();
+      const imageNumber = artifacts.length + 1;
+      artifacts.push({
+        kind: 'pdf_embedded_image',
+        fileName: `page-${pageNumber}-image-${imageNumber}.png`,
+        mimeType: 'image/png',
+        buffer: output,
+        pageNumber,
+        width,
+        height,
+        metadata: {
+          source: 'pdf-embedded-image',
+          imageNumber,
+          objectId: identity,
+        },
+      });
+      if (artifacts.length >= maxImages) break;
+    }
+
+    return artifacts;
+  }
+
+  private async resolvePdfImageObject(page: any, objectId: string) {
+    return new Promise<any>((resolve, reject) => {
+      try {
+        const value = page.objs.get(objectId, (resolved: any) => resolve(resolved));
+        if (value) resolve(value);
+      } catch (error) {
+        reject(error);
+      }
+    });
   }
 
   private async renderPdfPage(pdf: any, pageNumber: number) {
@@ -856,7 +983,11 @@ export class FilesService {
     return this.db.query.libraryBlob.findMany({
       where: (t) => and(
         eq(t.itemId, fileId),
-        or(eq(t.role, 'image'), eq(t.role, 'pdf_page_image')),
+        or(
+          eq(t.role, 'image'),
+          eq(t.role, 'pdf_embedded_image'),
+          eq(t.role, 'pdf_page_image'),
+        ),
       ),
       orderBy: (t) => t.createdAt,
     });

--- a/apps/commons-courses/app/api/educator/copilot/materials/route.ts
+++ b/apps/commons-courses/app/api/educator/copilot/materials/route.ts
@@ -341,13 +341,14 @@ async function draftWithAgentCommons(input: {
       sessionId: agentSessionId,
       workspaceId: input.session.identityWorkspaceId,
     });
-    const sourceVisuals = await persistSourceVisuals(uploadedFiles, {
+    const sourceDocuments = await prepareSourceDocuments(uploadedFiles, {
       accessToken: platformAccessToken,
       principalId,
       agentId,
       sessionId: agentSessionId,
       workspaceId: input.session.identityWorkspaceId,
     });
+    const sourceVisuals = sourceDocuments.visuals;
     const result = await client.run.once({
       agentId,
       sessionId: agentSessionId,
@@ -360,14 +361,23 @@ async function draftWithAgentCommons(input: {
         },
         {
           role: "user",
-          content: JSON.stringify({
-            mode: input.mode,
-            educatorInstructions: input.instructions,
-            materialText: input.materialText,
-            sourceVisuals,
-            visualInstructions:
-              "Use sourceVisuals assetUrl values on the lessons or challenges they illustrate. Preserve their page order and write useful assetAlt text. Do not invent asset URLs.",
-          }),
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                mode: input.mode,
+                educatorInstructions: input.instructions,
+                materialText: sourceDocuments.extractedText || input.materialText,
+                sourceVisuals,
+                visualInstructions:
+                  "Each sourceVisual is followed by its image in the same order. Match visuals to lessons and challenges using pageText and the actual image content. Use only the supplied assetUrl values, keep text out of images, preserve source order when it reflects the learning sequence, and write useful assetAlt text. Do not invent asset URLs.",
+              }),
+            },
+            ...sourceVisuals.map((visual) => ({
+              type: "image_url" as const,
+              image_url: { url: visual.assetUrl },
+            })),
+          ],
         },
       ],
     });
@@ -381,11 +391,19 @@ async function draftWithAgentCommons(input: {
 type SourceVisual = {
   sourceName: string;
   pageNumber?: number;
+  sourceKind?: string;
+  sectionTitle?: string;
+  pageText?: string;
   assetUrl: string;
   assetAlt: string;
 };
 
-async function persistSourceVisuals(
+type PreparedSourceDocuments = {
+  extractedText: string;
+  visuals: SourceVisual[];
+};
+
+async function prepareSourceDocuments(
   uploadedFiles: EducatorCopilotUploadedFile[],
   access: {
     accessToken: string;
@@ -394,36 +412,67 @@ async function persistSourceVisuals(
     sessionId?: string;
     workspaceId?: string;
   }
-): Promise<SourceVisual[]> {
-  if (!uploadedFiles.length || !isS3MediaStorageConfigured()) return [];
-
+): Promise<PreparedSourceDocuments> {
+  if (!uploadedFiles.length) return { extractedText: "", visuals: [] };
+  const canPersistVisuals = isS3MediaStorageConfigured();
+  const extractedParts: string[] = [];
   const candidates: Array<{
     sourceName: string;
     pageNumber?: number;
+    sourceKind?: string;
+    sectionTitle?: string;
+    pageText?: string;
     mimeType: string;
     url: string;
   }> = [];
   for (const uploaded of uploadedFiles) {
     const response = await readEducatorCopilotFile(uploaded.fileId, access, {
-      maxChars: 1,
-      includeImageUrls: true,
+      maxChars: 50_000,
+      includeImageUrls: canPersistVisuals,
     }).catch(() => null);
-    for (const artifact of response?.data?.artifacts || []) {
+    const extracted = response?.data?.content || "";
+    if (extracted) {
+      extractedParts.push(
+        `File: ${uploaded.name || response?.data?.name || "source material"}\n${extracted}`
+      );
+    }
+    const pageText = splitPdfPageText(extracted);
+    const artifacts = response?.data?.artifacts || [];
+    const pagesWithEmbeddedImages = new Set(
+      artifacts
+        .filter((artifact) => artifact.kind === "pdf_embedded_image")
+        .map((artifact) => artifact.pageNumber)
+        .filter((page): page is number => typeof page === "number")
+    );
+    for (const artifact of artifacts) {
       if (
         artifact.url &&
         artifact.mimeType?.startsWith("image/") &&
-        (artifact.kind === "image" || artifact.kind === "pdf_page_image")
+        (artifact.kind === "image" ||
+          artifact.kind === "pdf_embedded_image" ||
+          artifact.kind === "pdf_page_image") &&
+        !(
+          artifact.kind === "pdf_page_image" &&
+          artifact.pageNumber &&
+          pagesWithEmbeddedImages.has(artifact.pageNumber)
+        )
       ) {
+        const sectionText = artifact.pageNumber
+          ? pageText.get(artifact.pageNumber) || ""
+          : "";
         candidates.push({
           sourceName: uploaded.name || response?.data?.name || "source material",
           pageNumber: artifact.pageNumber,
+          sourceKind: artifact.kind,
+          sectionTitle: inferSectionTitle(sectionText),
+          pageText: sectionText.slice(0, 2_400),
           mimeType: artifact.mimeType,
           url: artifact.url,
         });
       }
-      if (candidates.length >= 8) break;
+      if (candidates.length >= 32) break;
     }
-    if (candidates.length >= 8) break;
+    if (candidates.length >= 32) break;
   }
 
   const visuals: SourceVisual[] = [];
@@ -439,7 +488,7 @@ async function persistSourceVisuals(
           ? "jpg"
           : "png";
       const pageLabel = candidate.pageNumber
-        ? `page-${candidate.pageNumber}`
+        ? `page-${candidate.pageNumber}-visual-${index + 1}`
         : `image-${index + 1}`;
       const assetUrl = await uploadCourseMediaToS3({
         file: {
@@ -452,48 +501,53 @@ async function persistSourceVisuals(
       visuals.push({
         sourceName: candidate.sourceName,
         pageNumber: candidate.pageNumber,
+        sourceKind: candidate.sourceKind,
+        sectionTitle: candidate.sectionTitle,
+        pageText: candidate.pageText,
         assetUrl,
         assetAlt: candidate.pageNumber
-          ? `${candidate.sourceName}, page ${candidate.pageNumber}`
+          ? `Source visual from ${candidate.sourceName}, page ${candidate.pageNumber}${
+              candidate.sectionTitle ? `: ${candidate.sectionTitle}` : ""
+            }`
           : `Visual from ${candidate.sourceName}`,
       });
     } catch {
       // A failed visual should not block a text-grounded course draft.
     }
   }
-  return visuals;
+  return {
+    extractedText: extractedParts.join("\n\n").slice(0, maxTextChars),
+    visuals,
+  };
 }
 
 function applySourceVisuals(draft: CopilotDraft, visuals: SourceVisual[]) {
   if (!visuals.length) return draft;
-  let visualIndex = 0;
+  const lessonVisuals = createVisualMatcher(visuals);
   const modules = draft.modules?.map((module) => ({
     ...module,
-    lessons: module.lessons?.map((lesson) => {
-      if (lesson.assetUrl || visualIndex >= visuals.length) return lesson;
-      const visual = visuals[visualIndex++];
-      return {
-        ...lesson,
-        assetUrl: visual.assetUrl,
-        assetAlt: lesson.assetAlt || visual.assetAlt,
-      };
-    }),
+    lessons: module.lessons?.map((lesson) =>
+      lessonVisuals.assign(lesson, [
+        module.title,
+        module.description,
+        lesson.title,
+        lesson.description,
+      ])
+    ),
   }));
-  let challengeVisualIndex = 0;
+  const challengeVisuals = createVisualMatcher(visuals);
   const skillPack = draft.skillPack
     ? {
         ...draft.skillPack,
-        challenges: draft.skillPack.challenges?.map((challenge) => {
-          if (challenge.assetUrl || challengeVisualIndex >= visuals.length) {
-            return challenge;
-          }
-          const visual = visuals[challengeVisualIndex++];
-          return {
-            ...challenge,
-            assetUrl: visual.assetUrl,
-            assetAlt: challenge.assetAlt || visual.assetAlt,
-          };
-        }),
+        challenges: draft.skillPack.challenges?.map((challenge) =>
+          challengeVisuals.assign(challenge, [
+            challenge.title,
+            challenge.shortTitle,
+            challenge.hook,
+            challenge.lesson,
+            ...(challenge.keyIdeas || []),
+          ])
+        ),
       }
     : undefined;
   return {
@@ -505,6 +559,112 @@ function applySourceVisuals(draft: CopilotDraft, visuals: SourceVisual[]) {
       `Extracted and organized ${visuals.length} source visual${visuals.length === 1 ? "" : "s"} from the uploaded material.`,
     ],
   };
+}
+
+function createVisualMatcher(visuals: SourceVisual[]) {
+  const available = [...visuals];
+  const allowedUrls = new Set(visuals.map((visual) => visual.assetUrl));
+  return {
+    assign<T extends { assetUrl?: string; assetAlt?: string }>(
+      item: T,
+      textParts: Array<string | undefined>
+    ): T {
+      const requested = item.assetUrl && allowedUrls.has(item.assetUrl)
+        ? available.findIndex((visual) => visual.assetUrl === item.assetUrl)
+        : -1;
+      const index = requested >= 0
+        ? requested
+        : bestVisualIndex(textParts.filter(Boolean).join(" "), available);
+      if (index < 0) {
+        const sanitized = { ...item };
+        delete sanitized.assetUrl;
+        delete sanitized.assetAlt;
+        return sanitized;
+      }
+      const [visual] = available.splice(index, 1);
+      return {
+        ...item,
+        assetUrl: visual.assetUrl,
+        assetAlt: item.assetAlt || visual.assetAlt,
+      };
+    },
+  };
+}
+
+function bestVisualIndex(content: string, visuals: SourceVisual[]) {
+  if (!visuals.length) return -1;
+  const contentTokens = significantTokens(content);
+  if (!contentTokens.size) return 0;
+  let bestIndex = 0;
+  let bestScore = -1;
+  for (const [index, visual] of visuals.entries()) {
+    const visualTokens = significantTokens(
+      `${visual.sectionTitle || ""} ${visual.pageText || ""}`
+    );
+    let score = 0;
+    for (const token of contentTokens) {
+      if (visualTokens.has(token)) score += 1;
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      bestIndex = index;
+    }
+  }
+  return bestIndex;
+}
+
+function significantTokens(value: string) {
+  const stopWords = new Set([
+    "about",
+    "after",
+    "again",
+    "also",
+    "because",
+    "before",
+    "being",
+    "from",
+    "have",
+    "into",
+    "lesson",
+    "material",
+    "more",
+    "that",
+    "their",
+    "there",
+    "these",
+    "they",
+    "this",
+    "through",
+    "what",
+    "when",
+    "where",
+    "which",
+    "with",
+    "would",
+  ]);
+  return new Set(
+    value
+      .toLowerCase()
+      .replace(/<[^>]*>/g, " ")
+      .match(/[a-z0-9]{4,}/g)
+      ?.filter((token) => !stopWords.has(token)) || []
+  );
+}
+
+function splitPdfPageText(content: string) {
+  const pages = new Map<number, string>();
+  const matches = [...content.matchAll(/--- Page (\d+) ---\n([\s\S]*?)(?=\n\n--- Page \d+ ---|$)/g)];
+  for (const match of matches) {
+    pages.set(Number(match[1]), match[2].replace(/\s+/g, " ").trim());
+  }
+  return pages;
+}
+
+function inferSectionTitle(pageText: string) {
+  const text = pageText.replace(/\s+/g, " ").trim();
+  if (!text) return undefined;
+  const sentence = text.match(/^(.{8,100}?)(?:[.!?]| {2,})/)?.[1];
+  return (sentence || text.slice(0, 80)).trim();
 }
 
 function safeSourceName(value: string) {
@@ -579,6 +739,8 @@ function copilotSystemPrompt() {
     "You are the CommonLab educator course copilot.",
     "Create rigorous, accessible course material from uploaded educator materials.",
     EDUCATOR_COPILOT_PEDAGOGY,
+    "For PDFs, treat page text and embedded visuals as separate source elements. Organize the text into clean explanations, then attach each original visual only to the lesson or challenge whose subject it actually illustrates.",
+    "Never flatten a PDF page screenshot into lesson copy when a separated embedded visual is available. Do not place prose inside generated images or use a visual merely because it appears next in the file.",
     "Use standard learning design: short introductions, meaningful examples, key ideas, challenging quizzes, and practical sandbox tasks when relevant.",
     "Create material directly inside the educator account as a draft. Keep it reviewable: complete lesson bodies, clear quiz feedback, and no placeholder copy.",
     "For skill paths, create a natural sequence that can sit alongside existing paths in the same course. Do not repeat prior modules unless the uploaded material requires a bridge.",

--- a/apps/commons-courses/app/educator/copilot/page.tsx
+++ b/apps/commons-courses/app/educator/copilot/page.tsx
@@ -5,6 +5,7 @@ import { buildManagedCoursesFilter, requireEducator } from "@/lib/educator-auth"
 import Course from "@/models/Course";
 import { Nav } from "@/components/nav";
 import { CopilotMaterialBuilder } from "@/components/educator/copilot-material-builder";
+import { BookOpen, FileText, Layers3, Sparkles } from "lucide-react";
 
 export default async function EducatorCopilotPage() {
   const authResult = await requireEducator();
@@ -27,27 +28,51 @@ export default async function EducatorCopilotPage() {
     .lean<Array<{ title: string; slug: string }>>();
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-slate-50/60">
       <Nav />
       <main className="mx-auto max-w-6xl px-4 pb-16 pt-24 sm:px-6 lg:px-8">
-        <Link href="/educator" className="text-sm font-bold text-slate-500">
-          Back to educator console
+        <Link href="/educator" className="text-sm font-medium text-slate-500 hover:text-slate-950">
+          ← Back to educator console
         </Link>
-        <div className="mb-8 mt-4 max-w-3xl">
-          <p className="mb-2 text-xs uppercase tracking-[0.2em] text-slate-400">
-            Educator copilot
-          </p>
-          <h1 className="text-3xl font-bold text-slate-950">
-            Create course material from uploads
-          </h1>
-          <p className="mt-3 text-sm leading-6 text-slate-500">
-            Upload slides, notes, PDFs, or images. The copilot creates a draft
-            course or skill path in your account so you can review and publish.
-          </p>
-        </div>
+        <section className="relative mb-8 mt-4 overflow-hidden rounded-2xl bg-slate-950 px-6 py-7 text-white sm:px-8">
+          <div className="absolute -right-16 -top-20 h-56 w-56 rounded-full bg-lime-300/15 blur-3xl" />
+          <div className="relative max-w-3xl">
+            <p className="mb-3 inline-flex items-center gap-2 text-xs font-medium uppercase tracking-[0.2em] text-lime-300">
+              <Sparkles className="h-3.5 w-3.5" /> Educator copilot studio
+            </p>
+            <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
+              Turn your source material into learning.
+            </h1>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-300">
+              Upload PDFs, slides, documents, spreadsheets, or images. Your personal
+              copilot extracts the ideas and visuals, then builds an educator-ready
+              draft for you to review.
+            </p>
+            <div className="mt-6 flex flex-wrap gap-2 text-xs text-slate-200">
+              <FormatPill icon={BookOpen} label="Courses" />
+              <FormatPill icon={FileText} label="Workbooks" />
+              <FormatPill icon={Layers3} label="Skill packs" />
+            </div>
+          </div>
+        </section>
 
         <CopilotMaterialBuilder courses={courses} />
       </main>
     </div>
+  );
+}
+
+function FormatPill({
+  icon: Icon,
+  label,
+}: {
+  icon: typeof BookOpen;
+  label: string;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-white/15 bg-white/10 px-3 py-1.5">
+      <Icon className="h-3.5 w-3.5 text-lime-300" />
+      {label}
+    </span>
   );
 }

--- a/apps/commons-courses/app/educator/layout.tsx
+++ b/apps/commons-courses/app/educator/layout.tsx
@@ -3,7 +3,7 @@ import { EducatorCopilotShell } from "@/components/educator/educator-copilot-she
 export default function EducatorLayout({ children }: { children: React.ReactNode }) {
   return (
     <>
-      {children}
+      <div id="educator-shell-content">{children}</div>
       <EducatorCopilotShell />
     </>
   );

--- a/apps/commons-courses/app/globals.css
+++ b/apps/commons-courses/app/globals.css
@@ -46,6 +46,16 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+#educator-shell-content {
+  transition: margin-right 180ms ease;
+}
+
+@media (min-width: 1024px) {
+  html.educator-copilot-open #educator-shell-content {
+    margin-right: var(--educator-copilot-panel-width, 360px);
+  }
+}
+
 ::selection {
   background: #d9f99d;
   color: #0a0a0a;

--- a/apps/commons-courses/components/educator/copilot-material-builder.tsx
+++ b/apps/commons-courses/components/educator/copilot-material-builder.tsx
@@ -2,7 +2,18 @@
 
 import { FormEvent, useMemo, useState } from "react";
 import Link from "next/link";
-import { ArrowRight, FileUp, Loader2, Sparkles } from "lucide-react";
+import {
+  ArrowRight,
+  BookOpen,
+  Check,
+  FileText,
+  FileUp,
+  Layers3,
+  Loader2,
+  Sparkles,
+} from "lucide-react";
+
+type MaterialMode = "course" | "workbook" | "skill_path";
 
 type ManagedCourse = {
   title: string;
@@ -10,7 +21,7 @@ type ManagedCourse = {
 };
 
 type CopilotResult = {
-  mode: "course" | "workbook" | "skill_path";
+  mode: MaterialMode;
   course: {
     title: string;
     slug: string;
@@ -24,12 +35,33 @@ type CopilotResult = {
   notes?: string[];
 };
 
+const MATERIAL_MODES = [
+  {
+    value: "course" as const,
+    title: "Course",
+    description: "Modules, lessons, activities, and assessment",
+    icon: BookOpen,
+  },
+  {
+    value: "workbook" as const,
+    title: "Workbook",
+    description: "Guided explanations, exercises, and reflection",
+    icon: FileText,
+  },
+  {
+    value: "skill_path" as const,
+    title: "Skill pack",
+    description: "Focused challenges for an existing course",
+    icon: Layers3,
+  },
+];
+
 export function CopilotMaterialBuilder({
   courses,
 }: {
   courses: ManagedCourse[];
 }) {
-  const [mode, setMode] = useState<"course" | "workbook" | "skill_path">("course");
+  const [mode, setMode] = useState<MaterialMode>("course");
   const [targetCourseSlug, setTargetCourseSlug] = useState(courses[0]?.slug || "");
   const [instructions, setInstructions] = useState("");
   const [files, setFiles] = useState<File[]>([]);
@@ -76,37 +108,63 @@ export function CopilotMaterialBuilder({
 
   return (
     <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
-      <form onSubmit={submit} className="space-y-5 rounded-lg border border-slate-200 bg-white p-5">
+      <form onSubmit={submit} className="space-y-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
         <div>
-          <p className="text-sm font-black text-slate-950">Material upload</p>
+          <p className="text-sm font-medium text-slate-950">Build a learning resource</p>
           <p className="mt-1 text-sm leading-6 text-slate-500">
-            Upload source material and let the copilot create a reviewable draft course or skill path in your account.
+            Choose the learning format, give your copilot direction, and add the source files.
           </p>
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-2">
-          <label className="rounded-lg border border-slate-200 p-3">
-            <span className="text-sm font-bold text-slate-700">Create</span>
-            <select
-              value={mode}
-              onChange={(event) =>
-                setMode(event.target.value as "course" | "workbook" | "skill_path")
-              }
-              className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-400"
-            >
-              <option value="course">New draft course</option>
-              <option value="workbook">Interactive workbook</option>
-              <option value="skill_path">Skill path for existing course</option>
-            </select>
-          </label>
+        <fieldset>
+          <legend className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500">
+            Learning format
+          </legend>
+          <div className="grid gap-3 sm:grid-cols-3">
+            {MATERIAL_MODES.map((option) => {
+              const Icon = option.icon;
+              const selected = mode === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setMode(option.value)}
+                  className={`rounded-xl border p-3 text-left transition ${
+                    selected
+                      ? "border-lime-400 bg-lime-50"
+                      : "border-slate-200 hover:bg-slate-50"
+                  }`}
+                >
+                  <span className="flex items-center justify-between gap-2">
+                    <Icon className="h-4 w-4 text-slate-700" />
+                    {selected ? (
+                      <span className="rounded-full bg-slate-950 p-0.5 text-white">
+                        <Check className="h-2.5 w-2.5" />
+                      </span>
+                    ) : null}
+                  </span>
+                  <span className="mt-3 block text-sm font-medium text-slate-950">
+                    {option.title}
+                  </span>
+                  <span className="mt-1 block text-xs leading-5 text-slate-500">
+                    {option.description}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </fieldset>
 
-          <label className="rounded-lg border border-slate-200 p-3">
-            <span className="text-sm font-bold text-slate-700">Target course</span>
+        {mode === "skill_path" ? (
+          <label className="block rounded-xl border border-slate-200 bg-slate-50 p-3">
+            <span className="text-xs font-medium uppercase tracking-wide text-slate-500">
+              Add the skill pack to
+            </span>
             <select
               value={targetCourseSlug}
               onChange={(event) => setTargetCourseSlug(event.target.value)}
-              disabled={mode !== "skill_path" || courses.length === 0}
-              className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm outline-none disabled:bg-slate-50 disabled:text-slate-400 focus:border-slate-400"
+              disabled={courses.length === 0}
+              className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm outline-none focus:border-slate-950 disabled:text-slate-400"
             >
               {courses.length ? (
                 courses.map((course) => (
@@ -115,29 +173,31 @@ export function CopilotMaterialBuilder({
                   </option>
                 ))
               ) : (
-                <option value="">No courses yet</option>
+                <option value="">Create a course first</option>
               )}
             </select>
           </label>
-        </div>
+        ) : null}
 
         <label className="block">
-          <span className="text-sm font-bold text-slate-700">Copilot instructions</span>
+          <span className="text-sm font-medium text-slate-700">Teaching direction</span>
           <textarea
             value={instructions}
             onChange={(event) => setInstructions(event.target.value)}
             placeholder="Example: keep the tone practical, create challenging quizzes, and add one sandbox task if the material supports it."
-            className="mt-2 min-h-32 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm leading-6 outline-none focus:border-slate-400"
+            className="mt-2 min-h-32 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm leading-6 outline-none focus:border-slate-950"
           />
         </label>
 
-        <label className="flex min-h-40 cursor-pointer flex-col items-center justify-center rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-6 text-center hover:bg-slate-100">
-          <FileUp className="mb-3 h-6 w-6 text-slate-400" />
-          <span className="text-sm font-bold text-slate-800">
-            Upload course materials
+        <label className="flex min-h-44 cursor-pointer flex-col items-center justify-center rounded-xl border border-dashed border-slate-300 bg-slate-50 px-4 py-6 text-center transition hover:border-lime-500 hover:bg-lime-50/50">
+          <span className="mb-3 rounded-full bg-white p-3 shadow-sm ring-1 ring-slate-200">
+            <FileUp className="h-5 w-5 text-slate-700" />
+          </span>
+          <span className="text-sm font-medium text-slate-900">
+            Add your source materials
           </span>
           <span className="mt-1 text-xs leading-5 text-slate-500">
-            PDF, Word, spreadsheets, images, Markdown, text, CSV, or JSON. Up to 8 files.
+            PDF, Word, spreadsheets, images, Markdown, text, CSV, or JSON · up to 8 files
           </span>
           <input
             type="file"
@@ -151,14 +211,15 @@ export function CopilotMaterialBuilder({
         </label>
 
         {files.length ? (
-          <div className="rounded-lg border border-slate-200 bg-white">
+          <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
             {files.map((file) => (
               <div
                 key={`${file.name}-${file.size}`}
                 className="flex items-center justify-between gap-3 border-b border-slate-100 px-3 py-2 text-sm last:border-b-0"
               >
-                <span className="truncate font-semibold text-slate-700">
-                  {file.name}
+                <span className="flex min-w-0 items-center gap-2 text-slate-700">
+                  <FileText className="h-4 w-4 shrink-0 text-slate-400" />
+                  <span className="truncate font-medium">{file.name}</span>
                 </span>
                 <span className="shrink-0 text-xs text-slate-400">
                   {Math.ceil(file.size / 1024)} KB
@@ -175,29 +236,41 @@ export function CopilotMaterialBuilder({
         <button
           type="submit"
           disabled={!canSubmit}
-          className="inline-flex items-center justify-center gap-2 rounded-lg bg-slate-950 px-5 py-3 text-sm font-bold text-white disabled:cursor-not-allowed disabled:opacity-45"
+          className="inline-flex items-center justify-center gap-2 rounded-lg bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-45"
         >
           {submitting ? (
             <Loader2 className="h-4 w-4 animate-spin" />
           ) : (
             <Sparkles className="h-4 w-4" />
           )}
-          Create draft
+          {submitting
+            ? "Building your draft…"
+            : `Create ${mode === "skill_path" ? "skill pack" : mode} draft`}
         </button>
       </form>
 
       <aside className="space-y-4">
-        <div className="rounded-lg border border-slate-200 bg-white p-4">
-          <p className="text-sm font-black text-slate-950">Copilot standard</p>
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <p className="text-sm font-medium text-slate-950">How your copilot builds</p>
+          <ol className="mt-3 space-y-3 text-xs leading-5 text-slate-600">
+            <BuildStep number="1" text="Extracts source text, structure, tables, and useful visuals." />
+            <BuildStep number="2" text="Organizes concepts into a coherent learning sequence." />
+            <BuildStep number="3" text="Creates activities and checks that support the learning goals." />
+            <BuildStep number="4" text="Saves a private draft for educator review—not automatic publishing." />
+          </ol>
+        </div>
+
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <p className="text-sm font-medium text-slate-950">CommonLab learning standard</p>
           <p className="mt-2 text-sm leading-6 text-slate-500">
-            The draft should follow the uploaded material, use consistent terminology,
-            avoid unsupported topics, include meaningful quizzes, and add a focused sandbox when the material supports practice.
+            Drafts stay grounded in your sources, preserve consistent terminology,
+            include meaningful practice, and use focused sandboxes only when hands-on work helps.
           </p>
         </div>
 
         {result ? (
-          <div className="rounded-lg border border-lime-200 bg-lime-50 p-4">
-            <p className="text-sm font-black text-lime-950">
+          <div className="rounded-2xl border border-lime-200 bg-lime-50 p-4 shadow-sm">
+            <p className="text-sm font-medium text-lime-950">
               Draft created
             </p>
             <p className="mt-2 text-sm leading-6 text-lime-800">
@@ -222,6 +295,17 @@ export function CopilotMaterialBuilder({
         ) : null}
       </aside>
     </div>
+  );
+}
+
+function BuildStep({ number, text }: { number: string; text: string }) {
+  return (
+    <li className="flex gap-2.5">
+      <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-lime-200 text-[10px] font-bold text-slate-950">
+        {number}
+      </span>
+      <span>{text}</span>
+    </li>
   );
 }
 

--- a/apps/commons-courses/components/educator/copilot-material-builder.tsx
+++ b/apps/commons-courses/components/educator/copilot-material-builder.tsx
@@ -253,8 +253,8 @@ export function CopilotMaterialBuilder({
         <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
           <p className="text-sm font-medium text-slate-950">How your copilot builds</p>
           <ol className="mt-3 space-y-3 text-xs leading-5 text-slate-600">
-            <BuildStep number="1" text="Extracts source text, structure, tables, and useful visuals." />
-            <BuildStep number="2" text="Organizes concepts into a coherent learning sequence." />
+            <BuildStep number="1" text="Separates source text, structure, tables, and original PDF visuals." />
+            <BuildStep number="2" text="Matches each visual to the section it actually illustrates." />
             <BuildStep number="3" text="Creates activities and checks that support the learning goals." />
             <BuildStep number="4" text="Saves a private draft for educator review—not automatic publishing." />
           </ol>

--- a/apps/commons-courses/components/educator/educator-copilot-shell.tsx
+++ b/apps/commons-courses/components/educator/educator-copilot-shell.tsx
@@ -4,24 +4,24 @@ import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "re
 import { usePathname, useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
 import {
-  Bot,
+  ArrowUp,
   BookOpen,
   Brain,
   Check,
   ChevronRight,
+  Clock3,
   FileText,
   FilePlus2,
-  History,
+  FlaskConical,
   Highlighter,
   Layers,
   LoaderCircle,
+  MessageSquarePlus,
   Navigation,
   Paperclip,
   PenLine,
   Plug,
-  Plus,
-  Send,
-  Settings,
+  Settings2,
   Sparkles,
   Trash2,
   X,
@@ -53,11 +53,21 @@ type CopilotStreamEvent = {
 };
 
 const QUICK_PROMPTS = [
-  "Give me a snapshot of all my courses and students",
-  "What needs my attention this week?",
-  "Help me improve a lesson in this course",
-  "Draft a new module from a file I upload",
+  "Give me a snapshot of my courses and learners",
+  "What needs my attention as an educator this week?",
+  "Help me improve this lesson for active learning",
+  "Turn an uploaded PDF into a course, workbook, or skill pack",
 ];
+
+const PANEL_WIDTH_KEY = "educator-copilot-panel-width";
+const PANEL_MIN_WIDTH = 320;
+const PANEL_MAX_WIDTH = 560;
+const PANEL_DEFAULT_WIDTH = 360;
+
+function clampPanelWidth(value: number) {
+  if (!Number.isFinite(value)) return PANEL_DEFAULT_WIDTH;
+  return Math.min(PANEL_MAX_WIDTH, Math.max(PANEL_MIN_WIDTH, Math.round(value)));
+}
 
 export function EducatorCopilotShell() {
   const router = useRouter();
@@ -74,12 +84,48 @@ export function EducatorCopilotShell() {
   const [localNotice, setLocalNotice] = useState<string | null>(null);
   const [streamStatus, setStreamStatus] = useState<string | null>(null);
   const [streamActivity, setStreamActivity] = useState<EducatorCopilotToolActivity[]>([]);
+  const [panelWidth, setPanelWidth] = useState(PANEL_DEFAULT_WIDTH);
   const autoApplied = useRef(new Set<string>());
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
   const actionMode: EducatorCopilotActionMode = profile?.actionMode || "manual";
   const messages = useMemo(() => activeSession?.messages || [], [activeSession?.messages]);
+
+  useEffect(() => {
+    const stored = Number(window.localStorage.getItem(PANEL_WIDTH_KEY));
+    if (stored) setPanelWidth(clampPanelWidth(stored));
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty(
+      "--educator-copilot-panel-width",
+      `${panelWidth}px`
+    );
+  }, [panelWidth]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("educator-copilot-open", open);
+    return () => document.documentElement.classList.remove("educator-copilot-open");
+  }, [open]);
+
+  const startPanelResize = (event: React.PointerEvent) => {
+    event.preventDefault();
+    const startX = event.clientX;
+    const startWidth = panelWidth;
+    let width = startWidth;
+    const onMove = (move: PointerEvent) => {
+      width = clampPanelWidth(startWidth + (startX - move.clientX));
+      setPanelWidth(width);
+    };
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.localStorage.setItem(PANEL_WIDTH_KEY, String(width));
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  };
 
   const updateLocalAction = useCallback(
     (
@@ -388,6 +434,11 @@ export function EducatorCopilotShell() {
         : "Ask about any of your courses, students, or materials — or upload a file and we'll build content from it.",
     [pathname]
   );
+  const pendingActionCount = messages.reduce(
+    (total, message) =>
+      total + (message.actions || []).filter((action) => action.status === "proposed").length,
+    0
+  );
 
   return (
     <>
@@ -401,99 +452,90 @@ export function EducatorCopilotShell() {
       <button
         type="button"
         aria-label="Open educator copilot"
-        onClick={() => setOpen(true)}
+        onClick={() => {
+          setOpen(true);
+          setPanel("chat");
+        }}
         className={cn(
-          "fixed bottom-5 right-5 z-40 inline-flex items-center gap-2 rounded-lg bg-slate-950 px-4 py-3 text-sm font-bold text-white shadow-lg transition hover:bg-slate-800",
+          "fixed bottom-5 right-5 z-40 rounded-full border border-slate-200 bg-white p-1 shadow-lg transition hover:-translate-y-0.5 hover:shadow-xl",
           open && "hidden"
         )}
       >
-        <Bot className="h-4 w-4" />
-        Copilot
+        <CopilotAvatar size="large" />
+        <span className="absolute -left-1 -top-1 rounded-full bg-slate-950 p-1 text-white shadow">
+          <Sparkles className="h-3 w-3" />
+        </span>
+        {pendingActionCount > 0 ? (
+          <span className="absolute -right-1 -top-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-amber-500 px-1 text-[10px] font-semibold text-white">
+            {pendingActionCount}
+          </span>
+        ) : null}
       </button>
 
       {open ? (
-        <div className="fixed inset-0 z-50 flex justify-end bg-slate-950/20">
-          <button
-            type="button"
-            aria-label="Close educator copilot"
-            className="hidden flex-1 md:block"
-            onClick={() => setOpen(false)}
+        <aside className="fixed inset-y-0 right-0 z-50 flex w-full flex-col border-l border-slate-200 bg-white shadow-xl lg:w-[var(--educator-copilot-panel-width,360px)]">
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize educator copilot panel"
+            onPointerDown={startPanelResize}
+            className="absolute inset-y-0 left-0 z-10 hidden w-1.5 cursor-col-resize touch-none hover:bg-slate-200/80 lg:block"
           />
-          <aside className="flex h-full w-full max-w-md flex-col border-l border-slate-200 bg-white shadow-xl">
-            <header className="border-b border-slate-100 p-4">
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <p className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">
-                    {profile?.copilotName || "Educator copilot"}
-                    <span
-                      title={
-                        profile?.agentReady
-                          ? "Connected to your Commons account"
-                          : profile?.connectionMessage || "Connection required"
-                      }
-                      className={cn(
-                        "inline-block h-1.5 w-1.5 rounded-full",
-                        profile?.agentReady ? "bg-emerald-500" : "bg-amber-400"
-                      )}
-                    />
-                  </p>
-                  <h2 className="mt-1 truncate text-base font-bold text-slate-950">
-                    {activeSession?.title || "Course assistant"}
-                  </h2>
-                </div>
-                <button
-                  type="button"
-                  aria-label="Close educator copilot"
-                  className="rounded-md p-1.5 text-slate-500 hover:bg-slate-100"
-                  onClick={() => setOpen(false)}
-                >
-                  <X className="h-4 w-4" />
-                </button>
-              </div>
-              <div className="mt-4 flex items-center gap-2">
-                <IconButton
-                  label="Previous sessions"
-                  active={panel === "sessions"}
-                  onClick={() => setPanel(panel === "sessions" ? "chat" : "sessions")}
-                >
-                  <History className="h-4 w-4" />
-                </IconButton>
-                <IconButton label="New session" onClick={createSession}>
-                  <Plus className="h-4 w-4" />
-                </IconButton>
-                <IconButton
-                  label="Settings"
-                  active={panel === "settings"}
-                  onClick={() => setPanel(panel === "settings" ? "chat" : "settings")}
-                >
-                  <Settings className="h-4 w-4" />
-                </IconButton>
-                <button
-                  type="button"
-                  onClick={() => updateActionMode(actionMode === "auto" ? "manual" : "auto")}
-                  title={
-                    actionMode === "auto"
-                      ? "Auto: safe actions run without approval. Click for Manual."
-                      : "Manual: you approve every action. Click for Auto."
-                  }
-                  className={cn(
-                    "ml-auto inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-bold transition",
-                    actionMode === "auto"
-                      ? "border-emerald-600 bg-emerald-50 text-emerald-700"
-                      : "border-slate-200 text-slate-500 hover:border-slate-950 hover:text-slate-950"
-                  )}
-                >
+          <header className="flex h-14 shrink-0 items-center gap-2 border-b border-slate-200 px-3">
+            <button
+              type="button"
+              onClick={() => setPanel("chat")}
+              className="flex min-w-0 flex-1 items-center gap-2.5 rounded-lg p-1 text-left transition hover:bg-slate-100"
+            >
+              <CopilotAvatar />
+              <span className="min-w-0">
+                <span className="flex items-center gap-1.5">
+                  <span className="truncate text-sm font-medium text-slate-950">
+                    {profile?.copilotName || "Educator Copilot"}
+                  </span>
                   <span
+                    title={
+                      profile?.agentReady
+                        ? "Connected to your Commons account"
+                        : profile?.connectionMessage || "Connection required"
+                    }
                     className={cn(
-                      "inline-block h-1.5 w-1.5 rounded-full",
-                      actionMode === "auto" ? "bg-emerald-500" : "bg-slate-400"
+                      "h-1.5 w-1.5 shrink-0 rounded-full",
+                      profile?.agentReady ? "bg-emerald-500" : "bg-amber-400"
                     )}
                   />
-                  {actionMode === "auto" ? "Auto" : "Manual"}
-                </button>
-              </div>
-            </header>
+                </span>
+                <span className="block truncate text-[11px] text-slate-500">
+                  {activeSession?.id
+                    ? activeSession.title || "Current Copilot session"
+                    : "CommonLab educator copilot"}
+                </span>
+              </span>
+            </button>
 
+            <IconButton
+              label="Recent chats"
+              active={panel === "sessions"}
+              onClick={() => setPanel("sessions")}
+            >
+              <Clock3 className="h-4 w-4" />
+            </IconButton>
+            <IconButton
+              label="Copilot settings"
+              active={panel === "settings"}
+              onClick={() => setPanel("settings")}
+            >
+              <Settings2 className="h-4 w-4" />
+            </IconButton>
+            <IconButton label="New chat" onClick={createSession}>
+              <MessageSquarePlus className="h-4 w-4" />
+            </IconButton>
+            <IconButton label="Close Copilot" onClick={() => setOpen(false)}>
+              <X className="h-4 w-4" />
+            </IconButton>
+          </header>
+
+          <div className="min-h-0 flex-1">
             {panel === "sessions" ? (
               <SessionsPanel
                 booted={booted}
@@ -509,24 +551,24 @@ export function EducatorCopilotShell() {
                 onModeChange={updateActionMode}
               />
             ) : (
-              <>
-                <div ref={scrollRef} className="flex-1 overflow-y-auto p-4">
+              <div className="flex h-full min-h-0 flex-col">
+                <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto px-3 py-4">
                   {messages.length === 0 ? (
-                    <div className="mt-8 text-center">
-                      <Sparkles className="mx-auto mb-3 h-5 w-5 text-slate-400" />
-                      <p className="text-sm font-semibold text-slate-800">
+                    <div className="flex min-h-full flex-col items-center justify-center py-8 text-center">
+                      <CopilotAvatar size="empty" />
+                      <p className="text-sm font-medium text-slate-950">
                         Your workspace, one question away.
                       </p>
-                      <p className="mx-auto mt-1 max-w-xs text-sm leading-6 text-slate-500">
+                      <p className="mx-auto mt-1 max-w-xs text-xs leading-5 text-slate-500">
                         {emptyState}
                       </p>
-                      <div className="mx-auto mt-5 flex max-w-xs flex-col gap-2">
+                      <div className="mx-auto mt-5 flex w-full max-w-xs flex-col gap-2">
                         {QUICK_PROMPTS.map((prompt) => (
                           <button
                             key={prompt}
                             type="button"
                             onClick={(event) => sendMessage(event, prompt)}
-                            className="rounded-lg border border-slate-200 px-3 py-2 text-left text-xs font-semibold text-slate-600 transition hover:border-slate-950 hover:text-slate-950"
+                            className="rounded-xl border border-slate-200 px-3 py-2.5 text-left text-xs text-slate-600 transition hover:bg-slate-50 hover:text-slate-950"
                           >
                             {prompt}
                           </button>
@@ -534,11 +576,12 @@ export function EducatorCopilotShell() {
                       </div>
                     </div>
                   ) : (
-                    <div className="space-y-3">
+                    <div className="space-y-1">
                       {messages.map((message, index) => (
                         <MessageBubble
                           key={message.id}
                           message={message}
+                          agentName={profile?.copilotName || "Educator Copilot"}
                           isStreamingTarget={
                             loading &&
                             index === messages.length - 1 &&
@@ -549,8 +592,8 @@ export function EducatorCopilotShell() {
                         />
                       ))}
                       {loading && streamStatus ? (
-                        <div className="mr-10 inline-flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-500">
-                          <LoaderCircle className="h-4 w-4 animate-spin" />
+                        <div className="inline-flex items-center gap-2 py-2 text-xs text-slate-500">
+                          <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
                           {streamStatus}
                         </div>
                       ) : null}
@@ -562,33 +605,34 @@ export function EducatorCopilotShell() {
                     </p>
                   ) : null}
                 </div>
-                <form onSubmit={sendMessage} className="border-t border-slate-100 p-3">
-                  {files.length ? (
-                    <div className="mb-2 flex flex-wrap gap-2">
-                      {files.map((file, index) => (
-                        <span
-                          key={`${file.name}-${index}`}
-                          className="inline-flex max-w-full items-center gap-1 rounded-md border border-slate-200 bg-slate-50 px-2 py-1 text-xs font-semibold text-slate-600"
-                        >
-                          <FileText className="h-3.5 w-3.5 flex-shrink-0" />
-                          <span className="max-w-40 truncate">{file.name}</span>
-                          <button
-                            type="button"
-                            aria-label={`Remove ${file.name}`}
-                            onClick={() =>
-                              setFiles((current) =>
-                                current.filter((_, fileIndex) => fileIndex !== index)
-                              )
-                            }
-                            className="rounded text-slate-400 hover:text-rose-600"
+
+                <form onSubmit={sendMessage} className="shrink-0 border-t border-slate-200 p-3">
+                  <div className="rounded-2xl border border-stone-300 bg-white shadow-sm">
+                    {files.length ? (
+                      <div className="flex flex-wrap gap-2 px-3 pt-3">
+                        {files.map((file, index) => (
+                          <span
+                            key={`${file.name}-${index}`}
+                            className="inline-flex max-w-full items-center gap-1.5 rounded-lg border border-slate-200 bg-slate-50 px-2 py-1.5 text-xs text-slate-600"
                           >
-                            <X className="h-3 w-3" />
-                          </button>
-                        </span>
-                      ))}
-                    </div>
-                  ) : null}
-                  <div className="flex items-end gap-2 rounded-lg border border-slate-200 bg-white p-2">
+                            <FileText className="h-3.5 w-3.5 shrink-0" />
+                            <span className="max-w-40 truncate">{file.name}</span>
+                            <button
+                              type="button"
+                              aria-label={`Remove ${file.name}`}
+                              onClick={() =>
+                                setFiles((current) =>
+                                  current.filter((_, fileIndex) => fileIndex !== index)
+                                )
+                              }
+                              className="rounded text-slate-400 hover:text-rose-600"
+                            >
+                              <X className="h-3 w-3" />
+                            </button>
+                          </span>
+                        ))}
+                      </div>
+                    ) : null}
                     <textarea
                       value={input}
                       onChange={(event) => setInput(event.target.value)}
@@ -600,7 +644,7 @@ export function EducatorCopilotShell() {
                       }}
                       placeholder="Ask about your courses, students, or this page…"
                       rows={2}
-                      className="max-h-28 min-h-10 flex-1 resize-none border-0 bg-transparent text-sm outline-none placeholder:text-slate-400"
+                      className="h-16 w-full resize-none rounded-2xl bg-transparent p-3 text-sm outline-none placeholder:text-slate-400"
                     />
                     <input
                       ref={fileInputRef}
@@ -616,29 +660,36 @@ export function EducatorCopilotShell() {
                         event.currentTarget.value = "";
                       }}
                     />
-                    <button
-                      type="button"
-                      aria-label="Attach files"
-                      title="Attach files"
-                      onClick={() => fileInputRef.current?.click()}
-                      className="rounded-md border border-slate-200 p-2 text-slate-500 hover:bg-slate-50"
-                    >
-                      <Paperclip className="h-4 w-4" />
-                    </button>
-                    <button
-                      type="submit"
-                      disabled={loading || (input.trim().length === 0 && files.length === 0)}
-                      aria-label="Send message"
-                      className="rounded-md bg-slate-950 p-2 text-white disabled:opacity-40"
-                    >
-                      <Send className="h-4 w-4" />
-                    </button>
+                    <div className="flex items-center justify-between px-2 pb-2">
+                      <button
+                        type="button"
+                        aria-label="Add photos and files"
+                        title="Add photos and files"
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={loading}
+                        className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-100 hover:text-slate-950 disabled:opacity-40"
+                      >
+                        <Paperclip className="h-4 w-4" />
+                      </button>
+                      <button
+                        type="submit"
+                        disabled={loading || (input.trim().length === 0 && files.length === 0)}
+                        aria-label="Send message"
+                        className="rounded-lg bg-slate-950 p-1.5 text-white transition hover:opacity-80 disabled:opacity-40"
+                      >
+                        {loading ? (
+                          <LoaderCircle className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <ArrowUp className="h-4 w-4" />
+                        )}
+                      </button>
+                    </div>
                   </div>
                 </form>
-              </>
+              </div>
             )}
-          </aside>
-        </div>
+          </div>
+        </aside>
       ) : null}
     </>
   );
@@ -646,94 +697,98 @@ export function EducatorCopilotShell() {
 
 function MessageBubble({
   message,
+  agentName,
   isStreamingTarget,
   liveActivity,
   onDecision,
 }: {
   message: EducatorCopilotMessage;
+  agentName: string;
   isStreamingTarget: boolean;
   liveActivity: EducatorCopilotToolActivity[];
   onDecision: (action: EducatorCopilotAction, decision: "approve" | "reject") => void;
 }) {
   const activity = isStreamingTarget ? liveActivity : message.activity || [];
+  const isUser = message.role === "user";
   return (
-    <div
-      className={cn(
-        "rounded-lg px-3 py-2 text-sm leading-6",
-        message.role === "user"
-          ? "ml-10 bg-slate-950 text-white"
-          : "mr-6 border border-slate-200 bg-white text-slate-700"
-      )}
-    >
-      {activity.length ? (
-        <div className="mb-2 flex flex-wrap gap-1.5">
-          {activity.map((item, index) => (
-            <span
-              key={`${item.tool}-${index}`}
-              className={cn(
-                "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-semibold",
-                item.status === "running"
-                  ? "border-sky-200 bg-sky-50 text-sky-700"
-                  : item.status === "error"
-                    ? "border-rose-200 bg-rose-50 text-rose-600"
-                    : "border-slate-200 bg-slate-50 text-slate-500"
-              )}
-            >
-              {item.status === "running" ? (
-                <LoaderCircle className="h-3 w-3 animate-spin" />
-              ) : (
-                <Check className="h-3 w-3" />
-              )}
-              {item.label}
-            </span>
-          ))}
-        </div>
-      ) : null}
-      {message.content ? (
-        message.role === "assistant" ? (
-          <RichTextRenderer
-            value={message.content}
-            className="space-y-2 text-sm leading-6 [&_h2]:text-base [&_h3]:text-sm [&_h4]:text-sm"
-          />
-        ) : (
-          <p className="whitespace-pre-wrap">{message.content}</p>
-        )
-      ) : isStreamingTarget ? (
-        <span className="inline-flex items-center gap-2 text-slate-400">
-          <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-          Working…
-        </span>
-      ) : null}
-      {message.attachments?.length ? (
-        <div className="mt-2 space-y-1">
-          {message.attachments.map((attachment, index) => (
-            <div
-              key={`${attachment.name}-${index}`}
-              className={cn(
-                "flex items-center gap-2 rounded-md px-2 py-1 text-xs",
-                message.role === "user"
-                  ? "bg-white/10 text-white/85"
-                  : "bg-slate-50 text-slate-600"
-              )}
-            >
-              <FileText className="h-3.5 w-3.5 flex-shrink-0" />
-              <span className="truncate">{attachment.name}</span>
-              {attachment.status === "uploaded" ? (
-                <span className="ml-auto text-[10px] font-bold uppercase tracking-wide opacity-70">
-                  synced
-                </span>
-              ) : null}
-            </div>
-          ))}
-        </div>
-      ) : null}
-      {message.actions?.length ? (
-        <div className="mt-3 space-y-2">
-          {message.actions.map((action) => (
-            <ActionCard key={action.id} action={action} onDecision={onDecision} />
-          ))}
-        </div>
-      ) : null}
+    <div className={cn("my-3", isUser ? "flex justify-end" : "mr-2")}>
+      <div className={cn(isUser ? "max-w-[80%] rounded-2xl rounded-tr-sm bg-lime-100 px-4 py-2.5" : "w-full")}>
+        {!isUser ? (
+          <div className="mb-2 flex items-center gap-2">
+            <CopilotAvatar size="message" />
+            <span className="truncate text-xs text-slate-500">{agentName}</span>
+          </div>
+        ) : null}
+        {activity.length ? (
+          <div className="mb-2 flex flex-wrap gap-1.5">
+            {activity.map((item, index) => (
+              <span
+                key={`${item.tool}-${index}`}
+                className={cn(
+                  "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium",
+                  item.status === "running"
+                    ? "border-sky-200 bg-sky-50 text-sky-700"
+                    : item.status === "error"
+                      ? "border-rose-200 bg-rose-50 text-rose-600"
+                      : "border-slate-200 bg-slate-50 text-slate-500"
+                )}
+              >
+                {item.status === "running" ? (
+                  <LoaderCircle className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Check className="h-3 w-3" />
+                )}
+                {item.label}
+              </span>
+            ))}
+          </div>
+        ) : null}
+        {message.content ? (
+          isUser ? (
+            <p className="whitespace-pre-wrap text-sm leading-relaxed text-slate-900">
+              {message.content}
+            </p>
+          ) : (
+            <RichTextRenderer
+              value={message.content}
+              className="space-y-2 text-sm leading-6 text-slate-700 [&_h2]:text-base [&_h3]:text-sm [&_h4]:text-sm"
+            />
+          )
+        ) : isStreamingTarget ? (
+          <span className="inline-flex items-center gap-2 text-sm text-slate-400">
+            <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+            Working…
+          </span>
+        ) : null}
+        {message.attachments?.length ? (
+          <div className="mt-2 space-y-1">
+            {message.attachments.map((attachment, index) => (
+              <div
+                key={`${attachment.name}-${index}`}
+                className={cn(
+                  "flex items-center gap-2 rounded-md px-2 py-1 text-xs",
+                  isUser ? "bg-white/60 text-slate-700" : "bg-slate-50 text-slate-600"
+                )}
+              >
+                <FileText className="h-3.5 w-3.5 shrink-0" />
+                <span className="truncate">{attachment.name}</span>
+                {attachment.status === "uploaded" ? (
+                  <span className="ml-auto text-[10px] font-medium uppercase tracking-wide opacity-70">
+                    synced
+                  </span>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        ) : null}
+        {message.actions?.length ? (
+          <div className="mt-3 space-y-2">
+            {message.actions.map((action) => (
+              <ActionCard key={action.id} action={action} onDecision={onDecision} />
+            ))}
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }
@@ -837,10 +892,13 @@ function SessionsPanel({
   onArchive: (id: string) => void;
 }) {
   return (
-    <div className="flex-1 overflow-y-auto p-4">
-      <p className="mb-3 text-xs font-black uppercase tracking-widest text-slate-500">
-        Previous sessions
-      </p>
+    <div className="h-full overflow-y-auto p-3">
+      <div className="px-2 pb-2 pt-1">
+        <h2 className="text-sm font-medium text-slate-950">Recent chats</h2>
+        <p className="mt-1 text-xs leading-5 text-slate-500">
+          Continue earlier planning, course, and material sessions.
+        </p>
+      </div>
       {!booted ? (
         <p className="text-sm text-slate-500">Loading sessions…</p>
       ) : sessions.length === 0 ? (
@@ -851,8 +909,10 @@ function SessionsPanel({
             <div
               key={session.id}
               className={cn(
-                "group rounded-lg border p-3",
-                activeId === session.id ? "border-slate-950" : "border-slate-200"
+                "group rounded-xl border p-3 transition hover:bg-slate-50",
+                activeId === session.id
+                  ? "border-slate-950 bg-slate-50"
+                  : "border-slate-200"
               )}
             >
               <button
@@ -1051,7 +1111,13 @@ function SettingsPanel({
   const actionMode = profile?.actionMode || "manual";
 
   return (
-    <div className="flex-1 space-y-6 overflow-y-auto p-4">
+    <div className="h-full space-y-6 overflow-y-auto p-4">
+      <div>
+        <h2 className="text-sm font-medium text-slate-950">Copilot settings</h2>
+        <p className="mt-1 text-xs leading-5 text-slate-500">
+          Shape how your teaching copilot works, remembers, and connects.
+        </p>
+      </div>
       {profile && !profile.agentReady ? (
         <section className="rounded-lg border border-amber-200 bg-amber-50 p-4">
           <p className="text-sm font-black text-amber-950">
@@ -1314,11 +1380,21 @@ function ModeOption({
       type="button"
       onClick={onClick}
       className={cn(
-        "w-full rounded-lg border p-3 text-left",
-        checked ? "border-slate-950 bg-white" : "border-slate-200 bg-slate-50"
+        "w-full rounded-xl border p-3 text-left transition",
+        checked
+          ? "border-lime-400 bg-lime-50"
+          : "border-slate-200 bg-white hover:bg-slate-50"
       )}
     >
-      <span className="text-sm font-black text-slate-950">{title}</span>
+      <span className="flex items-center gap-2 text-sm font-medium text-slate-950">
+        <span
+          className={cn(
+            "h-3.5 w-3.5 rounded-full border",
+            checked ? "border-[4px] border-slate-950" : "border-slate-300"
+          )}
+        />
+        {title}
+      </span>
       <span className="mt-1 block text-xs leading-5 text-slate-500">{body}</span>
     </button>
   );
@@ -1342,12 +1418,49 @@ function IconButton({
       title={label}
       onClick={onClick}
       className={cn(
-        "inline-flex h-9 w-9 items-center justify-center rounded-md border text-slate-600",
-        active ? "border-slate-950 bg-slate-950 text-white" : "border-slate-200 bg-white"
+        "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-slate-500 transition hover:bg-slate-100 hover:text-slate-950",
+        active && "bg-slate-100 text-slate-950"
       )}
     >
       {children}
     </button>
+  );
+}
+
+function CopilotAvatar({
+  size = "header",
+}: {
+  size?: "header" | "large" | "empty" | "message";
+}) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "relative flex shrink-0 items-center justify-center rounded-full bg-slate-950 text-lime-300 ring-1 ring-slate-200",
+        size === "large"
+          ? "h-[52px] w-[52px]"
+          : size === "empty"
+            ? "mb-3 h-12 w-12"
+            : size === "message"
+              ? "h-5 w-5"
+            : "h-[34px] w-[34px]"
+      )}
+    >
+      <FlaskConical
+        className={cn(
+          size === "large"
+            ? "h-6 w-6"
+            : size === "empty"
+              ? "h-5 w-5"
+              : size === "message"
+                ? "h-2.5 w-2.5"
+                : "h-4 w-4"
+        )}
+      />
+      {size !== "message" ? (
+        <span className="absolute bottom-0.5 right-0.5 h-2 w-2 rounded-full border border-slate-950 bg-lime-300" />
+      ) : null}
+    </span>
   );
 }
 


### PR DESCRIPTION
## What changed

- rebuilt the educator copilot shell around the Commons Copilot drawer structure: circular launcher, compact agent header, chat/session/settings views, matching composer, mobile full-screen behavior, and a persistent resizable desktop panel
- kept educator capabilities intact, including streaming, attachments, page context, safe actions, memory, connectors, model selection, account linking, and course-aware sessions
- added CommonLab's education-focused flask identity, lime learning accents, educator prompts, and clearer course/workbook/skill-pack language
- redesigned the material builder as a CommonLab educator studio with learning-format cards, PDF/document upload guidance, teaching direction, grounded content standards, and explicit private-draft review
- reserved desktop page space while the copilot is open, matching the Commons Copilot interaction instead of covering educator content
- extracts original embedded PDF images separately from page text while retaining page-render fallbacks, page numbers, dimensions, and section text
- processes up to 32 source visuals, prioritizes separated embedded images over text-baked page renders, and sends each visual to the educator's multimodal agent with its corresponding section text
- validates agent-returned asset URLs and content-matches each source visual to the relevant lesson or skill challenge before saving the draft

## Why

The educator copilot had the right domain functionality but used a separate modal-style UI. This aligns its interaction model with the proven Commons Copilot experience while keeping the product unmistakably focused on educators and learning-resource creation.

## Validation

- `pnpm --filter commons-courses exec tsc --noEmit`
- focused ESLint for all changed TSX files
- `pnpm --filter commons-courses build` (65 routes)
- local production server: `/` returned 200 and signed-out `/educator/copilot` returned the expected 307 authentication redirect
- `CommonsEducation.pdf` acceptance extraction: 19/19 embedded 1920×1080 visuals separated, 19 page-render fallbacks retained, and 12,404 characters of page-delimited text extracted
- `git diff --check`
