### PR TITLE
Promote session fetching and history fixes

### DIFF
--- a/apps/commons-api/migrations/versioned/018_session_fetch_indexes.sql
+++ b/apps/commons-api/migrations/versioned/018_session_fetch_indexes.sql
@@ -1,0 +1,8 @@
+-- Session sidebars and dashboards filter by owner and sort by recent activity.
+-- Keep these covering prefixes aligned with SessionService list queries so the
+-- API never has to scan or sort the JSONB history payloads.
+CREATE INDEX IF NOT EXISTS idx_session_initiator_updated
+  ON session (initiator, updated_at DESC, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_session_agent_initiator_updated
+  ON session (agent_id, initiator, updated_at DESC, created_at DESC);

--- a/apps/commons-api/models/schema.ts
+++ b/apps/commons-api/models/schema.ts
@@ -506,77 +506,99 @@ export const agentComputerEvent = pgTable(
 
 /* ─────────────────────────  SESSION  ───────────────────────── */
 
-export const session = pgTable('session', {
-  sessionId: uuid('session_id')
-    .default(sql`uuid_generate_v4()`)
-    .primaryKey(),
+export const session = pgTable(
+  'session',
+  {
+    sessionId: uuid('session_id')
+      .default(sql`uuid_generate_v4()`)
+      .primaryKey(),
 
-  agentId: text('agent_id').notNull(),
+    agentId: text('agent_id').notNull(),
 
-  title: text('title'),
-  initiator: text('initiator'), // wallet address of user or agent
+    title: text('title'),
+    initiator: text('initiator'), // wallet address of user or agent
 
-  model: jsonb('model').$type<{
-    name?: string; // Legacy field - keep for backward compat
-    provider?: string; // 'openai' | 'anthropic' | 'google' | 'mistral' | 'groq' | 'ollama'
-    modelId?: string; // e.g. 'claude-sonnet-4-6', 'gpt-4o'
-    apiKey?: string; // BYOK — encrypted at rest
-    baseUrl?: string; // For custom endpoints
-    temperature?: number;
-    maxTokens?: number;
-    topP?: number;
-    presencePenalty?: number;
-    frequencyPenalty?: number;
-    reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
-    verbosity?: 'low' | 'medium' | 'high';
-  }>(),
+    model: jsonb('model').$type<{
+      name?: string; // Legacy field - keep for backward compat
+      provider?: string; // 'openai' | 'anthropic' | 'google' | 'mistral' | 'groq' | 'ollama'
+      modelId?: string; // e.g. 'claude-sonnet-4-6', 'gpt-4o'
+      apiKey?: string; // BYOK — encrypted at rest
+      baseUrl?: string; // For custom endpoints
+      temperature?: number;
+      maxTokens?: number;
+      topP?: number;
+      presencePenalty?: number;
+      frequencyPenalty?: number;
+      reasoningEffort?:
+        | 'none'
+        | 'minimal'
+        | 'low'
+        | 'medium'
+        | 'high'
+        | 'xhigh';
+      verbosity?: 'low' | 'medium' | 'high';
+    }>(),
 
-  query: jsonb('query').$type<{
-    text: string;
-    timestamp: string;
-    metadata?: Record<string, any>;
-  }>(),
-
-  history: jsonb('history').$type<
-    Array<{
-      role: string;
-      content: string;
+    query: jsonb('query').$type<{
+      text: string;
       timestamp: string;
       metadata?: Record<string, any>;
-    }>
-  >(),
+    }>(),
 
-  metrics: jsonb('metrics').$type<{
-    totalTokens?: number;
-    responseTime?: number;
-    toolCalls?: number;
-    errorCount?: number;
-  }>(),
+    history: jsonb('history').$type<
+      Array<{
+        role: string;
+        content: string;
+        timestamp: string;
+        metadata?: Record<string, any>;
+      }>
+    >(),
 
-  endedAt: timestamp('ended_at', { withTimezone: true }),
+    metrics: jsonb('metrics').$type<{
+      totalTokens?: number;
+      responseTime?: number;
+      toolCalls?: number;
+      errorCount?: number;
+    }>(),
 
-  // 'web' | 'cli' — where this session was initiated from.
-  // Column already exists in DB (phase14 migration); default is 'web'.
-  initiatorType: text('initiator_type').default('web'),
+    endedAt: timestamp('ended_at', { withTimezone: true }),
 
-  // Canonical session identity remains in Agent Commons. Runtime-specific
-  // session handles are optional adapter metadata and never replace it.
-  runtimeType: text('runtime_type').default('native').notNull(),
-  runtimeSessionId: text('runtime_session_id'),
+    // 'web' | 'cli' — where this session was initiated from.
+    // Column already exists in DB (phase14 migration); default is 'web'.
+    initiatorType: text('initiator_type').default('web'),
 
-  // Keep as JSON list of space IDs for now (not relational)
-  spaces: jsonb('spaces').$type<{ spaceIds: string[] }>(),
+    // Canonical session identity remains in Agent Commons. Runtime-specific
+    // session handles are optional adapter metadata and never replace it.
+    runtimeType: text('runtime_type').default('native').notNull(),
+    runtimeSessionId: text('runtime_session_id'),
 
-  // Make this a UUID so we can reference session.sessionId
-  parentSessionId: uuid('parent_session'),
+    // Keep as JSON list of space IDs for now (not relational)
+    spaces: jsonb('spaces').$type<{ spaceIds: string[] }>(),
 
-  createdAt: timestamp('created_at', { withTimezone: true })
-    .default(sql`timezone('utc', now())`)
-    .notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: true })
-    .default(sql`timezone('utc', now())`)
-    .notNull(),
-});
+    // Make this a UUID so we can reference session.sessionId
+    parentSessionId: uuid('parent_session'),
+
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .default(sql`timezone('utc', now())`)
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .default(sql`timezone('utc', now())`)
+      .notNull(),
+  },
+  (table) => ({
+    initiatorUpdatedIdx: index('idx_session_initiator_updated').on(
+      table.initiator,
+      table.updatedAt,
+      table.createdAt,
+    ),
+    agentInitiatorUpdatedIdx: index('idx_session_agent_initiator_updated').on(
+      table.agentId,
+      table.initiator,
+      table.updatedAt,
+      table.createdAt,
+    ),
+  }),
+);
 
 /* ─────────────────────────  ARTIFACT LIBRARY  ───────────────────────── */
 

