### PR TITLE
Add personalized learner guidance

### DIFF
--- a/apps/commons-courses/app/account/page.tsx
+++ b/apps/commons-courses/app/account/page.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useEffect, useState } from "react";
 import Link from "next/link";
 import { Nav } from "@/components/nav";
+import { LearnerProfileDialog } from "@/components/learning/learner-profile-dialog";
 
 type AccountUser = {
   name: string;
@@ -79,6 +80,24 @@ export default function AccountPage() {
               <span className="font-bold text-slate-900">Sign-in:</span>{" "}
               {user?.authProvider === "google" ? "Google" : "Email and password"}
             </p>
+          </div>
+        </section>
+
+        <section
+          id="learning-profile"
+          className="mb-6 rounded-xl border border-slate-200 p-5"
+        >
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-lg font-bold text-slate-900">
+                Learning preferences
+              </h2>
+              <p className="mt-1 max-w-xl text-sm leading-6 text-slate-500">
+                Choose the contexts and learning views your copilot can use.
+                Your educator&apos;s original content is never replaced.
+              </p>
+            </div>
+            <LearnerProfileDialog buttonLabel="Edit preferences" />
           </div>
         </section>
 

--- a/apps/commons-courses/app/api/agent/chat/route.ts
+++ b/apps/commons-courses/app/api/agent/chat/route.ts
@@ -12,7 +12,9 @@ import {
 import { scopedVectorSearch } from "@/lib/vector-search";
 import Course from "@/models/Course";
 import Enrollment from "@/models/Enrollment";
+import LearnerProfile from "@/models/LearnerProfile";
 import type { CourseAgentMessage, CourseAgentViewContext } from "@/types/course-agent";
+import type { LearnerProfileData } from "@/types/learner-profile";
 
 type Body = {
   message?: string;
@@ -66,6 +68,13 @@ export async function POST(req: NextRequest) {
     .select("_id title slug")
     .sort({ updatedAt: -1 })
     .lean()) as unknown as EducatorCourse[];
+  const learnerProfile = (await LearnerProfile.findOne({
+    userId: session.user.id,
+  })
+    .select(
+      "personalizationEnabled roleOrContext domain interests goals preferredFormats guidanceStyle customContext allowUsageLearning usageSignals",
+    )
+    .lean()) as Partial<LearnerProfileData> | null;
 
   const learnerCourses = enrollments
     .map((enrollment) => {
@@ -168,6 +177,7 @@ export async function POST(req: NextRequest) {
       })),
     },
     searchResults: searchResults.slice(0, 10),
+    learnerProfile,
   });
 
   return NextResponse.json({ reply });

--- a/apps/commons-courses/app/api/course-agents/chat/route.ts
+++ b/apps/commons-courses/app/api/course-agents/chat/route.ts
@@ -12,7 +12,9 @@ import {
 import { scopedVectorSearch } from "@/lib/vector-search";
 import Course from "@/models/Course";
 import Enrollment from "@/models/Enrollment";
+import LearnerProfile from "@/models/LearnerProfile";
 import type { CourseAgentConfig, CourseAgentMessage } from "@/types/course-agent";
+import type { LearnerProfileData } from "@/types/learner-profile";
 
 type ChatBody = {
   courseSlug?: string;
@@ -107,6 +109,14 @@ export async function POST(req: NextRequest) {
           .select("completedLessons progress accessLevel")
           .lean()) as LearnerProgress | null)
       : null;
+  const learnerProfile =
+    role === "learner"
+      ? ((await LearnerProfile.findOne({ userId: session.user.id })
+          .select(
+            "personalizationEnabled roleOrContext domain interests goals preferredFormats guidanceStyle customContext allowUsageLearning usageSignals",
+          )
+          .lean()) as Partial<LearnerProfileData> | null)
+      : null;
   const searchResults = await scopedVectorSearch({
     scope: searchScope,
     query: body.message,
@@ -124,6 +134,7 @@ export async function POST(req: NextRequest) {
     context: body.context,
     searchResults,
     learnerProgress,
+    learnerProfile,
     educatorAnalytics,
   });
 

--- a/apps/commons-courses/app/api/learner/learning-view/route.ts
+++ b/apps/commons-courses/app/api/learner/learning-view/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { connectDB } from "@/lib/db";
+import { generateLearningView } from "@/lib/learner-learning-runtime";
+import { serializeLearnerProfile } from "@/lib/learner-profile";
+import Course from "@/models/Course";
+import LearnerProfile from "@/models/LearnerProfile";
+import type { LearnerProfileData } from "@/types/learner-profile";
+
+type Body = {
+  kind?: "contextual_example" | "mind_map";
+  courseSlug?: string;
+  courseTitle?: string;
+  contentTitle?: string;
+  source?: string;
+};
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { error: "Sign in to create a learning view." },
+      { status: 401 },
+    );
+  }
+
+  const body = (await req.json()) as Body;
+  if (
+    !body.kind ||
+    !["contextual_example", "mind_map"].includes(body.kind) ||
+    !body.courseSlug ||
+    !body.contentTitle ||
+    !body.source
+  ) {
+    return NextResponse.json(
+      { error: "kind, courseSlug, contentTitle, and source are required." },
+      { status: 400 },
+    );
+  }
+
+  const source = body.source.trim().slice(0, 16000);
+  if (source.length < 20) {
+    return NextResponse.json(
+      { error: "There is not enough source content to create this view." },
+      { status: 400 },
+    );
+  }
+
+  await connectDB();
+  const [course, storedProfile] = await Promise.all([
+    Course.findOne({
+      published: true,
+      $or: [
+        { slug: body.courseSlug },
+        { "skillPack.slug": body.courseSlug },
+        { "skillPacks.slug": body.courseSlug },
+      ],
+    })
+      .select("_id title")
+      .lean<{ _id: unknown; title: string } | null>(),
+    LearnerProfile.findOne({ userId: session.user.id }).lean(),
+  ]);
+  if (!course) {
+    return NextResponse.json({ error: "Content not found." }, { status: 404 });
+  }
+
+  const profile = serializeLearnerProfile(
+    storedProfile as unknown as Partial<LearnerProfileData> | null,
+  );
+  if (body.kind === "contextual_example" && !profile.personalizationEnabled) {
+    return NextResponse.json(
+      { error: "Turn on personalization to create a contextual example." },
+      { status: 409 },
+    );
+  }
+
+  const view = await generateLearningView({
+    kind: body.kind,
+    courseTitle: body.courseTitle || course.title,
+    contentTitle: body.contentTitle,
+    source,
+    profile,
+  });
+
+  if (profile.allowUsageLearning) {
+    const signal =
+      body.kind === "mind_map" ? "usageSignals.mindMapViews" : "usageSignals.contextualExampleViews";
+    await LearnerProfile.updateOne(
+      { userId: session.user.id },
+      {
+        $inc: { [signal]: 1 },
+        $setOnInsert: { userId: session.user.id },
+      },
+      { upsert: true },
+    );
+  }
+
+  return NextResponse.json({ kind: body.kind, view });
+}

--- a/apps/commons-courses/app/api/learner/profile/route.ts
+++ b/apps/commons-courses/app/api/learner/profile/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { connectDB } from "@/lib/db";
+import {
+  sanitizeLearnerProfile,
+  serializeLearnerProfile,
+} from "@/lib/learner-profile";
+import LearnerProfile from "@/models/LearnerProfile";
+import type { LearnerProfileData } from "@/types/learner-profile";
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  await connectDB();
+  const profile = (await LearnerProfile.findOne({ userId: session.user.id })
+    .lean()) as (Partial<LearnerProfileData> & { updatedAt?: Date }) | null;
+
+  return NextResponse.json({
+    profile: serializeLearnerProfile(
+      profile
+        ? {
+            ...profile,
+            updatedAt: profile.updatedAt?.toISOString(),
+          }
+        : null,
+    ),
+  });
+}
+export async function PUT(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  const patch = sanitizeLearnerProfile(await req.json());
+  await connectDB();
+  const profile = (await LearnerProfile.findOneAndUpdate(
+    { userId: session.user.id },
+    {
+      $set: patch,
+      $setOnInsert: { userId: session.user.id },
+    },
+    { upsert: true, new: true, runValidators: true },
+  ).lean()) as unknown as Partial<LearnerProfileData> & { updatedAt?: Date };
+
+  return NextResponse.json({
+    profile: serializeLearnerProfile({
+      ...profile,
+      updatedAt: profile.updatedAt?.toISOString(),
+    }),
+  });
+}

--- a/apps/commons-courses/app/api/learner/signals/route.ts
+++ b/apps/commons-courses/app/api/learner/signals/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { connectDB } from "@/lib/db";
+import LearnerProfile from "@/models/LearnerProfile";
+
+const supportedSignals = {
+  audio_started: "usageSignals.audioStarts",
+  learning_view_helpful: "usageSignals.helpfulMarks",
+} as const;
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  const body = (await req.json()) as { signal?: keyof typeof supportedSignals };
+  if (!body.signal || !supportedSignals[body.signal]) {
+    return NextResponse.json({ error: "Unsupported signal." }, { status: 400 });
+  }
+
+  await connectDB();
+  const profile = await LearnerProfile.findOne({ userId: session.user.id })
+    .select("allowUsageLearning")
+    .lean<{ allowUsageLearning?: boolean } | null>();
+  if (profile?.allowUsageLearning === false) {
+    return NextResponse.json({ recorded: false });
+  }
+
+  await LearnerProfile.updateOne(
+    { userId: session.user.id },
+    {
+      $inc: { [supportedSignals[body.signal]]: 1 },
+      $setOnInsert: { userId: session.user.id },
+    },
+    { upsert: true },
+  );
+  return NextResponse.json({ recorded: true });
+}

