### PR TITLE
Fix CLI account token platform scopes

### DIFF
--- a/apps/commons-identity/lib/auth-config.ts
+++ b/apps/commons-identity/lib/auth-config.ts
@@ -2,6 +2,7 @@ import { oauthProvider } from "@better-auth/oauth-provider";
 import { bearer, deviceAuthorization, jwt } from "better-auth/plugins";
 import bcrypt from "bcryptjs";
 import { createCommonsId } from "@/lib/ids";
+import { PLATFORM_SCOPES } from "@/lib/platform-api";
 
 const AUTH_SESSION_VERSION = (
   process.env.COMMONS_AUTH_SESSION_VERSION ?? "v2"
@@ -267,6 +268,12 @@ export function commonsAuthOptions(database: unknown) {
               (user as { defaultWorkspaceId?: string }).defaultWorkspaceId ??
               null,
             actor_type: "user",
+            // First-party Commons sessions represent the user's account, so
+            // their short-lived platform JWT must carry the same capabilities
+            // exposed to the CLI and web app. Project API keys and third-party
+            // OAuth clients remain restricted to their explicitly granted
+            // scopes.
+            scopes: [...PLATFORM_SCOPES],
           }),
         },
       }),
@@ -278,14 +285,7 @@ export function commonsAuthOptions(database: unknown) {
           "profile",
           "email",
           "offline_access",
-          "activity:read",
-          "agents:create",
-          "agents:read",
-          "agents:write",
-          "agents:run",
-          "compute:read",
-          "compute:write",
-          "usage:read",
+          ...PLATFORM_SCOPES,
         ],
         validAudiences: ["commons-platform"],
         accessTokenExpiresIn: 15 * 60,

--- a/apps/commons-identity/scripts/e2e-smoke.ts
+++ b/apps/commons-identity/scripts/e2e-smoke.ts
@@ -32,6 +32,7 @@ await database.query(
 
 const { commonsAuthOptions } = await import("../lib/auth-config");
 const { ensureOAuthClient } = await import("../lib/oauth-client-store");
+const { PLATFORM_SCOPES } = await import("../lib/platform-api");
 const auth = betterAuth(commonsAuthOptions(database));
 const { createIdentityApp } = await import("../src/index");
 const app = createIdentityApp(auth as never, database as never);
@@ -241,6 +242,13 @@ const platformClaims = JSON.parse(
   Buffer.from(platformToken.token.split(".")[1]!, "base64url").toString("utf8"),
 ) as Record<string, unknown>;
 assert(platformClaims.sub === user.rows[0].id, "CLI JWT has the wrong subject");
+assert(
+  Array.isArray(platformClaims.scopes) &&
+    PLATFORM_SCOPES.every((scope) =>
+      (platformClaims.scopes as unknown[]).includes(scope),
+    ),
+  "CLI JWT is missing Commons account platform scopes",
+);
 
 const jwks = await app.request(
   "http://identity.test/api/auth/.well-known/jwks.json",


### PR DESCRIPTION
## Summary
- include Commons platform scopes in first-party account JWTs
- reuse the canonical platform scope catalog for OAuth configuration
- assert the complete scope set in the device-login E2E test

## Verification
- `pnpm --filter commons-identity build`
- `pnpm --filter commons-identity test:e2e`
- `pnpm --filter commons-api-gateway build`
- `pnpm --filter commons-api-gateway test`
- authenticated production CLI login reproduced the missing-scope failure before this patch