### PR TITLE
List all user sessions by default in CLI

### DIFF
--- a/packages/agc-cli/dist/bin.js
+++ b/packages/agc-cli/dist/bin.js
@@ -887,7 +887,7 @@ function sessionsCommand() {
     const spinner = spin("Fetching sessions\u2026");
     try {
       const client = makeClient();
-      const agentId2 = opts.agent ?? cfg.defaultAgentId;
+      const agentId2 = opts.agent;
       const res = agentId2 ? await client.sessions.list(agentId2, cfg.initiator) : await client.sessions.listByUser(cfg.initiator);
       const sessions = res?.data ?? res ?? [];
       spinner.stop();

--- a/packages/agc-cli/src/commands/sessions.ts
+++ b/packages/agc-cli/src/commands/sessions.ts
@@ -20,7 +20,10 @@ export function sessionsCommand(): Command {
       const spinner = spin('Fetching sessions…');
       try {
         const client = makeClient();
-        const agentId = opts.agent ?? cfg.defaultAgentId;
+        // Listing without --agent must include every session owned by the
+        // current user. Falling back to defaultAgentId silently hid sessions
+        // belonging to every other agent.
+        const agentId = opts.agent;
         const res = agentId
           ? await client.sessions.list(agentId, cfg.initiator)
           : await client.sessions.listByUser(cfg.initiator);


### PR DESCRIPTION
## Summary
- stop silently filtering `agc sessions list` to the configured default agent
- preserve explicit `--agent` filtering
- rebuild the checked-in CLI bundle

## Verification
- `pnpm --filter ./packages/agc-cli build`
- live staging: unfiltered list contains the newly created multi-turn session
- live staging: explicit agent-filtered list contains the same session
- live staging: full session reload contains both user/assistant turns