--- a/apps/commons-courses/app/courses/[slug]/learn/page.tsx
+++ b/apps/commons-courses/app/courses/[slug]/learn/page.tsx
@@ -7,6 +7,7 @@ import { Nav } from "@/components/nav";
 import { AssignmentSubmissions } from "@/components/courses/assignment-submissions";
 import { AnalyticsTracker, useAnalytics } from "@/components/analytics/analytics-tracker";
 import { CourseAgentDrawer } from "@/components/course-agents/course-agent-drawer";
+import { LearningStudio } from "@/components/learning/learning-studio";
 import { RichTextRenderer } from "@/components/rich-text-renderer";
 import {
   CheckCircle,
@@ -564,7 +565,15 @@ export default function LearnPage({ params }: Props) {
               {/* Lesson description / summary */}
               {currentLesson?.description && (
                 <div className="prose prose-sm max-w-none">
-                  <h3 className="text-base font-bold text-slate-900 mb-3">Lesson Summary</h3>
+                  <LearningStudio
+                    courseSlug={slug}
+                    courseTitle={course.title}
+                    contentTitle={currentLesson.title}
+                    source={currentLesson.description}
+                  />
+                  <h3 className="text-base font-bold text-slate-900 mb-3">
+                    Educator&apos;s lesson
+                  </h3>
                   <RichTextRenderer value={currentLesson.description} />
                 </div>
               )}

--- a/apps/commons-courses/app/dashboard/page.tsx
+++ b/apps/commons-courses/app/dashboard/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { auth } from "@/lib/auth";
 import { Nav } from "@/components/nav";
 import { GeneralAgentDrawer } from "@/components/agents/general-agent-drawer";
+import { LearnerProfileDialog } from "@/components/learning/learner-profile-dialog";
 import { connectDB } from "@/lib/db";
 import Enrollment from "@/models/Enrollment";
 import { BookOpen, ArrowRight, Clock } from "lucide-react";
@@ -27,6 +28,9 @@ export default async function DashboardPage() {
           visibleText: "User dashboard with enrolled courses and progress",
         }}
       />
+      {session.user.role === "learner" ? (
+        <LearnerProfileDialog autoPrompt showTrigger={false} />
+      ) : null}
       <div className="pt-24 pb-16 max-w-5xl mx-auto px-6 lg:px-12">
         {/* Header */}
         <div className="mb-12">

--- a/apps/commons-courses/app/skills/[slug]/skill-path-client.tsx
+++ b/apps/commons-courses/app/skills/[slug]/skill-path-client.tsx
@@ -19,6 +19,7 @@ import { LoadingScreen } from "@/components/loading-screen";
 import { Confetti, type ConfettiRef } from "@/components/magicui/confetti";
 import { RichTextRenderer } from "@/components/rich-text-renderer";
 import { AgentLearnerSandbox } from "@/components/agents/agent-learner-sandbox";
+import { LearningStudio } from "@/components/learning/learning-studio";
 import { cn } from "@/lib/utils";
 import type { CourseSkillPack, SkillChallenge } from "@/types/skills";
 
@@ -499,6 +500,8 @@ export default function SkillPathClient({
               ) : (
                 <LessonView
                   challenge={challenge}
+                  courseSlug={pack.skillSlug}
+                  courseTitle={pack.title}
                   authenticated={progress.authenticated}
                   signInHref={`/auth/signin?callbackUrl=${encodeURIComponent(pathname)}`}
                   hasQuiz={challenge.questions.length > 0}
@@ -547,6 +550,8 @@ export default function SkillPathClient({
 
 function LessonView({
   challenge,
+  courseSlug,
+  courseTitle,
   authenticated,
   signInHref,
   hasQuiz,
@@ -555,6 +560,8 @@ function LessonView({
   onComplete,
 }: {
   challenge: SkillChallenge;
+  courseSlug: string;
+  courseTitle: string;
   authenticated: boolean;
   signInHref: string;
   hasQuiz: boolean;
@@ -581,6 +588,15 @@ function LessonView({
             {challenge.hook}
           </p>
         ) : null}
+        <LearningStudio
+          courseSlug={courseSlug}
+          courseTitle={courseTitle}
+          contentTitle={challenge.title}
+          source={[challenge.hook, challenge.lesson, ...challenge.keyIdeas]
+            .filter(Boolean)
+            .join("\n\n")}
+          compact
+        />
         <RichTextRenderer value={challenge.lesson} />
       </div>
 

--- a/apps/commons-courses/components/agents/general-agent-drawer.tsx
+++ b/apps/commons-courses/components/agents/general-agent-drawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FormEvent, useState } from "react";
-import { Compass, MessageSquare, Send, X } from "lucide-react";
+import { Compass, MessageSquare, Send, Sparkles, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { CourseAgentMessage, CourseAgentViewContext } from "@/types/course-agent";
 
@@ -69,8 +69,8 @@ export function GeneralAgentDrawer({ context }: Props) {
           open && "hidden"
         )}
       >
-        <Compass className="h-4 w-4" />
-        Assistant
+        <Sparkles className="h-4 w-4" />
+        Learning copilot
       </button>
 
       {open && (
@@ -85,10 +85,10 @@ export function GeneralAgentDrawer({ context }: Props) {
             <header className="flex items-start justify-between gap-3 border-b border-slate-100 p-4">
               <div>
                 <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">
-                  CommonLab assistant
+                  CommonLab copilot
                 </p>
                 <h2 className="mt-1 text-base font-bold text-slate-950">
-                  Navigate your workspace
+                  Find your next learning step
                 </h2>
               </div>
               <button
@@ -106,11 +106,11 @@ export function GeneralAgentDrawer({ context }: Props) {
                 <div className="mt-10 text-center">
                   <Compass className="mx-auto mb-3 h-5 w-5 text-slate-400" />
                   <p className="text-sm font-semibold text-slate-800">
-                    Ask across what you can access.
+                    Where would you like to go?
                   </p>
                   <p className="mx-auto mt-1 max-w-xs text-sm leading-6 text-slate-500">
-                    I can help find courses, continue lessons, locate
-                    assignments, and navigate your educator or learner work.
+                    I can help you resume a lesson, find an assignment, choose
+                    what to practise, or navigate CommonLab.
                   </p>
                 </div>
               ) : (

--- a/apps/commons-courses/components/course-agents/course-agent-drawer.tsx
+++ b/apps/commons-courses/components/course-agents/course-agent-drawer.tsx
@@ -1,9 +1,20 @@
 "use client";
 
 import { FormEvent, useMemo, useState } from "react";
-import { Bot, ChevronRight, MessageSquare, Send, Sparkles, X } from "lucide-react";
+import {
+  Bot,
+  Brain,
+  ChevronRight,
+  Compass,
+  MessageSquare,
+  Send,
+  Sparkles,
+  Target,
+  X,
+} from "lucide-react";
 import { defaultCourseAgents } from "@/lib/course-agent-defaults";
 import { cn } from "@/lib/utils";
+import { LearnerProfileDialog } from "@/components/learning/learner-profile-dialog";
 import type {
   CourseAgentConfig,
   CourseAgentMessage,
@@ -47,6 +58,11 @@ export function CourseAgentDrawer({
   async function sendMessage(event: FormEvent) {
     event.preventDefault();
     const content = input.trim();
+    if (!content) return;
+    await sendContent(content);
+  }
+
+  async function sendContent(content: string) {
     if (!content || loading || !activeAgent) return;
 
     const nextMessages = [...messages, { role: "user" as const, content }];
@@ -94,14 +110,23 @@ export function CourseAgentDrawer({
     <>
       <button
         type="button"
-        aria-label="Open course assistant"
+        aria-label={
+          role === "learner" ? "Open learning copilot" : "Open course assistant"
+        }
         onClick={() => setOpen(true)}
         className={cn(
           "fixed right-0 top-1/2 z-40 flex -translate-y-1/2 items-center gap-2 rounded-l-lg border border-r-0 border-slate-200 bg-white px-2.5 py-3 text-sm font-bold text-slate-800 shadow-sm transition hover:bg-slate-50",
           open && "translate-x-full"
         )}
       >
-        <Bot className="h-4 w-4" />
+        {role === "learner" ? (
+          <Sparkles className="h-4 w-4" />
+        ) : (
+          <Bot className="h-4 w-4" />
+        )}
+        <span className="hidden sm:inline">
+          {role === "learner" ? "Copilot" : ""}
+        </span>
         <ChevronRight className="h-3.5 w-3.5 rotate-180 text-slate-400" />
       </button>
 
@@ -118,11 +143,18 @@ export function CourseAgentDrawer({
               <div className="mb-3 flex items-start justify-between gap-3">
                 <div>
                   <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">
-                    Course agent
+                    {role === "learner"
+                      ? "Your learning copilot"
+                      : "Course agent"}
                   </p>
                   <h2 className="mt-1 text-base font-bold text-slate-950">
-                    {activeAgent.name}
+                    {role === "learner" ? "Learn with guidance" : activeAgent.name}
                   </h2>
+                  {role === "learner" ? (
+                    <p className="mt-1 text-xs text-slate-500">
+                      Understand, practise, and find your next step.
+                    </p>
+                  ) : null}
                 </div>
                 <button
                   type="button"
@@ -146,6 +178,14 @@ export function CourseAgentDrawer({
                   ))}
                 </select>
               )}
+              {role === "learner" ? (
+                <div className="mt-3">
+                  <LearnerProfileDialog
+                    buttonLabel="Personalize my guidance"
+                    className="w-full justify-center py-2 text-xs"
+                  />
+                </div>
+              ) : null}
             </header>
 
             <div className="flex-1 overflow-y-auto p-4">
@@ -153,12 +193,46 @@ export function CourseAgentDrawer({
                 <div className="mt-10 text-center">
                   <Sparkles className="mx-auto mb-3 h-5 w-5 text-slate-400" />
                   <p className="text-sm font-semibold text-slate-800">
-                    Ask from this exact view.
+                    {role === "learner"
+                      ? "Let’s work through this together."
+                      : "Ask from this exact view."}
                   </p>
                   <p className="mx-auto mt-1 max-w-xs text-sm leading-6 text-slate-500">
-                    I can use the current course, page, lesson, and visible
-                    workflow context while respecting the agent access policy.
+                    {role === "learner"
+                      ? "I can help you connect the ideas, test your understanding, and move forward without taking the learning away from you."
+                      : "I can use the current course, page, lesson, and visible workflow context while respecting the agent access policy."}
                   </p>
+                  {role === "learner" ? (
+                    <div className="mx-auto mt-5 grid max-w-sm gap-2 text-left">
+                      <Starter
+                        icon={Brain}
+                        label="Check my understanding"
+                        onClick={() =>
+                          sendContent(
+                            "Check my understanding of this lesson. Ask me one question at a time and use hints before explaining.",
+                          )
+                        }
+                      />
+                      <Starter
+                        icon={Target}
+                        label="Help me practise"
+                        onClick={() =>
+                          sendContent(
+                            "Give me a small, ungraded practice step for the idea on this page, then wait for my attempt.",
+                          )
+                        }
+                      />
+                      <Starter
+                        icon={Compass}
+                        label="What should I do next?"
+                        onClick={() =>
+                          sendContent(
+                            "Based on this lesson and my progress, guide me to the most useful next step.",
+                          )
+                        }
+                      />
+                    </div>
+                  ) : null}
                 </div>
               ) : (
                 <div className="space-y-3">
@@ -208,5 +282,27 @@ export function CourseAgentDrawer({
         </div>
       )}
     </>
+  );
+}
+
+function Starter({
+  icon: Icon,
+  label,
+  onClick,
+}: {
+  icon: typeof Brain;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex items-center gap-3 rounded-xl border border-slate-200 px-3 py-2.5 text-sm font-bold text-slate-700 transition-colors hover:bg-slate-50"
+    >
+      <Icon className="h-4 w-4 text-slate-400" />
+      {label}
+      <ChevronRight className="ml-auto h-3.5 w-3.5 text-slate-300" />
+    </button>
   );
 }

--- a/apps/commons-courses/components/learning/learner-profile-dialog.tsx
+++ b/apps/commons-courses/components/learning/learner-profile-dialog.tsx
@@ -1,0 +1,494 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  Settings2,
+  Sparkles,
+  X,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  defaultLearnerProfile,
+  learnerDomains,
+  type LearnerDomain,
+  type LearnerFormat,
+  type LearnerGuidanceStyle,
+  type LearnerProfileData,
+} from "@/types/learner-profile";
+
+type Props = {
+  autoPrompt?: boolean;
+  buttonLabel?: string;
+  className?: string;
+  controlledOpen?: boolean;
+  onControlledOpenChange?: (open: boolean) => void;
+  onSaved?: (profile: LearnerProfileData) => void;
+  showTrigger?: boolean;
+};
+
+const domainLabels: Record<LearnerDomain, string> = {
+  marketing: "Marketing",
+  healthcare: "Healthcare",
+  education: "Education",
+  technology: "Technology",
+  finance: "Finance",
+  creative: "Creative work",
+  operations: "Operations",
+  other: "Something else",
+};
+
+const formatOptions: Array<{
+  id: LearnerFormat;
+  label: string;
+  description: string;
+}> = [
+  { id: "examples", label: "Concrete examples", description: "See ideas in a familiar setting." },
+  { id: "mind_maps", label: "Mind maps", description: "See how the ideas connect." },
+  { id: "step_by_step", label: "Step by step", description: "Break practice into a sequence." },
+  { id: "reflection", label: "Reflection", description: "Learn through prompts and recall." },
+  { id: "audio", label: "Listen", description: "Hear lesson content read aloud." },
+];
+
+const guidanceOptions: Array<{
+  id: LearnerGuidanceStyle;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "coach_me",
+    label: "Coach me",
+    description: "Questions and hints before direct explanation.",
+  },
+  {
+    id: "show_then_practice",
+    label: "Show, then practise",
+    description: "A model example followed by a small attempt.",
+  },
+  {
+    id: "concise",
+    label: "Keep it concise",
+    description: "Short explanations and clear next actions.",
+  },
+];
+
+export function LearnerProfileDialog({
+  autoPrompt = false,
+  buttonLabel = "Learning preferences",
+  className,
+  controlledOpen,
+  onControlledOpenChange,
+  onSaved,
+  showTrigger = true,
+}: Props) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const [step, setStep] = useState(0);
+  const [profile, setProfile] = useState<LearnerProfileData>(
+    defaultLearnerProfile,
+  );
+  const [loaded, setLoaded] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (onControlledOpenChange) onControlledOpenChange(next);
+      else setInternalOpen(next);
+    },
+    [onControlledOpenChange],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/learner/profile")
+      .then(async (res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (cancelled || !data?.profile) return;
+        setProfile(data.profile);
+        setLoaded(true);
+        if (autoPrompt && !data.profile.onboardingCompleted) setOpen(true);
+      })
+      .finally(() => {
+        if (!cancelled) setLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [autoPrompt, setOpen]);
+
+  async function save() {
+    setSaving(true);
+    setError("");
+    const nextProfile = {
+      ...profile,
+      onboardingCompleted: true,
+    };
+    try {
+      const res = await fetch("/api/learner/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(nextProfile),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Could not save your preferences.");
+        return;
+      }
+      setProfile(data.profile);
+      setOpen(false);
+      setStep(0);
+      onSaved?.(data.profile);
+      window.dispatchEvent(
+        new CustomEvent("learner-profile-updated", { detail: data.profile }),
+      );
+    } catch {
+      setError("Could not save your preferences.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function toggleFormat(format: LearnerFormat) {
+    setProfile((current) => ({
+      ...current,
+      preferredFormats: current.preferredFormats.includes(format)
+        ? current.preferredFormats.filter((item) => item !== format)
+        : [...current.preferredFormats, format],
+    }));
+  }
+
+  if (!loaded && !open) return null;
+
+  return (
+    <>
+      {showTrigger ? (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className={cn(
+            "inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3.5 py-2 text-sm font-bold text-slate-700 transition-colors hover:bg-slate-50",
+            className,
+          )}
+        >
+          <Settings2 className="h-4 w-4" />
+          {buttonLabel}
+        </button>
+      ) : null}
+
+      {open ? (
+        <div
+          className="fixed inset-0 z-[80] flex items-end justify-center bg-slate-950/30 p-0 sm:items-center sm:p-6"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="learning-profile-title"
+        >
+          <button
+            type="button"
+            className="absolute inset-0"
+            aria-label="Close learning preferences"
+            onClick={() => setOpen(false)}
+          />
+          <section className="relative max-h-[92dvh] w-full max-w-xl overflow-y-auto rounded-t-2xl bg-white shadow-2xl sm:rounded-2xl">
+            <header className="sticky top-0 z-10 flex items-start justify-between border-b border-slate-100 bg-white px-5 py-4 sm:px-6">
+              <div>
+                <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">
+                  Your learning profile
+                </p>
+                <h2
+                  id="learning-profile-title"
+                  className="mt-1 text-lg font-bold text-slate-950"
+                >
+                  Make learning feel more familiar
+                </h2>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="rounded-lg p-2 text-slate-500 hover:bg-slate-100"
+                aria-label="Close"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </header>
+
+            <div className="px-5 py-5 sm:px-6">
+              <div className="mb-6 flex gap-2" aria-label={`Step ${step + 1} of 2`}>
+                {[0, 1].map((item) => (
+                  <div
+                    key={item}
+                    className={cn(
+                      "h-1 flex-1 rounded-full",
+                      item <= step ? "bg-slate-950" : "bg-slate-100",
+                    )}
+                  />
+                ))}
+              </div>
+
+              {step === 0 ? (
+                <div>
+                  <h3 className="text-base font-bold text-slate-950">
+                    What should examples connect to?
+                  </h3>
+                  <p className="mt-1 text-sm leading-6 text-slate-500">
+                    Share only what is useful. We use this to add optional
+                    context—not to change the educator’s lesson.
+                  </p>
+                  <label className="mt-5 block text-xs font-bold text-slate-700">
+                    Your role or current context
+                    <input
+                      value={profile.roleOrContext}
+                      onChange={(event) =>
+                        setProfile((current) => ({
+                          ...current,
+                          roleOrContext: event.target.value,
+                        }))
+                      }
+                      placeholder="e.g. Brand manager, nursing student"
+                      className="mt-2 w-full rounded-lg border border-slate-200 px-3.5 py-3 text-sm font-normal outline-none focus:border-slate-400"
+                    />
+                  </label>
+                  <div className="mt-5">
+                    <p className="text-xs font-bold text-slate-700">Field</p>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {learnerDomains.map((domain) => (
+                        <button
+                          key={domain}
+                          type="button"
+                          onClick={() =>
+                            setProfile((current) => ({
+                              ...current,
+                              domain:
+                                current.domain === domain ? "" : domain,
+                            }))
+                          }
+                          className={cn(
+                            "rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors",
+                            profile.domain === domain
+                              ? "border-slate-950 bg-slate-950 text-white"
+                              : "border-slate-200 text-slate-600 hover:bg-slate-50",
+                          )}
+                        >
+                          {domainLabels[domain]}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                  <label className="mt-5 block text-xs font-bold text-slate-700">
+                    What are you hoping to do with what you learn?
+                    <input
+                      value={profile.goals[0] || ""}
+                      onChange={(event) =>
+                        setProfile((current) => ({
+                          ...current,
+                          goals: event.target.value ? [event.target.value] : [],
+                        }))
+                      }
+                      placeholder="e.g. Build a useful agent for my team"
+                      className="mt-2 w-full rounded-lg border border-slate-200 px-3.5 py-3 text-sm font-normal outline-none focus:border-slate-400"
+                    />
+                  </label>
+                  <label className="mt-5 block text-xs font-bold text-slate-700">
+                    Things you enjoy or relate to
+                    <input
+                      value={profile.interests.join(", ")}
+                      onChange={(event) =>
+                        setProfile((current) => ({
+                          ...current,
+                          interests: event.target.value
+                            .split(",")
+                            .map((item) => item.trim())
+                            .filter(Boolean)
+                            .slice(0, 6),
+                        }))
+                      }
+                      placeholder="e.g. football, storytelling, community projects"
+                      className="mt-2 w-full rounded-lg border border-slate-200 px-3.5 py-3 text-sm font-normal outline-none focus:border-slate-400"
+                    />
+                    <span className="mt-1 block text-[11px] font-normal text-slate-400">
+                      Optional · separate with commas
+                    </span>
+                  </label>
+                </div>
+              ) : (
+                <div>
+                  <h3 className="text-base font-bold text-slate-950">
+                    How should your copilot guide you?
+                  </h3>
+                  <p className="mt-1 text-sm leading-6 text-slate-500">
+                    Choose any formats you enjoy. You can switch views inside a
+                    lesson at any time.
+                  </p>
+                  <label className="mt-5 flex items-start justify-between gap-4 rounded-xl border border-slate-200 p-3">
+                    <span>
+                      <span className="block text-sm font-bold text-slate-900">
+                        Personalize examples
+                      </span>
+                      <span className="mt-0.5 block text-xs leading-5 text-slate-500">
+                        Use the context you shared for optional examples and
+                        copilot guidance.
+                      </span>
+                    </span>
+                    <input
+                      type="checkbox"
+                      checked={profile.personalizationEnabled}
+                      onChange={(event) =>
+                        setProfile((current) => ({
+                          ...current,
+                          personalizationEnabled: event.target.checked,
+                        }))
+                      }
+                      className="mt-1 h-4 w-4 shrink-0"
+                    />
+                  </label>
+                  <div className="mt-5 grid gap-2 sm:grid-cols-2">
+                    {formatOptions.map((format) => {
+                      const selected = profile.preferredFormats.includes(format.id);
+                      return (
+                        <button
+                          key={format.id}
+                          type="button"
+                          onClick={() => toggleFormat(format.id)}
+                          className={cn(
+                            "flex items-start gap-3 rounded-xl border p-3 text-left",
+                            selected
+                              ? "border-slate-950 bg-slate-50"
+                              : "border-slate-200 bg-white",
+                          )}
+                        >
+                          <span
+                            className={cn(
+                              "mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md border",
+                              selected
+                                ? "border-slate-950 bg-slate-950 text-white"
+                                : "border-slate-300",
+                            )}
+                          >
+                            {selected ? <Check className="h-3 w-3" /> : null}
+                          </span>
+                          <span>
+                            <span className="block text-sm font-bold text-slate-900">
+                              {format.label}
+                            </span>
+                            <span className="mt-0.5 block text-xs leading-5 text-slate-500">
+                              {format.description}
+                            </span>
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                  <div className="mt-5 space-y-2">
+                    {guidanceOptions.map((option) => (
+                      <button
+                        key={option.id}
+                        type="button"
+                        onClick={() =>
+                          setProfile((current) => ({
+                            ...current,
+                            guidanceStyle: option.id,
+                          }))
+                        }
+                        className={cn(
+                          "w-full rounded-xl border px-4 py-3 text-left",
+                          profile.guidanceStyle === option.id
+                            ? "border-slate-950"
+                            : "border-slate-200",
+                        )}
+                      >
+                        <span className="text-sm font-bold text-slate-900">
+                          {option.label}
+                        </span>
+                        <span className="ml-2 text-xs text-slate-500">
+                          {option.description}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                  <label className="mt-5 flex items-start gap-3 rounded-xl bg-slate-50 p-3">
+                    <input
+                      type="checkbox"
+                      checked={profile.allowUsageLearning}
+                      onChange={(event) =>
+                        setProfile((current) => ({
+                          ...current,
+                          allowUsageLearning: event.target.checked,
+                        }))
+                      }
+                      className="mt-1"
+                    />
+                    <span>
+                      <span className="block text-sm font-bold text-slate-800">
+                        Improve from how I use learning views
+                      </span>
+                      <span className="mt-0.5 block text-xs leading-5 text-slate-500">
+                        Remember view usage and helpful marks. We do not infer
+                        sensitive traits, and you can turn this off.
+                      </span>
+                    </span>
+                  </label>
+                </div>
+              )}
+
+              {error ? (
+                <p className="mt-4 rounded-lg bg-rose-50 px-3 py-2 text-sm text-rose-700">
+                  {error}
+                </p>
+              ) : null}
+            </div>
+
+            <footer className="sticky bottom-0 flex items-center justify-between border-t border-slate-100 bg-white px-5 py-4 sm:px-6">
+              {step === 1 ? (
+                <button
+                  type="button"
+                  onClick={() => setStep(0)}
+                  className="inline-flex items-center gap-1.5 text-sm font-bold text-slate-600"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                  Back
+                </button>
+              ) : (
+                <span className="inline-flex items-center gap-1.5 text-xs text-slate-400">
+                  <Sparkles className="h-3.5 w-3.5" />
+                  Optional and editable
+                </span>
+              )}
+              {step === 0 ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setProfile((current) => ({
+                      ...current,
+                      personalizationEnabled:
+                        current.personalizationEnabled ||
+                        Boolean(
+                          current.domain ||
+                            current.roleOrContext ||
+                            current.customContext,
+                        ),
+                    }));
+                    setStep(1);
+                  }}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-slate-950 px-4 py-2.5 text-sm font-bold text-white"
+                >
+                  Continue
+                  <ArrowRight className="h-4 w-4" />
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={save}
+                  disabled={saving}
+                  className="rounded-lg bg-slate-950 px-5 py-2.5 text-sm font-bold text-white disabled:opacity-50"
+                >
+                  {saving ? "Saving…" : "Save my preferences"}
+                </button>
+              )}
+            </footer>
+          </section>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/apps/commons-courses/components/learning/learning-studio.tsx
+++ b/apps/commons-courses/components/learning/learning-studio.tsx
@@ -1,0 +1,478 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { CSSProperties } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  Check,
+  Headphones,
+  Loader2,
+  Network,
+  Pause,
+  SlidersHorizontal,
+  Sparkles,
+} from "lucide-react";
+import { stripRichTextHtml } from "@/lib/rich-text";
+import { cn } from "@/lib/utils";
+import type {
+  ContextualLearningView,
+  LearnerProfileData,
+  MindMapNode,
+} from "@/types/learner-profile";
+import { LearnerProfileDialog } from "./learner-profile-dialog";
+
+type Props = {
+  courseSlug: string;
+  courseTitle: string;
+  contentTitle: string;
+  source: string;
+  compact?: boolean;
+};
+
+type View = "original" | "context" | "mind_map";
+
+export function LearningStudio({
+  courseSlug,
+  courseTitle,
+  contentTitle,
+  source,
+  compact = false,
+}: Props) {
+  const [view, setView] = useState<View>("original");
+  const [profile, setProfile] = useState<LearnerProfileData | null>(null);
+  const [authenticated, setAuthenticated] = useState<boolean | null>(null);
+  const [profileOpen, setProfileOpen] = useState(false);
+  const [context, setContext] = useState<ContextualLearningView | null>(null);
+  const [mindMap, setMindMap] = useState<MindMapNode | null>(null);
+  const [loading, setLoading] = useState<View | null>(null);
+  const [error, setError] = useState("");
+  const [speaking, setSpeaking] = useState(false);
+  const [helpful, setHelpful] = useState(false);
+  const plainSource = useMemo(() => stripRichTextHtml(source), [source]);
+  const pathname = usePathname();
+  const signInHref = `/auth/signin?callbackUrl=${encodeURIComponent(pathname)}`;
+
+  useEffect(() => {
+    fetch("/api/learner/profile")
+      .then(async (res) => {
+        setAuthenticated(res.status !== 401);
+        return res.ok ? res.json() : null;
+      })
+      .then((data) => setProfile(data?.profile || null));
+    const profileUpdated = (event: Event) => {
+      setProfile((event as CustomEvent<LearnerProfileData>).detail);
+      setContext(null);
+    };
+    window.addEventListener("learner-profile-updated", profileUpdated);
+    return () => {
+      window.removeEventListener("learner-profile-updated", profileUpdated);
+      window.speechSynthesis?.cancel();
+    };
+  }, []);
+
+  async function selectView(nextView: View) {
+    setView(nextView);
+    setError("");
+    if (nextView === "original") return;
+    if (authenticated === false) return;
+    if (nextView === "context" && !profile?.personalizationEnabled) return;
+    if (
+      (nextView === "context" && context) ||
+      (nextView === "mind_map" && mindMap)
+    ) {
+      return;
+    }
+
+    setLoading(nextView);
+    try {
+      const res = await fetch("/api/learner/learning-view", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          kind: nextView === "context" ? "contextual_example" : "mind_map",
+          courseSlug,
+          courseTitle,
+          contentTitle,
+          source,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Could not create this learning view.");
+        return;
+      }
+      if (nextView === "context") setContext(data.view);
+      else setMindMap(data.view);
+    } catch {
+      setError("Could not create this learning view.");
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  function toggleAudio() {
+    if (!("speechSynthesis" in window)) {
+      setError("Read aloud is not supported by this browser.");
+      return;
+    }
+    if (speaking) {
+      window.speechSynthesis.cancel();
+      setSpeaking(false);
+      return;
+    }
+    const utterance = new SpeechSynthesisUtterance(
+      `${contentTitle}. ${plainSource}`,
+    );
+    utterance.rate = 0.95;
+    utterance.onend = () => setSpeaking(false);
+    utterance.onerror = () => setSpeaking(false);
+    window.speechSynthesis.cancel();
+    window.speechSynthesis.speak(utterance);
+    setSpeaking(true);
+    void recordSignal("audio_started");
+  }
+
+  function markHelpful() {
+    if (helpful) return;
+    setHelpful(true);
+    void recordSignal("learning_view_helpful");
+  }
+
+  return (
+    <section
+      className={cn(
+        "mb-7 overflow-hidden rounded-2xl border border-slate-200 bg-white",
+        compact && "mb-4 rounded-xl",
+      )}
+    >
+      <div className="flex flex-col gap-3 border-b border-slate-100 bg-slate-50/70 px-4 py-3 sm:flex-row sm:items-center">
+        <div className="min-w-0 flex-1">
+          <p className="flex items-center gap-1.5 text-xs font-bold text-slate-900">
+            <Sparkles className="h-3.5 w-3.5" />
+            Learn this your way
+          </p>
+          <p className="mt-0.5 text-[11px] text-slate-500">
+            The original lesson always remains the source of truth.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-1 rounded-lg border border-slate-200 bg-white p-1">
+          <ViewButton
+            active={view === "original"}
+            label="Original"
+            onClick={() => selectView("original")}
+          />
+          <ViewButton
+            active={view === "context"}
+            icon={SlidersHorizontal}
+            label="My context"
+            onClick={() => selectView("context")}
+          />
+          <ViewButton
+            active={view === "mind_map"}
+            icon={Network}
+            label="Mind map"
+            onClick={() => selectView("mind_map")}
+          />
+          <button
+            type="button"
+            onClick={toggleAudio}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-bold transition-colors",
+              speaking
+                ? "bg-sky-50 text-sky-700"
+                : "text-slate-500 hover:bg-slate-50 hover:text-slate-900",
+            )}
+          >
+            {speaking ? (
+              <Pause className="h-3.5 w-3.5" />
+            ) : (
+              <Headphones className="h-3.5 w-3.5" />
+            )}
+            {speaking ? "Stop" : "Listen"}
+          </button>
+        </div>
+      </div>
+
+      {view === "original" ? (
+        <div className="flex items-center justify-between gap-3 px-4 py-3">
+          <p className="text-xs leading-5 text-slate-500">
+            You are reading the educator’s original content below.
+          </p>
+          {authenticated === false ? (
+            <Link
+              href={signInHref}
+              className="shrink-0 px-2 py-1.5 text-xs font-bold text-slate-600 hover:text-slate-950"
+            >
+              Sign in to personalize
+            </Link>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setProfileOpen(true)}
+              className="shrink-0 px-2 py-1.5 text-xs font-bold text-slate-600 hover:text-slate-950"
+            >
+              Preferences
+            </button>
+          )}
+        </div>
+      ) : null}
+
+      {view !== "original" && authenticated === false ? (
+        <div className="px-5 py-6 text-center">
+          <Sparkles className="mx-auto h-5 w-5 text-slate-400" />
+          <h3 className="mt-2 text-sm font-bold text-slate-900">
+            Save learning views to your profile
+          </h3>
+          <p className="mx-auto mt-1 max-w-md text-sm leading-6 text-slate-500">
+            Sign in to create mind maps, personalized examples, and guidance
+            connected to your learning preferences.
+          </p>
+          <Link
+            href={signInHref}
+            className="mt-4 inline-flex rounded-lg bg-slate-950 px-4 py-2.5 text-sm font-bold text-white"
+          >
+            Sign in to continue
+          </Link>
+        </div>
+      ) : null}
+
+      {view === "context" &&
+      authenticated !== false &&
+      !profile?.personalizationEnabled ? (
+        <div className="px-5 py-6 text-center">
+          <SlidersHorizontal className="mx-auto h-5 w-5 text-slate-400" />
+          <h3 className="mt-2 text-sm font-bold text-slate-900">
+            Add just enough context to make examples familiar
+          </h3>
+          <p className="mx-auto mt-1 max-w-md text-sm leading-6 text-slate-500">
+            Tell us your field, role, or goal. Personalization is optional and
+            never replaces the educator’s lesson.
+          </p>
+          <button
+            type="button"
+            onClick={() => setProfileOpen(true)}
+            className="mt-4 rounded-lg bg-slate-950 px-4 py-2.5 text-sm font-bold text-white"
+          >
+            {profile?.onboardingCompleted
+              ? "Turn on personalization"
+              : "Set up my context"}
+          </button>
+        </div>
+      ) : null}
+
+      {loading && authenticated !== false ? (
+        <div className="flex items-center justify-center gap-2 px-5 py-8 text-sm text-slate-500">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          {loading === "mind_map"
+            ? "Mapping the key ideas…"
+            : "Connecting this to your context…"}
+        </div>
+      ) : null}
+
+      {error ? (
+        <p className="m-4 rounded-lg bg-rose-50 px-3 py-2 text-sm text-rose-700">
+          {error}
+        </p>
+      ) : null}
+
+      {view === "context" && context && !loading && authenticated !== false ? (
+        <div className="p-5">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-sky-700">
+                Personalized learning aid
+              </p>
+              <h3 className="mt-1 text-base font-bold text-slate-950">
+                {context.title}
+              </h3>
+            </div>
+            <button
+              type="button"
+              onClick={() => setProfileOpen(true)}
+              className="text-xs font-bold text-slate-500 hover:text-slate-900"
+            >
+              Adjust
+            </button>
+          </div>
+          <p className="mt-2 text-sm leading-6 text-slate-500">
+            {context.bridge}
+          </p>
+          <div className="mt-4 rounded-xl bg-sky-50/70 p-4 text-sm leading-7 text-slate-800">
+            {context.example}
+          </div>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <LearningNote label="How it connects" value={context.connection} />
+            <LearningNote label="Make it yours" value={context.tryIt} />
+          </div>
+          <div className="mt-4 flex flex-col gap-3 border-t border-slate-100 pt-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="max-w-lg text-[11px] leading-5 text-slate-400">
+              {context.fidelityNote}
+            </p>
+            <button
+              type="button"
+              onClick={markHelpful}
+              className={cn(
+                "inline-flex shrink-0 items-center gap-1.5 text-xs font-bold",
+                helpful ? "text-green-700" : "text-slate-500 hover:text-slate-900",
+              )}
+            >
+              <Check className="h-3.5 w-3.5" />
+              {helpful ? "Helpful" : "This helped"}
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {view === "mind_map" && mindMap && !loading && authenticated !== false ? (
+        <MindMapView node={mindMap} onHelpful={markHelpful} helpful={helpful} />
+      ) : null}
+
+      <LearnerProfileDialog
+        controlledOpen={profileOpen}
+        onControlledOpenChange={setProfileOpen}
+        onSaved={setProfile}
+        showTrigger={false}
+      />
+    </section>
+  );
+}
+
+function ViewButton({
+  active,
+  icon: Icon,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  icon?: typeof Network;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-bold transition-colors",
+        active
+          ? "bg-slate-950 text-white"
+          : "text-slate-500 hover:bg-slate-50 hover:text-slate-900",
+      )}
+    >
+      {Icon ? <Icon className="h-3.5 w-3.5" /> : null}
+      {label}
+    </button>
+  );
+}
+
+function LearningNote({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-slate-200 p-3">
+      <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
+        {label}
+      </p>
+      <p className="mt-1.5 text-sm leading-6 text-slate-700">{value}</p>
+    </div>
+  );
+}
+
+function MindMapView({
+  node,
+  helpful,
+  onHelpful,
+}: {
+  node: MindMapNode;
+  helpful: boolean;
+  onHelpful: () => void;
+}) {
+  return (
+    <div className="overflow-x-auto p-5">
+      <div className="min-w-[720px]">
+        <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-violet-700">
+          Generated from the educator’s lesson
+        </p>
+        <div className="mt-4 rounded-xl bg-slate-950 px-4 py-3 text-center text-sm font-bold text-white">
+          {node.label}
+          {node.detail ? (
+            <span className="mt-1 block text-xs font-normal leading-5 text-white/60">
+              {node.detail}
+            </span>
+          ) : null}
+        </div>
+        <div className="mx-auto h-5 w-px bg-slate-300" />
+        <div
+          className="relative grid gap-3 before:absolute before:left-[var(--mind-map-line-inset)] before:right-[var(--mind-map-line-inset)] before:top-0 before:h-px before:bg-slate-300"
+          style={
+            {
+              gridTemplateColumns: `repeat(${Math.max(
+                node.children?.length || 1,
+                1,
+              )}, minmax(0, 1fr))`,
+              "--mind-map-line-inset": `${50 / Math.max(
+                node.children?.length || 1,
+                1,
+              )}%`,
+            } as CSSProperties
+          }
+        >
+          {(node.children || []).map((child) => (
+            <div key={child.id} className="relative pt-5">
+              <div className="absolute left-1/2 top-0 h-5 w-px bg-slate-300" />
+              <div className="h-full rounded-xl border border-slate-200 bg-white p-3 text-center">
+                <p className="text-xs font-bold text-slate-900">{child.label}</p>
+                {child.detail ? (
+                  <p className="mt-1 text-[11px] leading-5 text-slate-500">
+                    {child.detail}
+                  </p>
+                ) : null}
+                {child.children?.length ? (
+                  <div className="mt-2 space-y-1.5 border-t border-slate-100 pt-2">
+                    {child.children.map((leaf) => (
+                      <p
+                        key={leaf.id}
+                        className="rounded-md bg-slate-50 px-2 py-1.5 text-[11px] text-slate-600"
+                      >
+                        {leaf.label}
+                      </p>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="mt-4 flex items-center justify-between border-t border-slate-100 pt-3">
+          <p className="text-[11px] text-slate-400">
+            A visual aid—not a replacement for the original lesson.
+          </p>
+          <button
+            type="button"
+            onClick={onHelpful}
+            className={cn(
+              "inline-flex items-center gap-1.5 text-xs font-bold",
+              helpful ? "text-green-700" : "text-slate-500 hover:text-slate-900",
+            )}
+          >
+            <Check className="h-3.5 w-3.5" />
+            {helpful ? "Helpful" : "This helped"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+async function recordSignal(
+  signal: "audio_started" | "learning_view_helpful",
+) {
+  try {
+    await fetch("/api/learner/signals", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ signal }),
+    });
+  } catch {
+    // Preference signals should never interrupt learning.
+  }
+}

--- a/apps/commons-courses/components/nav.tsx
+++ b/apps/commons-courses/components/nav.tsx
@@ -147,6 +147,13 @@ export function Nav() {
                     <Settings className="h-4 w-4" />
                     Account settings
                   </ProfileMenuLink>
+                  <ProfileMenuLink
+                    href="/account#learning-profile"
+                    onClick={() => setProfileOpen(false)}
+                  >
+                    <FlaskConical className="h-4 w-4" />
+                    Learning preferences
+                  </ProfileMenuLink>
                   <button
                     onClick={() => signOut()}
                     className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm text-slate-700 transition-colors hover:bg-slate-50"
@@ -261,6 +268,13 @@ export function Nav() {
                 onClick={() => setMobileOpen(false)}
               >
                 Account
+              </Link>
+              <Link
+                href="/account#learning-profile"
+                className="text-sm text-slate-700"
+                onClick={() => setMobileOpen(false)}
+              >
+                Learning preferences
               </Link>
               <button
                 onClick={() => signOut()}

--- a/apps/commons-courses/lib/course-agent-defaults.ts
+++ b/apps/commons-courses/lib/course-agent-defaults.ts
@@ -10,7 +10,7 @@ export const defaultCourseAgents: CourseAgentConfig[] = [
     learningMode: "guided",
     actions: ["suggest", "navigate"],
     instructions:
-      "Help learners understand the current course material, find relevant lessons, plan practice, and unblock setup. Do not complete assignments for them or reveal solutions that bypass learning.",
+      "Guide learners to understand the current course material, retrieve what they know, connect ideas, practise one step at a time, and find the right lesson or platform feature. Use questions and hints when useful; do not simply give answers, complete assignments, or reveal solutions that bypass learning.",
   },
   {
     id: "educator-copilot",

--- a/apps/commons-courses/lib/course-agent-runtime.ts
+++ b/apps/commons-courses/lib/course-agent-runtime.ts
@@ -6,6 +6,7 @@ import type {
   CourseAgentMessage,
   CourseAgentViewContext,
 } from "@/types/course-agent";
+import type { LearnerProfileData } from "@/types/learner-profile";
 
 export type RuntimeCourse = {
   title: string;
@@ -31,6 +32,7 @@ type RuntimeInput = {
     progress?: number;
     accessLevel?: string;
   } | null;
+  learnerProfile?: Partial<LearnerProfileData> | null;
   educatorAnalytics?: Record<string, unknown> | null;
 };
 
@@ -96,12 +98,24 @@ function fallbackCourseAgentReply(input: RuntimeInput) {
 }
 
 function buildRunMessages(input: RuntimeInput) {
+  const learnerTeachingPolicy =
+    input.role === "learner"
+      ? [
+          "Act as a learning copilot, not an answer machine.",
+          "First identify the learner's current understanding or goal when it is unclear.",
+          "Use a short cycle: orient, ask or model one step, invite the learner to try, then give feedback.",
+          "Prefer retrieval prompts, hints, worked analogies, and reflection before a full direct answer.",
+          "Adapt examples only from the explicit learner profile. State when an example is an added contextual aid, and preserve the educator's original meaning.",
+          "Never describe the learner as a fixed learning-style category.",
+        ].join("\n")
+      : "";
   const system = [
     input.agent.instructions,
     "You are embedded in Commons Courses as a context-aware course assistant.",
     "Respect the supplied courseAgentPolicy and scopedCourseContext.",
     "For learners, teach through hints, explanations, retrieval, and setup help. Do not complete graded work or reveal hidden answers.",
     "For educators, support course delivery, analytics interpretation, course operations, and drafting within the configured action policy.",
+    learnerTeachingPolicy,
   ]
     .filter(Boolean)
     .join("\n\n");
@@ -169,6 +183,20 @@ function buildScopedContext(input: RuntimeInput) {
         input.agent.dataScope === "course_content_and_progress"
           ? input.learnerProgress
           : null,
+      learnerProfile: input.learnerProfile?.personalizationEnabled
+        ? {
+            roleOrContext: input.learnerProfile.roleOrContext,
+            domain: input.learnerProfile.domain,
+            interests: input.learnerProfile.interests,
+            goals: input.learnerProfile.goals,
+            preferredFormats: input.learnerProfile.preferredFormats,
+            guidanceStyle: input.learnerProfile.guidanceStyle,
+            customContext: input.learnerProfile.customContext,
+            usageSignals: input.learnerProfile.allowUsageLearning
+              ? input.learnerProfile.usageSignals
+              : undefined,
+          }
+        : null,
     };
   }
 

--- a/apps/commons-courses/lib/general-agent-runtime.ts
+++ b/apps/commons-courses/lib/general-agent-runtime.ts
@@ -1,6 +1,7 @@
 import { getAgentCommonsClient } from "@/lib/agent-commons";
 import type { CourseAgentMessage, CourseAgentViewContext } from "@/types/course-agent";
 import type { ScopedSearchResult } from "@/types/vector-search";
+import type { LearnerProfileData } from "@/types/learner-profile";
 
 type GeneralAgentInput = {
   message: string;
@@ -30,6 +31,7 @@ type GeneralAgentInput = {
     }>;
   };
   searchResults: Array<ScopedSearchResult & { courseTitle?: string; courseSlug?: string }>;
+  learnerProfile?: Partial<LearnerProfileData> | null;
 };
 
 export async function runGeneralAgent(input: GeneralAgentInput) {
@@ -48,6 +50,9 @@ export async function runGeneralAgent(input: GeneralAgentInput) {
           currentView: input.context,
           accessibleWorkspace: input.accessible,
           semanticSearchResults: input.searchResults,
+          learnerProfile: input.learnerProfile?.personalizationEnabled
+            ? input.learnerProfile
+            : null,
           accessPolicy:
             "Only use the accessibleWorkspace and semanticSearchResults supplied here. Never claim access to hidden courses, another learner's private data, or educator-only data unless present in this context.",
         },
@@ -98,9 +103,11 @@ function fallbackReply(input: GeneralAgentInput) {
 
 function buildGeneralSystemPrompt() {
   return [
-    "You are the CommonLab workspace assistant.",
-    "Help users navigate and find things across only the courses and views they are allowed to access.",
-    "Prefer links and concrete next actions. Be concise.",
+    "You are the CommonLab learner copilot and workspace guide.",
+    "Help users navigate, choose a useful next learning step, and find things across only the courses and views they are allowed to access.",
+    "Guide rather than simply answer: orient the learner, offer one concrete next action, and ask a useful question when their goal is unclear.",
+    "Use an explicitly supplied learner profile to tailor examples or recommendations, but never infer sensitive traits or assign a fixed learning-style label.",
+    "Prefer links and concrete next actions. Be concise and encouraging without being performative.",
     "Do not expose another learner's private information, submissions, grades, progress, payments, messages, or feedback.",
     "Educator-only details may be used only when they are included in the supplied scoped context.",
   ].join("\n");

--- a/apps/commons-courses/lib/learner-learning-runtime.ts
+++ b/apps/commons-courses/lib/learner-learning-runtime.ts
@@ -1,0 +1,261 @@
+import { getAgentCommonsClient } from "@/lib/agent-commons";
+import { stripRichTextHtml } from "@/lib/rich-text";
+import type {
+  ContextualLearningView,
+  LearnerProfileData,
+  MindMapNode,
+} from "@/types/learner-profile";
+
+type LearningViewInput = {
+  kind: "contextual_example" | "mind_map";
+  courseTitle: string;
+  contentTitle: string;
+  source: string;
+  profile: LearnerProfileData;
+};
+
+export async function generateLearningView(input: LearningViewInput) {
+  const client = getAgentCommonsClient();
+  const agentId =
+    process.env.AGENT_COMMONS_LEARNER_COPILOT_ID ||
+    process.env.AGENT_COMMONS_GENERAL_AGENT_ID;
+
+  if (client && agentId) {
+    try {
+      const result = await client.run.once({
+        agentId,
+        messages: [
+          { role: "system", content: buildSystemPrompt(input.kind) },
+          {
+            role: "user",
+            content: JSON.stringify({
+              task: input.kind,
+              courseTitle: input.courseTitle,
+              contentTitle: input.contentTitle,
+              educatorSource: sourceText(input.source).slice(0, 12000),
+              learnerProfile: {
+                domain: input.profile.domain,
+                roleOrContext: input.profile.roleOrContext,
+                interests: input.profile.interests,
+                goals: input.profile.goals,
+                guidanceStyle: input.profile.guidanceStyle,
+                customContext: input.profile.customContext,
+                usageSignals: input.profile.allowUsageLearning
+                  ? input.profile.usageSignals
+                  : undefined,
+              },
+            }),
+          },
+        ],
+      });
+      const parsed = parseGeneratedResult(result);
+      if (input.kind === "mind_map" && isMindMap(parsed)) return parsed;
+      if (
+        input.kind === "contextual_example" &&
+        isContextualView(parsed)
+      ) {
+        return parsed;
+      }
+    } catch (error) {
+      console.error("[learner-learning-view] generation failed:", error);
+    }
+  }
+
+  return input.kind === "mind_map"
+    ? buildFallbackMindMap(input)
+    : buildFallbackContext(input);
+}
+
+function buildSystemPrompt(kind: LearningViewInput["kind"]) {
+  const shared = [
+    "You are the CommonLab learner copilot.",
+    "Your role is to help a learner understand educator-authored material without changing its claims, scope, intent, warnings, or learning objective.",
+    "Treat the educatorSource as canonical. Add a clearly separate learning aid; never rewrite or replace the source.",
+    "Do not invent facts, requirements, outcomes, or domain-specific claims. Do not introduce sensitive assumptions about the learner.",
+    "Use only the explicitly supplied learner profile. Avoid stereotypes.",
+    "Return valid JSON only, with no markdown fences.",
+  ];
+
+  if (kind === "mind_map") {
+    return [
+      ...shared,
+      'Return one tree with this shape: {"id":"root","label":"...","detail":"...","children":[{"id":"...","label":"...","detail":"...","children":[]}]}',
+      "Use 3–5 main branches and no more than 3 children per branch. Keep labels short. Map relationships present in the source only.",
+    ].join("\n");
+  }
+
+  return [
+    ...shared,
+    'Return: {"title":"In your context","bridge":"...","example":"...","connection":"...","tryIt":"...","fidelityNote":"..."}',
+    "The example may change the setting and actors, but must preserve the mechanism taught in the source.",
+    "The connection must explicitly map the example back to the source idea.",
+    "The tryIt prompt should invite retrieval or application; it must not give away graded work.",
+    'Use the fidelityNote: "This example adds context; the educator’s original meaning remains the source of truth."',
+  ].join("\n");
+}
+
+function parseGeneratedResult(result: unknown): unknown {
+  if (!result || typeof result !== "object") return null;
+  const record = result as Record<string, unknown>;
+  const candidates = [
+    record.content,
+    record.text,
+    record.output,
+    record.response,
+    (record.data as Record<string, unknown> | undefined)?.content,
+    (record.data as Record<string, unknown> | undefined)?.text,
+    (record.data as Record<string, unknown> | undefined)?.output,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") continue;
+    try {
+      return JSON.parse(
+        candidate
+          .trim()
+          .replace(/^```(?:json)?\s*/i, "")
+          .replace(/\s*```$/, ""),
+      );
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+function isContextualView(value: unknown): value is ContextualLearningView {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return ["title", "bridge", "example", "connection", "tryIt", "fidelityNote"].every(
+    (key) => typeof record[key] === "string" && Boolean(record[key]),
+  );
+}
+
+function isMindMap(value: unknown): value is MindMapNode {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === "string" &&
+    typeof record.label === "string" &&
+    Array.isArray(record.children)
+  );
+}
+
+function buildFallbackContext(input: LearningViewInput): ContextualLearningView {
+  const context =
+    input.profile.roleOrContext ||
+    domainLabels[input.profile.domain || ""] ||
+    "your day-to-day work";
+  const topic = input.contentTitle || input.courseTitle;
+  const source = sourceText(input.source);
+  const centralIdea = firstUsefulSentence(source) || `the central idea in ${topic}`;
+  const domainExample = fallbackExamples[input.profile.domain || ""]?.(
+    centralIdea,
+  );
+
+  return {
+    title: `See ${topic} in ${context}`,
+    bridge: `Here is a concrete way to connect this lesson to ${context}.`,
+    example:
+      domainExample ||
+      `Imagine you are using this idea during a real task in ${context}. Start with the same capability described in the lesson, then decide what it may access and what limits should apply before you use it.`,
+    connection: `The setting is different, but the mechanism is unchanged: ${centralIdea}`,
+    tryIt: `Name one task from ${context} where this idea would help. What access would be necessary, and what would you deliberately keep out of scope?`,
+    fidelityNote:
+      "This example adds context; the educator’s original meaning remains the source of truth.",
+  };
+}
+
+function buildFallbackMindMap(input: LearningViewInput): MindMapNode {
+  const source = sourceText(input.source);
+  const sentences = source
+    .split(/(?<=[.!?])\s+|\n+/)
+    .map((sentence) => sentence.trim())
+    .filter((sentence) => sentence.length > 28);
+  const branches = sentences.slice(0, 5).map((sentence, index) => {
+    const [lead, ...rest] = sentence.split(/[:;—]/);
+    return {
+      id: `idea-${index + 1}`,
+      label: shorten(lead, 48),
+      detail: shorten(rest.join(" ") || sentence, 120),
+      children: [],
+    };
+  });
+
+  if (branches.length < 3) {
+    branches.push(
+      {
+        id: "idea-purpose",
+        label: "Purpose",
+        detail: `What ${input.contentTitle} helps you understand or do.`,
+        children: [],
+      },
+      {
+        id: "idea-practice",
+        label: "In practice",
+        detail: "Apply the idea while keeping the stated boundaries in view.",
+        children: [],
+      },
+    );
+  }
+
+  return {
+    id: "root",
+    label: input.contentTitle,
+    detail: `A map of the educator’s key ideas in ${input.courseTitle}.`,
+    children: branches.slice(0, 5),
+  };
+}
+
+function firstUsefulSentence(value: string) {
+  return value
+    .split(/(?<=[.!?])\s+|\n+/)
+    .map((sentence) => sentence.trim())
+    .find((sentence) => sentence.length >= 35);
+}
+
+function shorten(value: string, max: number) {
+  const clean = value.replace(/\s+/g, " ").trim();
+  if (clean.length <= max) return clean;
+  return `${clean.slice(0, max - 1).trim()}…`;
+}
+
+function sourceText(value: string) {
+  return stripRichTextHtml(value)
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/(^|\s)[#>*_`~-]+(?=\S)/g, "$1")
+    .replace(/[*_`~]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+const domainLabels: Record<string, string> = {
+  marketing: "marketing work",
+  healthcare: "healthcare work",
+  education: "teaching and learning",
+  technology: "technology work",
+  finance: "financial services",
+  creative: "creative work",
+  operations: "operations",
+};
+
+const fallbackExamples: Record<
+  string,
+  ((centralIdea: string) => string) | undefined
+> = {
+  marketing: (idea) =>
+    `A campaign agent could read an approved brief, check the content calendar, and prepare channel-specific suggestions. It should not gain access to every customer record or publish automatically unless those permissions are intentionally granted. This puts the lesson’s idea into a marketing workflow: ${idea}`,
+  healthcare: (idea) =>
+    `A healthcare operations agent could check an approved staff rota before suggesting training times. It should not access clinical records because that information is unnecessary for the task. This keeps the example administrative and preserves the lesson’s mechanism: ${idea}`,
+  education: (idea) =>
+    `A teaching assistant agent could read the current lesson plan and approved class calendar before proposing a revision session. Its access can stay limited to those resources rather than all learner records. The same lesson idea still applies: ${idea}`,
+  technology: (idea) =>
+    `An engineering support agent could read a selected repository and issue queue to summarize a bug, while deployment credentials remain out of scope. The concrete setting changes, but the taught mechanism stays the same: ${idea}`,
+  finance: (idea) =>
+    `A finance operations agent could read an approved reporting sheet and calendar to prepare a review checklist, without access to unrelated customer accounts. The example preserves the source idea: ${idea}`,
+  creative: (idea) =>
+    `A creative production agent could read an approved brief and asset folder to prepare concepts, while publishing and client archives remain outside its scope. The example preserves the source idea: ${idea}`,
+  operations: (idea) =>
+    `An operations agent could check an approved schedule and inventory view before proposing the next action, without gaining access to unrelated systems. The example preserves the source idea: ${idea}`,
+};

--- a/apps/commons-courses/lib/learner-profile.ts
+++ b/apps/commons-courses/lib/learner-profile.ts
@@ -1,0 +1,111 @@
+import type {
+  LearnerDomain,
+  LearnerFormat,
+  LearnerGuidanceStyle,
+  LearnerProfileData,
+} from "@/types/learner-profile";
+import {
+  defaultLearnerProfile,
+  learnerDomains,
+  learnerFormats,
+  learnerGuidanceStyles,
+} from "@/types/learner-profile";
+
+const domainSet = new Set<string>(learnerDomains);
+const formatSet = new Set<string>(learnerFormats);
+const guidanceSet = new Set<string>(learnerGuidanceStyles);
+
+export function sanitizeLearnerProfile(
+  input: unknown,
+): Partial<LearnerProfileData> {
+  if (!input || typeof input !== "object") return {};
+  const value = input as Record<string, unknown>;
+  const output: Partial<LearnerProfileData> = {};
+
+  if (typeof value.personalizationEnabled === "boolean") {
+    output.personalizationEnabled = value.personalizationEnabled;
+  }
+  if (typeof value.onboardingCompleted === "boolean") {
+    output.onboardingCompleted = value.onboardingCompleted;
+  }
+  if (typeof value.allowUsageLearning === "boolean") {
+    output.allowUsageLearning = value.allowUsageLearning;
+  }
+
+  if (typeof value.roleOrContext === "string") {
+    output.roleOrContext = cleanText(value.roleOrContext, 120);
+  }
+  if (typeof value.customContext === "string") {
+    output.customContext = cleanText(value.customContext, 500);
+  }
+  if (typeof value.domain === "string" && domainSet.has(value.domain)) {
+    output.domain = value.domain as LearnerDomain;
+  }
+  if (
+    typeof value.guidanceStyle === "string" &&
+    guidanceSet.has(value.guidanceStyle)
+  ) {
+    output.guidanceStyle = value.guidanceStyle as LearnerGuidanceStyle;
+  }
+
+  if (Array.isArray(value.interests)) {
+    output.interests = cleanList(value.interests, 6, 80);
+  }
+  if (Array.isArray(value.goals)) {
+    output.goals = cleanList(value.goals, 4, 120);
+  }
+  if (Array.isArray(value.preferredFormats)) {
+    output.preferredFormats = Array.from(
+      new Set(
+        value.preferredFormats.filter(
+          (item): item is LearnerFormat =>
+            typeof item === "string" && formatSet.has(item),
+        ),
+      ),
+    ).slice(0, learnerFormats.length);
+  }
+
+  return output;
+}
+
+export function serializeLearnerProfile(
+  profile?: Partial<LearnerProfileData> | null,
+): LearnerProfileData {
+  return {
+    personalizationEnabled:
+      profile?.personalizationEnabled ??
+      defaultLearnerProfile.personalizationEnabled,
+    onboardingCompleted:
+      profile?.onboardingCompleted ?? defaultLearnerProfile.onboardingCompleted,
+    roleOrContext:
+      profile?.roleOrContext ?? defaultLearnerProfile.roleOrContext,
+    domain: profile?.domain ?? defaultLearnerProfile.domain,
+    interests: profile?.interests || [],
+    goals: profile?.goals || [],
+    preferredFormats:
+      profile?.preferredFormats || defaultLearnerProfile.preferredFormats,
+    guidanceStyle:
+      profile?.guidanceStyle ?? defaultLearnerProfile.guidanceStyle,
+    customContext:
+      profile?.customContext ?? defaultLearnerProfile.customContext,
+    allowUsageLearning:
+      profile?.allowUsageLearning ?? defaultLearnerProfile.allowUsageLearning,
+    usageSignals: profile?.usageSignals,
+    updatedAt: profile?.updatedAt,
+  };
+}
+
+function cleanText(value: string, maxLength: number) {
+  return value.replace(/\s+/g, " ").trim().slice(0, maxLength);
+}
+
+function cleanList(value: unknown[], limit: number, maxLength: number) {
+  return Array.from(
+    new Set(
+      value
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => cleanText(item, maxLength))
+        .filter(Boolean),
+    ),
+  ).slice(0, limit);
+}

--- a/apps/commons-courses/models/LearnerProfile.ts
+++ b/apps/commons-courses/models/LearnerProfile.ts
@@ -1,0 +1,78 @@
+import mongoose, { Document, Schema } from "mongoose";
+import type {
+  LearnerDomain,
+  LearnerFormat,
+  LearnerGuidanceStyle,
+} from "@/types/learner-profile";
+import {
+  learnerDomains,
+  learnerFormats,
+  learnerGuidanceStyles,
+} from "@/types/learner-profile";
+
+export interface ILearnerProfile extends Document {
+  userId: mongoose.Types.ObjectId;
+  personalizationEnabled: boolean;
+  onboardingCompleted: boolean;
+  roleOrContext: string;
+  domain?: LearnerDomain;
+  interests: string[];
+  goals: string[];
+  preferredFormats: LearnerFormat[];
+  guidanceStyle: LearnerGuidanceStyle;
+  customContext: string;
+  allowUsageLearning: boolean;
+  usageSignals: {
+    contextualExampleViews: number;
+    mindMapViews: number;
+    audioStarts: number;
+    helpfulMarks: number;
+  };
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const LearnerProfileSchema = new Schema<ILearnerProfile>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      unique: true,
+      index: true,
+    },
+    personalizationEnabled: { type: Boolean, default: false },
+    onboardingCompleted: { type: Boolean, default: false },
+    roleOrContext: { type: String, trim: true, maxlength: 120, default: "" },
+    domain: { type: String, enum: [...learnerDomains], default: undefined },
+    interests: {
+      type: [{ type: String, trim: true, maxlength: 80 }],
+      default: [],
+    },
+    goals: {
+      type: [{ type: String, trim: true, maxlength: 120 }],
+      default: [],
+    },
+    preferredFormats: {
+      type: [{ type: String, enum: [...learnerFormats] }],
+      default: ["examples", "mind_maps"],
+    },
+    guidanceStyle: {
+      type: String,
+      enum: [...learnerGuidanceStyles],
+      default: "coach_me",
+    },
+    customContext: { type: String, trim: true, maxlength: 500, default: "" },
+    allowUsageLearning: { type: Boolean, default: true },
+    usageSignals: {
+      contextualExampleViews: { type: Number, min: 0, default: 0 },
+      mindMapViews: { type: Number, min: 0, default: 0 },
+      audioStarts: { type: Number, min: 0, default: 0 },
+      helpfulMarks: { type: Number, min: 0, default: 0 },
+    },
+  },
+  { timestamps: true },
+);
+
+export default mongoose.models.LearnerProfile ||
+  mongoose.model<ILearnerProfile>("LearnerProfile", LearnerProfileSchema);

--- a/apps/commons-courses/types/learner-profile.ts
+++ b/apps/commons-courses/types/learner-profile.ts
@@ -1,0 +1,77 @@
+export const learnerDomains = [
+  "marketing",
+  "healthcare",
+  "education",
+  "technology",
+  "finance",
+  "creative",
+  "operations",
+  "other",
+] as const;
+
+export const learnerFormats = [
+  "examples",
+  "mind_maps",
+  "step_by_step",
+  "reflection",
+  "audio",
+] as const;
+
+export const learnerGuidanceStyles = [
+  "coach_me",
+  "show_then_practice",
+  "concise",
+] as const;
+
+export type LearnerDomain = (typeof learnerDomains)[number];
+export type LearnerFormat = (typeof learnerFormats)[number];
+export type LearnerGuidanceStyle = (typeof learnerGuidanceStyles)[number];
+
+export type LearnerProfileData = {
+  personalizationEnabled: boolean;
+  onboardingCompleted: boolean;
+  roleOrContext: string;
+  domain: LearnerDomain | "";
+  interests: string[];
+  goals: string[];
+  preferredFormats: LearnerFormat[];
+  guidanceStyle: LearnerGuidanceStyle;
+  customContext: string;
+  allowUsageLearning: boolean;
+  usageSignals?: {
+    contextualExampleViews: number;
+    mindMapViews: number;
+    audioStarts: number;
+    helpfulMarks: number;
+  };
+  updatedAt?: string;
+};
+
+export const defaultLearnerProfile: LearnerProfileData = {
+  personalizationEnabled: false,
+  onboardingCompleted: false,
+  roleOrContext: "",
+  domain: "",
+  interests: [],
+  goals: [],
+  preferredFormats: ["examples", "mind_maps"],
+  guidanceStyle: "coach_me",
+  customContext: "",
+  allowUsageLearning: true,
+};
+
+export type MindMapNode = {
+  id: string;
+  label: string;
+  detail?: string;
+  children?: MindMapNode[];
+};
+
+export type ContextualLearningView = {
+  title: string;
+  bridge: string;
+  example: string;
+  connection: string;
+  tryIt: string;
+  fidelityNote: string;
+};


### PR DESCRIPTION
## What changed

- adds an opt-in learner profile for role, field, goals, interests, format preferences, and coaching style
- adds contextual examples, generated mind maps, and read-aloud learning views to course lessons and skill packs
- upgrades the learner copilot to guide through retrieval, hints, practice, and next-step navigation
- records consent-based learning-view signals while keeping educator-authored content canonical
- adds signed-out fallbacks and account-level preference controls

## Why

Learners need multiple ways to engage with course material and examples that connect to familiar contexts without changing the educator's intended message. The learner copilot should support learning and navigation rather than simply produce answers.

## Impact

Learners can opt into personalization, generate additional learning views, and receive pedagogically guided help throughout CommonLab. Educator content remains visible and explicitly identified as the source of truth.

## Validation

- `pnpm exec tsc --noEmit`
- targeted ESLint across all changed course files
- `pnpm build` for `apps/commons-courses`
- signed-out API and public skill-path UI checks
- headless visual review of the skill lesson surface