--- a/apps/commons-api/src/agent/agent.service.ts
+++ b/apps/commons-api/src/agent/agent.service.ts
@@ -75,6 +75,7 @@ import {
   CopilotUiContext,
 } from './copilot-platform-guide';
 import { SkillService } from '~/skill/skill.service';
+import { durableRole, restoreSessionMessages } from '~/session/session-history';
 
 const got = import('got');
 
@@ -1987,33 +1988,12 @@ export class AgentService implements OnModuleInit {
             } as any);
             emitStatus('context', 'completed', 'Conversation context ready');
 
-            if (
-              currentSession?.history &&
-              Array.isArray(currentSession.history)
-            ) {
-              // Load user and assistant messages only — skip system messages since we inject fresh persona above
-              const validHistoryMessages = currentSession.history.filter(
-                (entry: any) =>
-                  entry.role === 'user' || entry.role === 'assistant',
-              );
-              messages.push(
-                ...validHistoryMessages.map((historyEntry: any) => {
-                  let content = historyEntry.content ?? '';
-                  if (typeof content === 'string' && content.startsWith('[')) {
-                    try {
-                      content = JSON.parse(content);
-                    } catch {
-                      // keep as string if parse fails
-                    }
-                  }
-                  return {
-                    type: historyEntry.role,
-                    role: historyEntry.role,
-                    content,
-                  };
-                }),
-              );
-            }
+            // Durable history is the cross-run source of truth. LangChain
+            // persists these roles as human/ai, so normalize them back to
+            // user/assistant before invoking the isolated run checkpoint.
+            messages.push(
+              ...(restoreSessionMessages(currentSession?.history) as any[]),
+            );
           }
 
           if (spaceId) {
@@ -2481,7 +2461,15 @@ export class AgentService implements OnModuleInit {
             // metadata. Prior entries align as an in-order prefix because both
             // saves serialize the same thread through the same pipeline.
             const previousEntries = existingHistory.filter(
-              (entry: any) => entry.metadata?.source !== 'agent_speech',
+              (entry: any) =>
+                durableRole(entry.role) !== null &&
+                !(
+                  durableRole(entry.role) === 'ai' &&
+                  (entry.content === null ||
+                    entry.content === undefined ||
+                    (typeof entry.content === 'string' &&
+                      !entry.content.trim()))
+                ),
             );
             let previousIndex = 0;
 
@@ -2490,42 +2478,44 @@ export class AgentService implements OnModuleInit {
             const lastHumanIndex = entryRoles.lastIndexOf('human');
 
             // Create new history entries from the current agent run
-            const newHistoryEntries = messageHistories.map((m, index) => {
-              const role = entryRoles[index];
-              const rawContent = this.serializeHistoryContent(m.content);
-              const content = this.stripAttachmentManifest(rawContent);
-              const isCurrentAttachmentTurn =
-                index === lastHumanIndex &&
-                Boolean(attachmentContext?.attachments?.length) &&
-                rawContent.includes('## Uploaded Files');
+            const newHistoryEntries = messageHistories
+              .map((m, index) => {
+                const role = entryRoles[index];
+                const rawContent = this.serializeHistoryContent(m.content);
+                const content = this.stripAttachmentManifest(rawContent);
+                const isCurrentAttachmentTurn =
+                  index === lastHumanIndex &&
+                  Boolean(attachmentContext?.attachments?.length) &&
+                  rawContent.includes('## Uploaded Files');
 
-              const previous = previousEntries[previousIndex];
-              const inherited =
-                previous &&
-                previous.role === role &&
-                previous.content === content
-                  ? ((previousIndex += 1), previous)
-                  : undefined;
+                const previous = previousEntries[previousIndex];
+                const inherited =
+                  previous &&
+                  durableRole(previous.role) === durableRole(role) &&
+                  previous.content === content
+                    ? ((previousIndex += 1), previous)
+                    : undefined;
 
-              const fresh: Record<string, any> = {};
-              if (index === lastAiIndex) {
-                if (toolCalls.length) fresh.toolCalls = toolCalls;
-                if (resolvedAgentCalls.length)
-                  fresh.agentCalls = resolvedAgentCalls;
-                fresh.durationMs = runDurationMs;
-              }
-              if (isCurrentAttachmentTurn)
-                fresh.attachments = attachmentContext?.attachments;
-              if (index === lastHumanIndex && computerRequest)
-                fresh.computerRequest = computerRequest;
+                const fresh: Record<string, any> = {};
+                if (index === lastAiIndex) {
+                  if (toolCalls.length) fresh.toolCalls = toolCalls;
+                  if (resolvedAgentCalls.length)
+                    fresh.agentCalls = resolvedAgentCalls;
+                  fresh.durationMs = runDurationMs;
+                }
+                if (isCurrentAttachmentTurn)
+                  fresh.attachments = attachmentContext?.attachments;
+                if (index === lastHumanIndex && computerRequest)
+                  fresh.computerRequest = computerRequest;
 
-              return {
-                role,
-                content,
-                timestamp: inherited?.timestamp ?? new Date().toISOString(),
-                metadata: { ...(inherited?.metadata ?? {}), ...fresh },
-              };
-            });
+                return {
+                  role,
+                  content,
+                  timestamp: inherited?.timestamp ?? new Date().toISOString(),
+                  metadata: { ...(inherited?.metadata ?? {}), ...fresh },
+                };
+              })
+              .filter((entry) => entry.metadata?.source !== 'agent_speech');
 
             // Merge and sort by timestamp to maintain chronological order
             const mergedHistory = [

--- a/apps/commons-api/src/session/session-history.spec.ts
+++ b/apps/commons-api/src/session/session-history.spec.ts
@@ -1,0 +1,43 @@
+import { restoreSessionMessages } from './session-history';
+
+describe('restoreSessionMessages', () => {
+  it('restores every turn persisted with LangChain human/ai roles', () => {
+    const restored = restoreSessionMessages([
+      { role: 'human', content: 'first question' },
+      { role: 'ai', content: 'first answer' },
+      { role: 'human', content: 'follow-up question' },
+      { role: 'ai', content: 'follow-up answer' },
+    ]);
+
+    expect(restored).toEqual([
+      { type: 'user', role: 'user', content: 'first question' },
+      { type: 'assistant', role: 'assistant', content: 'first answer' },
+      { type: 'user', role: 'user', content: 'follow-up question' },
+      { type: 'assistant', role: 'assistant', content: 'follow-up answer' },
+    ]);
+  });
+
+  it('supports legacy roles and structured content without restoring tools', () => {
+    expect(
+      restoreSessionMessages([
+        { role: 'system', content: 'stale system prompt' },
+        { role: 'user', content: '[{"type":"text","text":"hello"}]' },
+        { role: 'ai', content: '' },
+        { role: 'tool', content: 'expired signed URL' },
+        { role: 'assistant', content: 'hello back' },
+      ]),
+    ).toEqual([
+      {
+        type: 'user',
+        role: 'user',
+        content: [{ type: 'text', text: 'hello' }],
+      },
+      { type: 'assistant', role: 'assistant', content: 'hello back' },
+    ]);
+  });
+
+  it('returns an empty list for malformed history', () => {
+    expect(restoreSessionMessages(null)).toEqual([]);
+    expect(restoreSessionMessages({ role: 'human' })).toEqual([]);
+  });
+});

--- a/apps/commons-api/src/session/session-history.ts
+++ b/apps/commons-api/src/session/session-history.ts
@@ -1,0 +1,72 @@
+type DurableHistoryEntry = {
+  role?: unknown;
+  content?: unknown;
+};
+
+export type RestoredSessionMessage = {
+  type: 'user' | 'assistant';
+  role: 'user' | 'assistant';
+  content: unknown;
+};
+
+function modelRole(role: unknown): RestoredSessionMessage['role'] | null {
+  if (role === 'human' || role === 'user') return 'user';
+  if (role === 'ai' || role === 'assistant') return 'assistant';
+  return null;
+}
+
+export function durableRole(role: unknown): 'human' | 'ai' | null {
+  const normalized = modelRole(role);
+  if (normalized === 'user') return 'human';
+  if (normalized === 'assistant') return 'ai';
+  return null;
+}
+
+function restoreContent(content: unknown) {
+  if (typeof content !== 'string' || !content.startsWith('[')) {
+    return content ?? '';
+  }
+
+  try {
+    return JSON.parse(content);
+  } catch {
+    return content;
+  }
+}
+
+/**
+ * Convert durable session history back into model input.
+ *
+ * LangChain serializes user/assistant messages as `human`/`ai`, while older
+ * records and external runtimes can contain `user`/`assistant`. Accept both
+ * families and emit the OpenAI-style roles understood by MessagesAnnotation.
+ * Tool and system entries stay excluded because each run injects a fresh
+ * system prompt and tool results can contain expired signed URLs.
+ */
+export function restoreSessionMessages(
+  history: unknown,
+): RestoredSessionMessage[] {
+  if (!Array.isArray(history)) return [];
+
+  return history.flatMap((candidate) => {
+    if (!candidate || typeof candidate !== 'object') return [];
+    const entry = candidate as DurableHistoryEntry;
+    const role = modelRole(entry.role);
+    if (!role) return [];
+    if (
+      role === 'assistant' &&
+      (entry.content === null ||
+        entry.content === undefined ||
+        (typeof entry.content === 'string' && !entry.content.trim()))
+    ) {
+      return [];
+    }
+    return [
+      {
+        type: role,
+        role,
+        content: restoreContent(entry.content),
+      },
+    ];
+  });
+}

--- a/apps/commons-api/src/session/session.service.ts
+++ b/apps/commons-api/src/session/session.service.ts
@@ -5,13 +5,30 @@ import {
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
-import { and, eq, InferInsertModel, InferSelectModel, sql, desc } from 'drizzle-orm';
+import {
+  and,
+  eq,
+  InferInsertModel,
+  InferSelectModel,
+  sql,
+  desc,
+} from 'drizzle-orm';
 import { DatabaseService } from '~/modules/database/database.service';
 import * as schema from '#/models/schema';
 import { first } from 'lodash';
 import { inArray } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import { EncryptionService } from '~/modules/encryption';
+
+const sessionSummaryColumns = {
+  sessionId: true,
+  title: true,
+  initiator: true,
+  initiatorType: true,
+  agentId: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
 
 @Injectable()
 export class SessionService {
@@ -20,18 +37,30 @@ export class SessionService {
     private encryption: EncryptionService,
   ) {}
 
-  private encryptModelApiKey(model: Record<string, any> | null | undefined): Record<string, any> | null | undefined {
+  private encryptModelApiKey(
+    model: Record<string, any> | null | undefined,
+  ): Record<string, any> | null | undefined {
     if (!model?.apiKey) return model;
     const { encryptedValue, iv, tag } = this.encryption.encrypt(model.apiKey);
     return { ...model, apiKey: `enc:${iv}:${tag}:${encryptedValue}` };
   }
 
-  static decryptModelApiKey(model: Record<string, any> | null | undefined, encryption: EncryptionService): Record<string, any> | null | undefined {
+  static decryptModelApiKey(
+    model: Record<string, any> | null | undefined,
+    encryption: EncryptionService,
+  ): Record<string, any> | null | undefined {
     if (!model?.apiKey) return model;
     const stored: string = model.apiKey;
     if (!stored.startsWith('enc:')) return model; // plaintext (legacy)
     const [, iv, tag, encryptedValue] = stored.split(':');
     return { ...model, apiKey: encryption.decrypt(encryptedValue, iv, tag) };
+  }
+
+  private publicModel(model: Record<string, any> | null | undefined) {
+    if (!model?.apiKey) return model ?? {};
+    const safeModel = { ...model };
+    delete safeModel.apiKey;
+    return safeModel;
   }
 
   public async createSession(props: {
@@ -90,7 +119,9 @@ export class SessionService {
         sessionId: uuidv4(),
         agentId,
         initiator: initiator ?? `space:${spaceId}`,
-        model: this.encryptModelApiKey(model as any) ?? ({ name: 'gpt-5.4-mini' } as any),
+        model:
+          this.encryptModelApiKey(model as any) ??
+          ({ name: 'gpt-5.4-mini' } as any),
         spaces: { spaceIds: [spaceId] },
         parentSessionId: parentSessionId ?? undefined,
         title: title ?? null,
@@ -111,7 +142,8 @@ export class SessionService {
     //search for sessions where parentSessionId matches the sessionId and return them as child sessions
     const childSessions = await this.db.query.session.findMany({
       where: (t) => eq(t.parentSessionId, props.id),
-      orderBy: (t) => t.createdAt,
+      columns: sessionSummaryColumns,
+      orderBy: (t) => [desc(t.updatedAt), desc(t.createdAt)],
     });
     //return session with child sessions as an array
     const sessionData = {
@@ -125,7 +157,8 @@ export class SessionService {
   public async getSessionsByAgentId(agentId: string) {
     const sessions = await this.db.query.session.findMany({
       where: (t) => eq(t.agentId, agentId),
-      orderBy: (t) => t.createdAt,
+      columns: sessionSummaryColumns,
+      orderBy: (t) => [desc(t.updatedAt), desc(t.createdAt)],
     });
     return sessions;
   }
@@ -146,7 +179,7 @@ export class SessionService {
       ...sessionEntry,
       history: sessionEntry.history || [],
       metrics: sessionEntry.metrics || {},
-      model: sessionEntry.model || {},
+      model: this.publicModel(sessionEntry.model),
       query: sessionEntry.query || {},
     };
   }
@@ -162,37 +195,33 @@ export class SessionService {
       throw new NotFoundException(`Session with ID ${id} not found`);
     }
 
-    // Get all tasks for this session (goals are deprecated)
-    const tasks = await this.db.query.task.findMany({
-      where: (t) => eq(t.sessionId, id),
-      orderBy: (t) => t.createdAt,
-    });
-
-    //search for sessions where parentSessionId matches the sessionId and return them as child sessions
-    const childSessions = await this.db.query.session.findMany({
-      where: (t) => eq(t.parentSessionId, props.id),
-      orderBy: (t) => t.createdAt,
-    });
-
-    // Get space details if spaces column contains space IDs
-    let spaceDetails: any = [];
-    if (sessionEntry.spaces && Array.isArray((sessionEntry.spaces as any).spaceIds) && (sessionEntry.spaces as any).spaceIds.length > 0) {
-      console.log(
-        `Fetching spaces for session ${id} with space IDs:`,
-        sessionEntry.spaces.spaceIds,
-      );
-      spaceDetails = await this.db.query.space.findMany({
-        where: (s) => inArray(s.spaceId, sessionEntry.spaces!.spaceIds),
-      });
-    }
-    console.log('Space details:', spaceDetails);
+    const spaceIds = Array.isArray(sessionEntry.spaces?.spaceIds)
+      ? sessionEntry.spaces.spaceIds
+      : [];
+    const [tasks, childSessions, spaceDetails] = await Promise.all([
+      // Goals are deprecated; tasks remain a flat session-level list.
+      this.db.query.task.findMany({
+        where: (t) => eq(t.sessionId, id),
+        orderBy: (t) => t.createdAt,
+      }),
+      this.db.query.session.findMany({
+        where: (t) => eq(t.parentSessionId, props.id),
+        columns: sessionSummaryColumns,
+        orderBy: (t) => [desc(t.updatedAt), desc(t.createdAt)],
+      }),
+      spaceIds.length
+        ? this.db.query.space.findMany({
+            where: (s) => inArray(s.spaceId, spaceIds),
+          })
+        : Promise.resolve([]),
+    ]);
 
     // Return history as is, without modifying the roles
     return {
       ...sessionEntry,
       history: sessionEntry.history || [],
       metrics: sessionEntry.metrics || {},
-      model: sessionEntry.model || {},
+      model: this.publicModel(sessionEntry.model),
       query: sessionEntry.query || {},
       tasks: tasks || [], // Return tasks as flat array (goals are deprecated)
       childSessions: childSessions || [],
@@ -205,9 +234,13 @@ export class SessionService {
     delta: Partial<InferInsertModel<typeof schema.session>>;
   }) {
     const { id, delta } = props;
-    const encrypted = delta.model !== undefined
-      ? { ...delta, model: this.encryptModelApiKey(delta.model as any) as any }
-      : delta;
+    const encrypted =
+      delta.model !== undefined
+        ? {
+            ...delta,
+            model: this.encryptModelApiKey(delta.model as any) as any,
+          }
+        : delta;
     const sessionEntry = await this.db
       .update(schema.session)
       .set(encrypted)
@@ -225,8 +258,17 @@ export class SessionService {
       .update(schema.session)
       .set({ title, updatedAt: new Date() })
       .where(eq(schema.session.sessionId, id))
-      .returning();
-    if (!updated) throw new NotFoundException(`Session with ID ${id} not found`);
+      .returning({
+        sessionId: schema.session.sessionId,
+        title: schema.session.title,
+        initiator: schema.session.initiator,
+        initiatorType: schema.session.initiatorType,
+        agentId: schema.session.agentId,
+        createdAt: schema.session.createdAt,
+        updatedAt: schema.session.updatedAt,
+      });
+    if (!updated)
+      throw new NotFoundException(`Session with ID ${id} not found`);
     return updated;
   }
 
@@ -244,7 +286,8 @@ export class SessionService {
       .delete(schema.session)
       .where(eq(schema.session.sessionId, id))
       .returning({ sessionId: schema.session.sessionId });
-    if (!deleted) throw new NotFoundException(`Session with ID ${id} not found`);
+    if (!deleted)
+      throw new NotFoundException(`Session with ID ${id} not found`);
     return deleted;
   }
 
@@ -278,14 +321,9 @@ export class SessionService {
     const sessions = await this.db.query.session.findMany({
       where: (s) => eq(s.initiator, initiator),
       columns: {
-        sessionId: true,
-        title: true,
-        initiator: true,
-        agentId: true,
-        createdAt: true,
-        updatedAt: true,
+        ...sessionSummaryColumns,
       },
-      orderBy: (s) => desc(s.createdAt),
+      orderBy: (s) => [desc(s.updatedAt), desc(s.createdAt)],
     });
     return sessions;
   }
@@ -299,14 +337,9 @@ export class SessionService {
     const sessions = await this.db.query.session.findMany({
       where: (s) => and(eq(s.agentId, agentId), eq(s.initiator, initiator)),
       columns: {
-        sessionId: true,
-        title: true,
-        initiator: true,
-        agentId: true,
-        createdAt: true,
-        updatedAt: true,
+        ...sessionSummaryColumns,
       },
-      orderBy: (s) => desc(s.createdAt),
+      orderBy: (s) => [desc(s.updatedAt), desc(s.createdAt)],
     });
     return sessions;
   }

--- a/apps/commons-app/app/sessions/page.tsx
+++ b/apps/commons-app/app/sessions/page.tsx
@@ -14,21 +14,28 @@ import { normalizePrincipalId } from "@/lib/principal-id";
 export default function SessionsPage() {
   const { authState } = useAuth();
   const userAddress = normalizePrincipalId(authState.walletAddress);
-  const { sessions, setSessions, isLoading } = useUserSessions(userAddress);
+  const { sessions, setSessions, isLoading, error, refetch } =
+    useUserSessions(userAddress);
   const { renameSession, deleteSession } = useSessionMutations();
   const [filter, setFilter] = useState<"all" | "cli" | "web">("all");
 
   const filtered = useMemo(() => {
     let list = sessions;
-    if (filter === "cli") list = list.filter((s) => s.initiatorType === "cli" || s.source === "cli");
-    if (filter === "web") list = list.filter((s) => s.initiatorType !== "cli" && s.source !== "cli");
+    if (filter === "cli")
+      list = list.filter(
+        (s) => s.initiatorType === "cli" || s.source === "cli",
+      );
+    if (filter === "web")
+      list = list.filter(
+        (s) => s.initiatorType !== "cli" && s.source !== "cli",
+      );
     return list;
   }, [sessions, filter]);
 
   const handleRename = async (sessionId: string, title: string) => {
     const prev = sessions;
     setSessions((list) =>
-      list.map((s) => (s.sessionId === sessionId ? { ...s, title } : s))
+      list.map((s) => (s.sessionId === sessionId ? { ...s, title } : s)),
     );
     const ok = await renameSession(sessionId, title);
     if (!ok) setSessions(prev);
@@ -72,13 +79,17 @@ export default function SessionsPage() {
                   "flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
                   filter === f
                     ? "bg-foreground text-background"
-                    : "bg-muted text-muted-foreground hover:text-foreground"
+                    : "bg-muted text-muted-foreground hover:text-foreground",
                 )}
               >
                 {f === "cli" && <Terminal className="h-3 w-3" />}
                 {f === "web" && <Globe className="h-3 w-3" />}
                 {f === "all" && <MessageSquare className="h-3 w-3" />}
-                {f === "all" ? "All sessions" : f === "cli" ? "CLI runs" : "Web sessions"}
+                {f === "all"
+                  ? "All sessions"
+                  : f === "cli"
+                    ? "CLI runs"
+                    : "Web sessions"}
                 {f === "all" && !isLoading && (
                   <span className="ml-0.5 opacity-60">({sessions.length})</span>
                 )}
@@ -92,14 +103,29 @@ export default function SessionsPage() {
               <div className="flex items-center justify-center h-40">
                 <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
               </div>
+            ) : error ? (
+              <div className="flex h-40 flex-col items-center justify-center gap-3">
+                <p className="text-sm text-destructive">
+                  Sessions could not be loaded
+                </p>
+                <button
+                  type="button"
+                  className="rounded-md border border-border px-3 py-1.5 text-xs font-medium hover:bg-muted"
+                  onClick={refetch}
+                >
+                  Try again
+                </button>
+              </div>
             ) : filtered.length === 0 ? (
               <div className="flex flex-col items-center justify-center h-40 gap-3">
                 <MessageSquare className="h-8 w-8 text-muted-foreground/30" />
                 <p className="text-sm text-muted-foreground">No sessions yet</p>
                 <p className="text-xs text-muted-foreground/60">
                   Start a conversation with an agent or run{" "}
-                  <code className="bg-muted px-1 py-0.5 rounded text-[11px]">agc chat</code> in
-                  the terminal
+                  <code className="bg-muted px-1 py-0.5 rounded text-[11px]">
+                    agc chat
+                  </code>{" "}
+                  in the terminal
                 </p>
               </div>
             ) : (

--- a/apps/commons-app/components/layout/dashboard-side-bar.tsx
+++ b/apps/commons-app/components/layout/dashboard-side-bar.tsx
@@ -30,7 +30,8 @@ export function DashboardSideBar({ username }: { username: string }) {
   const pathname = usePathname();
   const router = useRouter();
 
-  const { sessions, setSessions, isLoading } = useUserSessions(username);
+  const { sessions, setSessions, isLoading, error, refetch } =
+    useUserSessions(username);
   const { renameSession, deleteSession } = useSessionMutations();
 
   const isLockedDetailRoute = useMemo(() => {
@@ -210,6 +211,14 @@ export function DashboardSideBar({ username }: { username: string }) {
                   />
                 ))}
               </div>
+            ) : error ? (
+              <button
+                type="button"
+                className="mx-2 my-3 rounded-md border border-border px-3 py-2 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+                onClick={refetch}
+              >
+                Retry sessions
+              </button>
             ) : (
               <SessionsList
                 sessions={sessions}

--- a/apps/commons-app/hooks/sessions/use-user-sessions.ts
+++ b/apps/commons-app/hooks/sessions/use-user-sessions.ts
@@ -2,41 +2,82 @@
 
 import { useState, useEffect, useCallback } from "react";
 
+const SESSION_LIST_CACHE_MS = 2_000;
+const sessionListCache = new Map<
+  string,
+  { sessions: any[]; expiresAt: number }
+>();
+const sessionListRequests = new Map<string, Promise<any[]>>();
+
+async function requestUserSessions(userAddress: string, force = false) {
+  const key = userAddress.toLowerCase();
+  const cached = sessionListCache.get(key);
+  if (!force && cached && cached.expiresAt > Date.now()) {
+    return cached.sessions;
+  }
+
+  const pending = sessionListRequests.get(key);
+  if (pending) return pending;
+
+  const request = (async () => {
+    const res = await fetch(
+      `/api/sessions/user?initiatorId=${encodeURIComponent(userAddress)}`,
+    );
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new Error(formatSessionFetchError(res.status, data));
+    }
+    const sessions = Array.isArray(data?.data) ? data.data : [];
+    sessionListCache.set(key, {
+      sessions,
+      expiresAt: Date.now() + SESSION_LIST_CACHE_MS,
+    });
+    return sessions;
+  })().finally(() => {
+    sessionListRequests.delete(key);
+  });
+
+  sessionListRequests.set(key, request);
+  return request;
+}
+
 export function useUserSessions(userAddress: string) {
   const [sessions, setSessions] = useState<any[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [loadedUser, setLoadedUser] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
-  const fetchSessions = useCallback(async () => {
-    if (!userAddress) return;
-    setIsLoading(true);
-    try {
-      const res = await fetch(
-        `/api/sessions/user?initiatorId=${encodeURIComponent(userAddress)}`
-      );
-      const data = await res.json();
-      if (!res.ok) {
-        throw new Error(formatSessionFetchError(res.status, data));
+  const fetchSessions = useCallback(
+    async (force = false) => {
+      if (!userAddress) return;
+      setIsLoading(true);
+      setError(null);
+      try {
+        setSessions(await requestUserSessions(userAddress, force));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unknown error");
+        console.error("Error fetching user sessions:", err);
+      } finally {
+        setLoadedUser(userAddress);
+        setIsLoading(false);
       }
-      setSessions(data.data || []);
-    } catch (err) {
-      console.error("Error fetching user sessions:", err);
-    } finally {
-      setLoadedUser(userAddress);
-      setIsLoading(false);
-    }
-  }, [userAddress]);
+    },
+    [userAddress],
+  );
 
   useEffect(() => {
     fetchSessions();
   }, [fetchSessions]);
+
+  const refetch = useCallback(() => fetchSessions(true), [fetchSessions]);
 
   return {
     sessions,
     setSessions,
     isLoading:
       Boolean(userAddress) && (isLoading || loadedUser !== userAddress),
-    refetch: fetchSessions,
+    error,
+    refetch,
   };
 }
 

--- a/apps/commons-app/lib/session-history.ts
+++ b/apps/commons-app/lib/session-history.ts
@@ -48,35 +48,41 @@ export function normalizeSessionHistory(history: unknown): HistoryEntry[] {
   for (const raw of history) {
     const entry = raw as HistoryEntry;
     if (!entry || typeof entry !== "object") continue;
-    const role = entry.role;
+    const role = entry.role === "assistant" ? "ai" : entry.role;
+    const normalizedEntry = role === entry.role ? entry : { ...entry, role };
 
     if (role === "tool") {
-      pendingTools.push(entry);
+      pendingTools.push(normalizedEntry);
       continue;
     }
 
-    if (role === "ai" || role === "assistant") {
+    if (role === "ai") {
       const hasContent =
-        typeof entry.content === "string"
-          ? entry.content.trim().length > 0
-          : Boolean(entry.content);
+        typeof normalizedEntry.content === "string"
+          ? normalizedEntry.content.trim().length > 0
+          : Boolean(normalizedEntry.content);
       const hasRunMetadata = Boolean(
-        entry.metadata?.toolCalls?.length || entry.metadata?.agentCalls?.length,
+        normalizedEntry.metadata?.toolCalls?.length ||
+          normalizedEntry.metadata?.agentCalls?.length,
       );
       if (!hasContent && !hasRunMetadata && !pendingTools.length) continue;
       const copy: HistoryEntry = {
-        ...entry,
-        metadata: { ...(entry.metadata ?? {}) },
+        ...normalizedEntry,
+        metadata: { ...(normalizedEntry.metadata ?? {}) },
       };
       attachPendingTools(copy);
-      if (!hasContent && !Boolean(copy.metadata?.toolCalls?.length) && !hasRunMetadata) {
+      if (
+        !hasContent &&
+        !Boolean(copy.metadata?.toolCalls?.length) &&
+        !hasRunMetadata
+      ) {
         continue;
       }
       result.push(withTimestamp(copy));
       continue;
     }
 
-    result.push(withTimestamp(entry));
+    result.push(withTimestamp(normalizedEntry));
   }
 
   // Tool entries with no AI message after them (e.g. interrupted run) —

--- a/packages/agc-cli/dist/bin.js
+++ b/packages/agc-cli/dist/bin.js
@@ -887,7 +887,7 @@ function sessionsCommand() {
     const spinner = spin("Fetching sessions\u2026");
     try {
       const client = makeClient();
-      const agentId2 = opts.agent ?? cfg.defaultAgentId;
+      const agentId2 = opts.agent;
       const res = agentId2 ? await client.sessions.list(agentId2, cfg.initiator) : await client.sessions.listByUser(cfg.initiator);
       const sessions = res?.data ?? res ?? [];
       spinner.stop();

--- a/packages/agc-cli/src/commands/sessions.ts
+++ b/packages/agc-cli/src/commands/sessions.ts
@@ -20,7 +20,10 @@ export function sessionsCommand(): Command {
       const spinner = spin('Fetching sessions…');
       try {
         const client = makeClient();
-        const agentId = opts.agent ?? cfg.defaultAgentId;
+        // Listing without --agent must include every session owned by the
+        // current user. Falling back to defaultAgentId silently hid sessions
+        // belonging to every other agent.
+        const agentId = opts.agent;
         const res = agentId
           ? await client.sessions.list(agentId, cfg.initiator)
           : await client.sessions.listByUser(cfg.initiator);


### PR DESCRIPTION
## Summary
- restore complete durable multi-turn history after per-run checkpoint isolation
- normalize persisted LangChain and legacy message roles
- make session-list reads lighter, indexed, deduplicated, and failure-aware
- stop the CLI from silently hiding non-default-agent sessions

## Staging verification
- API migration and deployment succeeded
- direct staging API health passed
- two-turn agent run persisted `human, ai, human, ai` in order
- fresh session GET returned both prompts and both responses
- agent-filtered and unfiltered lists contained the session exactly once
- test session was deleted after verification
- full API tests: 41 suites / 358 tests passed
- API and web production builds passed