### PR TITLE
Promote educator copilot skill path editing

### DIFF
--- a/apps/commons-courses/app/api/educator/copilot/actions/route.ts
+++ b/apps/commons-courses/app/api/educator/copilot/actions/route.ts
@@ -85,7 +85,6 @@ export async function POST(req: NextRequest) {
       currentPath: session.currentPath,
       createdAt: session.createdAt,
       updatedAt: session.updatedAt,
-      messages: session.messages || [],
     },
   });
 }

--- a/apps/commons-courses/components/educator/educator-copilot-shell.tsx
+++ b/apps/commons-courses/components/educator/educator-copilot-shell.tsx
@@ -86,6 +86,9 @@ export function EducatorCopilotShell() {
   const [localNotice, setLocalNotice] = useState<string | null>(null);
   const [streamStatus, setStreamStatus] = useState<string | null>(null);
   const [streamActivity, setStreamActivity] = useState<EducatorCopilotToolActivity[]>([]);
+  const [pendingDecisions, setPendingDecisions] = useState<
+    Record<string, "approve" | "reject">
+  >({});
   const [panelWidth, setPanelWidth] = useState(PANEL_DEFAULT_WIDTH);
   const autoApplied = useRef(new Set<string>());
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -410,23 +413,43 @@ export function EducatorCopilotShell() {
       }
       return;
     }
-    const res = await fetch("/api/educator/copilot/actions", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionId: activeSession.id,
-        actionId: action.id,
-        decision,
-      }),
-    });
-    const data = await res.json();
-    if (!res.ok) {
-      setLocalNotice(data.error || "Could not apply action.");
-      return;
+    if (pendingDecisions[action.id]) return;
+    setLocalNotice(null);
+    setPendingDecisions((current) => ({ ...current, [action.id]: decision }));
+    try {
+      const res = await fetch("/api/educator/copilot/actions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sessionId: activeSession.id,
+          actionId: action.id,
+          decision,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setLocalNotice(data.error || "Could not apply action.");
+        return;
+      }
+      updateLocalAction(action.id, {
+        status: data.action.status,
+        result: data.action.result,
+      });
+      setSessions((current) => upsertSession(current, data.session));
+      if (data.action?.status === "applied") router.refresh();
+    } catch {
+      setLocalNotice(
+        decision === "approve"
+          ? "Could not apply that change. Please try again."
+          : "Could not reject that change. Please try again."
+      );
+    } finally {
+      setPendingDecisions((current) => {
+        const next = { ...current };
+        delete next[action.id];
+        return next;
+      });
     }
-    setActiveSession(data.session);
-    setSessions((current) => upsertSession(current, summarizeSession(data.session)));
-    if (data.action?.status === "applied") router.refresh();
   }
 
   const emptyState = useMemo(
@@ -590,6 +613,7 @@ export function EducatorCopilotShell() {
                             message.role === "assistant"
                           }
                           liveActivity={streamActivity}
+                          pendingDecisions={pendingDecisions}
                           onDecision={decideAction}
                         />
                       ))}
@@ -702,12 +726,14 @@ function MessageBubble({
   agentName,
   isStreamingTarget,
   liveActivity,
+  pendingDecisions,
   onDecision,
 }: {
   message: EducatorCopilotMessage;
   agentName: string;
   isStreamingTarget: boolean;
   liveActivity: EducatorCopilotToolActivity[];
+  pendingDecisions: Record<string, "approve" | "reject">;
   onDecision: (action: EducatorCopilotAction, decision: "approve" | "reject") => void;
 }) {
   const activity = isStreamingTarget ? liveActivity : message.activity || [];
@@ -786,7 +812,12 @@ function MessageBubble({
         {message.actions?.length ? (
           <div className="mt-3 space-y-2">
             {message.actions.map((action) => (
-              <ActionCard key={action.id} action={action} onDecision={onDecision} />
+              <ActionCard
+                key={action.id}
+                action={action}
+                pendingDecision={pendingDecisions[action.id]}
+                onDecision={onDecision}
+              />
             ))}
           </div>
         ) : null}
@@ -802,6 +833,7 @@ function actionIcon(action: EducatorCopilotAction) {
     case "navigate":
       return <Navigation className="mt-0.5 h-4 w-4 text-slate-500" />;
     case "add_module":
+    case "create_skill_path":
       return <Layers className="mt-0.5 h-4 w-4 text-violet-600" />;
     case "add_lesson":
       return <FilePlus2 className="mt-0.5 h-4 w-4 text-violet-600" />;
@@ -811,6 +843,7 @@ function actionIcon(action: EducatorCopilotAction) {
       return <Globe2 className="mt-0.5 h-4 w-4 text-violet-600" />;
     case "update_course_lesson":
     case "update_module":
+    case "update_skill_path":
     case "update_skill_challenge":
       return <PenLine className="mt-0.5 h-4 w-4 text-amber-600" />;
     default:
@@ -820,12 +853,16 @@ function actionIcon(action: EducatorCopilotAction) {
 
 function ActionCard({
   action,
+  pendingDecision,
   onDecision,
 }: {
   action: EducatorCopilotAction;
+  pendingDecision?: "approve" | "reject";
   onDecision: (action: EducatorCopilotAction, decision: "approve" | "reject") => void;
 }) {
   const done = ["applied", "rejected", "blocked", "failed"].includes(action.status);
+  const pendingLabel =
+    pendingDecision === "approve" ? "Applying…" : pendingDecision === "reject" ? "Rejecting…" : null;
   return (
     <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
       <div className="flex items-start gap-2">
@@ -856,24 +893,37 @@ function ActionCard({
                 : "bg-white text-slate-500"
           )}
         >
-          {action.status}
+          {pendingLabel || action.status}
         </span>
         {!done ? (
           <>
             <button
               type="button"
               onClick={() => onDecision(action, "approve")}
-              className="ml-auto inline-flex items-center gap-1 rounded-md bg-slate-950 px-2.5 py-1.5 text-xs font-bold text-white"
+              disabled={Boolean(pendingDecision)}
+              className="ml-auto inline-flex items-center gap-1 rounded-md bg-slate-950 px-2.5 py-1.5 text-xs font-bold text-white transition disabled:cursor-wait disabled:opacity-60"
             >
-              <Check className="h-3.5 w-3.5" />
-              {action.type === "navigate" || action.type === "highlight" ? "Run" : "Approve"}
+              {pendingDecision === "approve" ? (
+                <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Check className="h-3.5 w-3.5" />
+              )}
+              {pendingDecision === "approve"
+                ? "Applying…"
+                : action.type === "navigate" || action.type === "highlight"
+                  ? "Run"
+                  : "Approve"}
             </button>
             <button
               type="button"
               onClick={() => onDecision(action, "reject")}
-              className="rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-bold text-slate-600"
+              disabled={Boolean(pendingDecision)}
+              className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-bold text-slate-600 transition disabled:cursor-wait disabled:opacity-60"
             >
-              Reject
+              {pendingDecision === "reject" ? (
+                <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+              ) : null}
+              {pendingDecision === "reject" ? "Rejecting…" : "Reject"}
             </button>
           </>
         ) : null}

--- a/apps/commons-courses/lib/educator-copilot-agent.ts
+++ b/apps/commons-courses/lib/educator-copilot-agent.ts
@@ -100,9 +100,12 @@ export function buildCopilotInstructions({
       "Editing and creating course content:",
       "- Read the current course structure with get_course before proposing edits so module and lesson indexes are correct.",
       "- Propose real, complete drafts — full lesson descriptions, not placeholders.",
-      "- Use update_lesson / update_module / update_course_overview for revisions, add_module / add_lesson to build new content (for example turning an uploaded document into modules and lessons), and update_skill_challenge for skill paths.",
+      "- Use update_lesson / update_module / update_course_overview for course revisions and add_module / add_lesson to build course content (for example turning an uploaded document into modules and lessons).",
+      "- Skill paths are first-class course content: use create_skill_path to add a complete new badge/challenge sequence, update_skill_path for path metadata or a deliberate full-sequence replacement, and update_skill_challenge for a focused edit to one existing challenge. Never substitute add_module for a requested skill path.",
+      "- Uploaded skill-path images must be referenced by their exact chat filenames through coverAttachmentName or assetAttachmentName. The skill tools persist them to durable course media; never put a bare filename such as 28.png into coverUrl or assetUrl.",
       "- Each write tool returns whether the change was applied immediately (auto mode) or recorded as a proposal awaiting the educator's approval (manual mode). Reflect that honestly in your reply — say 'I've queued this for your approval' when it is proposed, 'Done' when it is applied.",
       "- Break large builds into one action per module so the educator can approve them piece by piece.",
+      "- Create a complete skill path in one create_skill_path action so its banner, images, and challenge order can be reviewed together.",
     ].join("\n"),
 
     [

--- a/apps/commons-courses/lib/educator-copilot-runtime.ts
+++ b/apps/commons-courses/lib/educator-copilot-runtime.ts
@@ -47,6 +47,8 @@ const TOOL_LABELS: Record<string, string> = {
   add_module: "Drafting a new module",
   update_module: "Drafting a module edit",
   update_course_overview: "Drafting overview copy",
+  create_skill_path: "Drafting a new skill path",
+  update_skill_path: "Drafting a skill path edit",
   update_skill_challenge: "Drafting a challenge edit",
   update_experience_world: "Validating a world edit",
   navigate: "Preparing navigation",

--- a/apps/commons-courses/lib/educator-copilot-tools.ts
+++ b/apps/commons-courses/lib/educator-copilot-tools.ts
@@ -8,6 +8,7 @@ import {
   EXPERIENCE_COPILOT_WORLD_GUIDE,
 } from "@/lib/experience-ai";
 import { normalizeExperienceDocument } from "@/lib/experience-schema";
+import { uploadCourseMediaToS3 } from "@/lib/media-storage";
 import { indexCourseForSearch } from "@/lib/search-indexers";
 import Assignment from "@/models/Assignment";
 import Course from "@/models/Course";
@@ -21,6 +22,7 @@ import type {
   EducatorCopilotLessonDraft,
   EducatorCopilotPageContext,
 } from "@/types/educator-copilot";
+import type { SkillChallenge, SkillPack, SkillQuestion } from "@/types/skills";
 
 /** JSON-schema tool catalog handed to the agent run as cliTools. */
 export type CopilotToolDefinition = {
@@ -51,6 +53,78 @@ const lessonPatchProperties = {
   assetUrl: { type: "string" },
   assetAlt: { type: "string" },
   isFree: { type: "boolean" },
+};
+
+const skillQuestionProperties = {
+  id: { type: "string" },
+  prompt: { type: "string" },
+  options: { type: "array", items: { type: "string" } },
+  answerIndex: { type: "number" },
+  explanation: { type: "string" },
+};
+
+const skillChallengeProperties = {
+  id: { type: "string" },
+  title: { type: "string" },
+  shortTitle: { type: "string" },
+  minutes: { type: "number" },
+  points: { type: "number" },
+  streakBoost: { type: "number" },
+  assetUrl: {
+    type: "string",
+    description: "Existing durable course-media URL. Prefer assetAttachmentName for a chat upload.",
+  },
+  assetAttachmentName: {
+    type: "string",
+    description:
+      "Exact image filename from this chat. The tool persists it to course media and sets assetUrl.",
+  },
+  assetAlt: { type: "string" },
+  accentColor: { type: "string" },
+  audioCue: { type: "string", enum: ["spark", "focus", "complete"] },
+  hook: { type: "string" },
+  lesson: {
+    type: "string",
+    description: "Full challenge lesson body in markdown or safe HTML.",
+  },
+  keyIdeas: { type: "array", items: { type: "string" } },
+  microTask: { type: "string" },
+  questions: {
+    type: "array",
+    items: {
+      type: "object",
+      properties: skillQuestionProperties,
+      required: ["prompt", "options", "answerIndex"],
+    },
+  },
+};
+
+const skillPathProperties = {
+  slug: { type: "string" },
+  enabled: {
+    type: "boolean",
+    description: "Whether the skill path is published to learners (defaults to true when creating).",
+  },
+  title: { type: "string" },
+  subtitle: { type: "string" },
+  coverUrl: {
+    type: "string",
+    description: "Existing durable course-media URL. Prefer coverAttachmentName for a chat upload.",
+  },
+  coverAttachmentName: {
+    type: "string",
+    description:
+      "Exact banner image filename from this chat. The tool persists it to course media and sets coverUrl.",
+  },
+  learnerPromise: { type: "string" },
+  challenges: {
+    type: "array",
+    items: {
+      type: "object",
+      properties: skillChallengeProperties,
+      required: ["title", "lesson"],
+    },
+  },
 };
 
 export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
@@ -278,8 +352,45 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
     },
   },
   {
+    name: "create_skill_path",
+    description:
+      "Create a complete new skill path/badge sequence on a managed course, including its banner, daily challenge images, lesson copy, and quiz questions. Use exact uploaded filenames in coverAttachmentName and assetAttachmentName; this educator-console tool persists those uploads as durable course media. In manual mode it queues one approval card; in auto mode it applies immediately.",
+    parameters: {
+      type: "object",
+      properties: {
+        courseSlug: { type: "string" },
+        skillPath: {
+          type: "object",
+          properties: skillPathProperties,
+          required: ["title", "challenges"],
+        },
+        reason: { type: "string" },
+      },
+      required: ["courseSlug", "skillPath"],
+    },
+  },
+  {
+    name: "update_skill_path",
+    description:
+      "Update an existing skill path's metadata, banner, publication state, or (when explicitly requested) replace its complete challenge sequence. Call get_course first and identify it by skillPackSlug. For a single challenge edit use update_skill_challenge so other challenges are preserved.",
+    parameters: {
+      type: "object",
+      properties: {
+        courseSlug: { type: "string" },
+        skillPackSlug: { type: "string" },
+        patch: {
+          type: "object",
+          properties: skillPathProperties,
+        },
+        reason: { type: "string" },
+      },
+      required: ["courseSlug", "skillPackSlug", "patch"],
+    },
+  },
+  {
     name: "update_skill_challenge",
-    description: "Revise a skill-path challenge (hook, lesson body, key ideas, micro task).",
+    description:
+      "Revise an existing skill-path challenge, including its lesson copy, badge image, scoring, and quiz questions. Use assetAttachmentName to persist an image uploaded in this chat.",
     parameters: {
       type: "object",
       properties: {
@@ -288,14 +399,7 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
         skillPackSlug: { type: "string" },
         patch: {
           type: "object",
-          properties: {
-            title: { type: "string" },
-            shortTitle: { type: "string" },
-            hook: { type: "string" },
-            lesson: { type: "string", description: "Full challenge lesson body in markdown" },
-            keyIdeas: { type: "array", items: { type: "string" } },
-            microTask: { type: "string" },
-          },
+          properties: skillChallengeProperties,
         },
         reason: { type: "string" },
       },
@@ -459,6 +563,8 @@ async function runTool(
     case "add_module":
     case "update_module":
     case "update_course_overview":
+    case "create_skill_path":
+    case "update_skill_path":
     case "update_skill_challenge":
       return toolContentWrite(ctx, name, args);
     case "update_experience_world":
@@ -618,10 +724,14 @@ async function toolGetCourse(ctx: CopilotToolContext, args: Record<string, unkno
         })
       ),
     })),
-    skillPacks: packs.map((pack) => ({
-      skillPackSlug: pack.slug,
+    skillPacks: packs.map((pack, packIndex) => ({
+      skillPackSlug: pack.slug || (packIndex === 0 && course.skillPack ? course.slug : undefined),
+      storage: packIndex === 0 && course.skillPack ? "primary" : "additional",
       title: pack.title,
       enabled: pack.enabled,
+      subtitle: pack.subtitle,
+      coverUrl: pack.coverUrl,
+      learnerPromise: truncate(pack.learnerPromise as string, textLimit),
       challenges: ((pack.challenges as Array<Record<string, unknown>>) || []).map(
         (challenge) => ({
           challengeId: challenge.id,
@@ -629,6 +739,13 @@ async function toolGetCourse(ctx: CopilotToolContext, args: Record<string, unkno
           title: challenge.title,
           hook: truncate(challenge.hook as string, full ? 1200 : 200),
           lesson: truncate(challenge.lesson as string, textLimit),
+          minutes: challenge.minutes,
+          points: challenge.points,
+          streakBoost: challenge.streakBoost,
+          assetUrl: challenge.assetUrl,
+          assetAlt: challenge.assetAlt,
+          accentColor: challenge.accentColor,
+          audioCue: challenge.audioCue,
           keyIdeas: challenge.keyIdeas,
           microTask: truncate(challenge.microTask as string, full ? 1200 : 200),
           questionCount: Array.isArray(challenge.questions)
@@ -949,18 +1066,24 @@ async function toolContentWrite(
   name: string,
   args: Record<string, unknown>
 ) {
-  const action = buildContentAction(name, args);
+  const requestedCourseSlug = cleanString(args.courseSlug);
+  if (!requestedCourseSlug) {
+    return { error: "courseSlug is required." };
+  }
+  // Authorize the educator before persisting any uploaded images or recording
+  // an action against the course.
+  const course = await findManagedCourse(ctx.user, requestedCourseSlug);
+  if (!course) {
+    return { error: `No managed course with slug "${requestedCourseSlug}".` };
+  }
+
+  const preparedArgs = await persistSkillPathAttachments(ctx, name, args);
+  const action = buildContentAction(name, preparedArgs);
   if (!action) {
     return {
       error:
         "Invalid or empty change. Check required fields (courseSlug, indexes, and a non-empty patch/draft).",
     };
-  }
-
-  // Verify the course really belongs to this educator before recording anything.
-  const course = await findManagedCourse(ctx.user, action.courseSlug);
-  if (!course) {
-    return { error: `No managed course with slug "${action.courseSlug}".` };
   }
 
   if (ctx.actionMode === "auto") {
@@ -982,6 +1105,136 @@ async function toolContentWrite(
     note: "Manual mode: the change is queued as an action card the educator must approve. Tell them it is ready for review — do not claim it is applied.",
     actionLabel: action.label,
   };
+}
+
+async function persistSkillPathAttachments(
+  ctx: CopilotToolContext,
+  name: string,
+  args: Record<string, unknown>
+) {
+  if (
+    name !== "create_skill_path" &&
+    name !== "update_skill_path" &&
+    name !== "update_skill_challenge"
+  ) {
+    return args;
+  }
+
+  const prepared = { ...args };
+  const attachmentNames = new Set<string>();
+  const uploadedImageName = (value: unknown) => {
+    const candidate = cleanString(value)?.toLowerCase();
+    if (!candidate) return undefined;
+    return ctx.materials.find(
+      (material) =>
+        material.type.startsWith("image/") && material.name.toLowerCase() === candidate
+    )?.name;
+  };
+  const collect = (value: unknown) => {
+    const input = asRecord(value);
+    const coverName =
+      cleanString(input.coverAttachmentName) || uploadedImageName(input.coverUrl);
+    const assetName =
+      cleanString(input.assetAttachmentName) || uploadedImageName(input.assetUrl);
+    if (coverName) attachmentNames.add(coverName);
+    if (assetName) attachmentNames.add(assetName);
+    for (const challenge of Array.isArray(input.challenges) ? input.challenges : []) {
+      const challengeInput = asRecord(challenge);
+      const challengeName =
+        cleanString(challengeInput.assetAttachmentName) ||
+        uploadedImageName(challengeInput.assetUrl);
+      if (challengeName) attachmentNames.add(challengeName);
+    }
+  };
+
+  if (name === "create_skill_path") collect(args.skillPath);
+  else collect(args.patch);
+
+  if (!attachmentNames.size) return prepared;
+  const persisted = new Map(
+    await Promise.all(
+      [...attachmentNames].map(async (attachmentName) => [
+        attachmentName,
+        await persistUploadedSkillImage(ctx, attachmentName),
+      ] as const)
+    )
+  );
+
+  const replace = (value: unknown) => {
+    const input = { ...asRecord(value) };
+    const coverName =
+      cleanString(input.coverAttachmentName) || uploadedImageName(input.coverUrl);
+    if (coverName) input.coverUrl = persisted.get(coverName);
+    delete input.coverAttachmentName;
+    const assetName =
+      cleanString(input.assetAttachmentName) || uploadedImageName(input.assetUrl);
+    if (assetName) input.assetUrl = persisted.get(assetName);
+    delete input.assetAttachmentName;
+    if (Array.isArray(input.challenges)) {
+      input.challenges = input.challenges.map((challenge) => replace(challenge));
+    }
+    return input;
+  };
+
+  if (name === "create_skill_path") prepared.skillPath = replace(args.skillPath);
+  else prepared.patch = replace(args.patch);
+  return prepared;
+}
+
+async function persistUploadedSkillImage(
+  ctx: CopilotToolContext,
+  attachmentName: string
+) {
+  const query = attachmentName.toLowerCase();
+  const exact = ctx.materials.find((material) => material.name.toLowerCase() === query);
+  const partial = ctx.materials.filter((material) =>
+    material.name.toLowerCase().includes(query)
+  );
+  const material = exact || (partial.length === 1 ? partial[0] : undefined);
+  if (!material) {
+    const detail = partial.length > 1 ? "matches more than one upload" : "was not uploaded";
+    throw new Error(
+      `Image attachment “${attachmentName}” ${detail}. Use an exact filename from read_attachment.`
+    );
+  }
+  if (!material.type.startsWith("image/")) {
+    throw new Error(`Attachment “${material.name}” is not an image.`);
+  }
+  if (!material.fileId || !ctx.client || !ctx.agentId) {
+    throw new Error(
+      `Attachment “${material.name}” is not available from durable file storage. Upload it again and retry.`
+    );
+  }
+
+  const content = await ctx.client.files.content(material.fileId, {
+    agentId: ctx.agentId,
+    sessionId: ctx.agentSessionId,
+    includeImageUrls: true,
+    includeDownloadUrl: true,
+    maxChars: 1,
+  });
+  const sourceUrl = content.data.downloadUrl || content.data.imageUrls?.[0];
+  if (!sourceUrl) {
+    throw new Error(`Attachment “${material.name}” has no downloadable image source.`);
+  }
+  const source = await fetch(sourceUrl);
+  if (!source.ok) {
+    throw new Error(`Could not download attachment “${material.name}” (${source.status}).`);
+  }
+  const responseType = source.headers.get("content-type") || "";
+  const mimeType = responseType.startsWith("image/") ? responseType : material.type;
+  if (!mimeType.startsWith("image/")) {
+    throw new Error(`Attachment “${material.name}” did not resolve to an image.`);
+  }
+  const data = Buffer.from(await source.arrayBuffer());
+  if (!data.length || data.length > 20 * 1024 * 1024) {
+    throw new Error(`Attachment “${material.name}” has an unsupported image size.`);
+  }
+  return uploadCourseMediaToS3({
+    file: { name: material.name, type: mimeType },
+    data,
+    keyPrefix: "course-media/copilot-skill-paths",
+  });
 }
 
 async function toolExperienceWrite(
@@ -1081,6 +1334,8 @@ type ContentWriteAction = Extract<
       | "add_module"
       | "update_module"
       | "update_course_overview"
+      | "create_skill_path"
+      | "update_skill_path"
       | "update_skill_challenge";
   }
 >;
@@ -1208,6 +1463,42 @@ function buildContentAction(
       courseSlug,
       patch,
       preview: previewFromPatch(patch),
+    };
+  }
+
+  if (name === "create_skill_path") {
+    const skillPath = sanitizeSkillPathDraft(args.skillPath, { requireChallenges: true });
+    if (!skillPath) return null;
+    return {
+      ...base,
+      type: "create_skill_path",
+      label: `Create skill path “${skillPath.title}” (${skillPath.challenges.length} challenge${skillPath.challenges.length === 1 ? "" : "s"})`,
+      courseSlug,
+      skillPath,
+      preview: [
+        skillPath.enabled ? "Published to learners" : "Saved as unpublished",
+        skillPath.coverUrl ? "Banner image included" : "No banner image",
+        ...skillPath.challenges.map((challenge, index) =>
+          `${index + 1}. ${challenge.title}${challenge.assetUrl ? " · image included" : ""}`
+        ),
+      ]
+        .join("\n")
+        .slice(0, 1200),
+    };
+  }
+
+  if (name === "update_skill_path") {
+    const skillPackSlug = cleanString(args.skillPackSlug);
+    const patch = sanitizeSkillPathPatch(args.patch);
+    if (!skillPackSlug || !Object.keys(patch).length) return null;
+    return {
+      ...base,
+      type: "update_skill_path",
+      label: `Update skill path${patch.title ? `: ${patch.title}` : ` ${skillPackSlug}`}`,
+      courseSlug,
+      skillPackSlug,
+      patch,
+      preview: previewSkillPathPatch(patch),
     };
   }
 
@@ -1435,6 +1726,76 @@ export async function applyEducatorCopilotAction({
         Object.assign(course, action.patch);
         break;
       }
+      case "create_skill_path": {
+        const existingPacks = [
+          ...(course.skillPack ? [course.skillPack] : []),
+          ...((course.skillPacks as SkillPack[]) || []),
+        ];
+        if (
+          existingPacks.some(
+            (pack) =>
+              pack.slug === action.skillPath.slug ||
+              pack.title?.toLowerCase() === action.skillPath.title.toLowerCase()
+          )
+        ) {
+          return {
+            ...action,
+            status: "failed",
+            result:
+              "A skill path with this slug or title already exists in the course. Read the course again and update that path instead.",
+          };
+        }
+        if (
+          action.skillPath.slug &&
+          (await skillPathSlugExists(action.skillPath.slug, course._id))
+        ) {
+          return {
+            ...action,
+            status: "failed",
+            result:
+              "That skill-path slug is already used by another course. Choose a distinct slug and retry.",
+          };
+        }
+        course.skillPacks = [
+          ...((course.skillPacks as SkillPack[]) || []),
+          action.skillPath,
+        ];
+        course.markModified("skillPacks");
+        break;
+      }
+      case "update_skill_path": {
+        const primary = course.skillPack as SkillPack | undefined;
+        const additional = (course.skillPacks as SkillPack[]) || [];
+        const pack =
+          (primary &&
+          (primary.slug === action.skillPackSlug ||
+            (!primary.slug && action.skillPackSlug === course.slug))
+            ? primary
+            : undefined) ||
+          additional.find((candidate) => candidate.slug === action.skillPackSlug);
+        if (!pack) {
+          return { ...action, status: "failed", result: "Skill path not found." };
+        }
+        if (
+          action.patch.slug &&
+          action.patch.slug !== pack.slug &&
+          ([primary, ...additional].some(
+            (candidate) => candidate && candidate !== pack && candidate.slug === action.patch.slug
+          ) ||
+            (await skillPathSlugExists(action.patch.slug, course._id)))
+        ) {
+          return {
+            ...action,
+            status: "failed",
+            result:
+              "That skill-path slug is already used by another course. Choose a distinct slug and retry.",
+          };
+        }
+        Object.assign(pack, action.patch);
+        course.markModified("skillPack");
+        course.markModified("skillPacks");
+        break;
+      }
       case "update_skill_challenge": {
         const packs = [
           ...(course.skillPack ? [course.skillPack] : []),
@@ -1488,6 +1849,10 @@ function appliedSummary(action: EducatorCopilotAction) {
       return "Module updated.";
     case "update_course_overview":
       return "Course overview updated.";
+    case "create_skill_path":
+      return `Created skill path “${action.skillPath.title}” with ${action.skillPath.challenges.length} challenge(s).`;
+    case "update_skill_path":
+      return "Skill path updated.";
     case "update_skill_challenge":
       return "Skill challenge updated.";
     default:
@@ -1508,6 +1873,15 @@ async function findManagedCourse(user: CopilotUser, slug: string) {
           }),
         };
   return Course.findOne(filter);
+}
+
+async function skillPathSlugExists(slug: string, currentCourseId: unknown) {
+  return Boolean(
+    await Course.exists({
+      _id: { $ne: currentCourseId },
+      $or: [{ slug }, { "skillPack.slug": slug }, { "skillPacks.slug": slug }],
+    })
+  );
 }
 
 async function findManagedExperience(user: CopilotUser, experienceId: string) {
@@ -1585,22 +1959,157 @@ function sanitizeLessonDraft(value: unknown): EducatorCopilotLessonDraft | null 
 }
 
 function sanitizeSkillChallengePatch(value: unknown) {
-  const input = value && typeof value === "object" ? (value as Record<string, unknown>) : {};
-  const patch: Record<string, unknown> = {};
-  for (const key of ["title", "shortTitle", "hook", "lesson", "microTask"]) {
+  const input = asRecord(value);
+  const patch: Partial<Omit<SkillChallenge, "id" | "day">> = {};
+  for (const key of [
+    "title",
+    "shortTitle",
+    "assetUrl",
+    "assetAlt",
+    "accentColor",
+    "hook",
+    "lesson",
+    "microTask",
+  ] as const) {
     const next = cleanString(input[key]);
     if (next !== undefined) patch[key] = next;
+  }
+  for (const key of ["minutes", "points", "streakBoost"] as const) {
+    const next = nonNegativeInteger(input[key]);
+    if (next !== undefined && (key !== "minutes" || next > 0)) patch[key] = next;
+  }
+  const audioCue = cleanString(input.audioCue);
+  if (audioCue === "spark" || audioCue === "focus" || audioCue === "complete") {
+    patch.audioCue = audioCue;
   }
   if (Array.isArray(input.keyIdeas)) {
     patch.keyIdeas = input.keyIdeas
       .map((idea) => cleanString(idea))
-      .filter(Boolean)
-      .slice(0, 6);
+      .filter((idea): idea is string => Boolean(idea))
+      .slice(0, 8);
   }
-  return patch as Extract<
+  if (Array.isArray(input.questions)) {
+    patch.questions = input.questions
+      .map(sanitizeSkillQuestion)
+      .filter((question): question is SkillQuestion => Boolean(question));
+  }
+  return patch;
+}
+
+function sanitizeSkillQuestion(value: unknown, index = 0): SkillQuestion | null {
+  const input = asRecord(value);
+  const prompt = cleanString(input.prompt);
+  const options = Array.isArray(input.options)
+    ? input.options
+        .map((option) => cleanString(option))
+        .filter((option): option is string => Boolean(option))
+        .slice(0, 8)
+    : [];
+  const answerIndex = toIndex(input.answerIndex);
+  if (!prompt || options.length < 2 || answerIndex === null || answerIndex >= options.length) {
+    return null;
+  }
+  return {
+    id: cleanString(input.id) || `q${index + 1}`,
+    prompt,
+    options,
+    answerIndex,
+    explanation: cleanString(input.explanation),
+  };
+}
+
+function sanitizeSkillChallengeDraft(value: unknown, index: number): SkillChallenge | null {
+  const input = asRecord(value);
+  const title = cleanString(input.title);
+  const lesson = cleanString(input.lesson);
+  if (!title || !lesson) return null;
+  const patch = sanitizeSkillChallengePatch(input);
+  return {
+    id: cleanString(input.id) || `day-${index + 1}`,
+    day: index + 1,
+    title,
+    minutes: patch.minutes || 6,
+    points: patch.points ?? 60,
+    streakBoost: patch.streakBoost ?? 1,
+    shortTitle: patch.shortTitle,
+    assetUrl: patch.assetUrl,
+    assetAlt: patch.assetAlt,
+    accentColor: patch.accentColor || "#B8F56D",
+    audioCue: patch.audioCue || "focus",
+    hook: patch.hook,
+    lesson,
+    keyIdeas: patch.keyIdeas || [],
+    microTask: patch.microTask,
+    questions: patch.questions || [],
+  };
+}
+
+function sanitizeSkillPathDraft(
+  value: unknown,
+  options: { requireChallenges: boolean }
+): SkillPack | null {
+  const input = asRecord(value);
+  const title = cleanString(input.title);
+  if (!title) return null;
+  const challenges = (Array.isArray(input.challenges) ? input.challenges : [])
+    .map(sanitizeSkillChallengeDraft)
+    .filter((challenge): challenge is SkillChallenge => Boolean(challenge));
+  if (options.requireChallenges && !challenges.length) return null;
+  const usedIds = new Set<string>();
+  for (const [index, challenge] of challenges.entries()) {
+    const baseId = safeSlug(challenge.id) || `day-${index + 1}`;
+    let id = baseId;
+    let suffix = 2;
+    while (usedIds.has(id)) id = `${baseId}-${suffix++}`;
+    challenge.id = id;
+    challenge.day = index + 1;
+    usedIds.add(id);
+  }
+  return {
+    slug: safeSlug(cleanString(input.slug) || title),
+    enabled: typeof input.enabled === "boolean" ? input.enabled : true,
+    title,
+    subtitle: cleanString(input.subtitle),
+    coverUrl: cleanString(input.coverUrl),
+    learnerPromise: cleanString(input.learnerPromise),
+    challenges,
+  };
+}
+
+function sanitizeSkillPathPatch(value: unknown) {
+  const input = asRecord(value);
+  const patch: Extract<
     EducatorCopilotAction,
-    { type: "update_skill_challenge" }
-  >["patch"];
+    { type: "update_skill_path" }
+  >["patch"] = {};
+  for (const key of ["title", "subtitle", "coverUrl", "learnerPromise"] as const) {
+    const next = cleanString(input[key]);
+    if (next !== undefined) patch[key] = next;
+  }
+  const slug = cleanString(input.slug);
+  if (slug) patch.slug = safeSlug(slug);
+  if (typeof input.enabled === "boolean") patch.enabled = input.enabled;
+  if (Array.isArray(input.challenges)) {
+    patch.challenges = input.challenges
+      .map(sanitizeSkillChallengeDraft)
+      .filter((challenge): challenge is SkillChallenge => Boolean(challenge));
+  }
+  return patch;
+}
+
+function previewSkillPathPatch(
+  patch: Extract<EducatorCopilotAction, { type: "update_skill_path" }>["patch"]
+) {
+  const metadata = Object.entries(patch)
+    .filter(([key]) => key !== "challenges")
+    .map(([key, value]) => `${key}: ${String(value)}`);
+  if (patch.challenges) {
+    metadata.push(
+      `Challenges (${patch.challenges.length}):`,
+      ...patch.challenges.map((challenge, index) => `${index + 1}. ${challenge.title}`)
+    );
+  }
+  return metadata.join("\n").slice(0, 1200);
 }
 
 function previewFromPatch(patch: Record<string, unknown>) {
@@ -1634,6 +2143,24 @@ function formatExperienceImpact(
 
 function cleanString(value: unknown) {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+function safeSlug(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 90);
+}
+
+function nonNegativeInteger(value: unknown) {
+  const num = typeof value === "string" ? Number(value) : value;
+  if (typeof num !== "number" || !Number.isFinite(num) || num < 0) return undefined;
+  return Math.floor(num);
 }
 
 function truncate(value: unknown, max: number) {

--- a/apps/commons-courses/types/educator-copilot.ts
+++ b/apps/commons-courses/types/educator-copilot.ts
@@ -1,4 +1,5 @@
 import type { ExperienceDocument } from "@/types/experience";
+import type { SkillChallenge, SkillPack } from "@/types/skills";
 
 export type EducatorCopilotActionMode = "manual" | "auto";
 
@@ -89,18 +90,24 @@ export type EducatorCopilotAction =
       };
     })
   | (ActionBase & {
+      type: "create_skill_path";
+      courseSlug: string;
+      skillPath: SkillPack;
+    })
+  | (ActionBase & {
+      type: "update_skill_path";
+      courseSlug: string;
+      skillPackSlug: string;
+      patch: Partial<Omit<SkillPack, "challenges">> & {
+        challenges?: SkillChallenge[];
+      };
+    })
+  | (ActionBase & {
       type: "update_skill_challenge";
       courseSlug: string;
       skillPackSlug?: string;
       challengeId: string;
-      patch: {
-        title?: string;
-        shortTitle?: string;
-        hook?: string;
-        lesson?: string;
-        keyIdeas?: string[];
-        microTask?: string;
-      };
+      patch: Partial<Omit<SkillChallenge, "id" | "day">>;
     })
   | (ActionBase & {
       type: "update_experience_world";


### PR DESCRIPTION
## Production promotion

Promotes the educator copilot skill-path fix from `staging` to `main`.

## Included behavior

- Create complete skill paths and badge/challenge sequences from the educator console.
- Update skill-path metadata, publication state, full sequences, or individual challenges.
- Persist uploaded banners and challenge images to durable course media.
- Keep writes scoped to courses managed by the educator and gated by manual/auto approval mode.
- Show immediate applying/rejecting loaders and return smaller action responses for a faster UI.

## Validation

- Feature PR CI passed.
- All feature preview deployments passed, including `commons-courses`.
- Staging push CI passed.
- Staging `commons-courses` deployment completed successfully.
