### PR TITLE
Add facilitated live learning sessions

### DIFF
--- a/apps/commons-courses/app/api/educator/courses/[slug]/live-sessions/route.ts
+++ b/apps/commons-courses/app/api/educator/courses/[slug]/live-sessions/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createJoinCode, normalizeSessionCreate } from "@/lib/live-session-input";
+import { serializeEducatorLiveSession } from "@/lib/live-session-data";
+import { requireEducatorCourse } from "@/lib/educator-auth";
+import LiveSession from "@/models/LiveSession";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const result = await requireEducatorCourse(slug);
+  if (result.error) return result.error;
+  const sessions = await LiveSession.find({ courseId: result.course._id })
+    .sort({ createdAt: -1 })
+    .limit(100);
+  return NextResponse.json({
+    sessions: await Promise.all(
+      sessions.map((session) =>
+        serializeEducatorLiveSession(session, result.course.title),
+      ),
+    ),
+  });
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const result = await requireEducatorCourse(slug);
+  if (result.error) return result.error;
+  const input = normalizeSessionCreate(await req.json().catch(() => ({})));
+  let joinCode = createJoinCode();
+  while (await LiveSession.exists({ joinCode })) joinCode = createJoinCode();
+  const session = await LiveSession.create({
+    ...input,
+    courseId: result.course._id,
+    courseSlug: result.course.slug,
+    joinCode,
+    createdBy: result.session.userId,
+  });
+  return NextResponse.json(
+    { session: await serializeEducatorLiveSession(session, result.course.title) },
+    { status: 201 },
+  );
+}
+

--- a/apps/commons-courses/app/api/educator/live-sessions/[id]/route.ts
+++ b/apps/commons-courses/app/api/educator/live-sessions/[id]/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Types } from "mongoose";
+import { connectDB } from "@/lib/db";
+import { requireEducatorCourse } from "@/lib/educator-auth";
+import { normalizeSessionPatch } from "@/lib/live-session-input";
+import {
+  getParticipants,
+  getSessionResults,
+  serializeEducatorLiveSession,
+} from "@/lib/live-session-data";
+import LiveSession from "@/models/LiveSession";
+import type { LiveActivity } from "@/types/live-session";
+
+async function authorize(id: string) {
+  if (!Types.ObjectId.isValid(id)) return null;
+  await connectDB();
+  const session = await LiveSession.findById(id);
+  if (!session) return null;
+  const result = await requireEducatorCourse(session.courseSlug);
+  if (result.error) return { error: result.error, session: null, result: null };
+  return { error: null, session, result };
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const authResult = await authorize(id);
+  if (!authResult) return NextResponse.json({ error: "Session not found." }, { status: 404 });
+  if (authResult.error) return authResult.error;
+  const { session, result } = authResult;
+  const [serialized, participants, results] = await Promise.all([
+    serializeEducatorLiveSession(session, result.course.title),
+    getParticipants(session._id),
+    getSessionResults(session, session.settings.showParticipantNames),
+  ]);
+  return NextResponse.json({ session: serialized, participants, results });
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const authResult = await authorize(id);
+  if (!authResult) return NextResponse.json({ error: "Session not found." }, { status: 404 });
+  if (authResult.error) return authResult.error;
+  const { session, result } = authResult;
+  const body = await req.json().catch(() => ({}));
+  const record = body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+  const patch = normalizeSessionPatch(body);
+
+  if (record.command === "open_lobby") {
+    session.status = "lobby";
+  } else if (record.command === "start") {
+    session.status = "live";
+    if (!session.currentActivityId) {
+      const first = session.activities[0];
+      if (first) {
+        if (session.pace === "learner") {
+          for (const activity of session.activities) activity.status = "open";
+        } else {
+          first.status = "open";
+        }
+        session.currentActivityId = first.id;
+      }
+    }
+  } else if (record.command === "end") {
+    session.status = "ended";
+    for (const activity of session.activities) {
+      if (activity.status === "open") activity.status = "closed";
+    }
+  } else if (record.command === "activate") {
+    const activityId = typeof record.activityId === "string" ? record.activityId : "";
+    if (!session.activities.some((activity: LiveActivity) => activity.id === activityId)) {
+      return NextResponse.json({ error: "Activity not found." }, { status: 404 });
+    }
+    session.status = "live";
+    session.currentActivityId = activityId;
+    for (const activity of session.activities) {
+      if (activity.id === activityId) activity.status = "open";
+      else if (activity.status === "open") activity.status = "closed";
+    }
+  } else if (record.command === "close_activity") {
+    const activityId = typeof record.activityId === "string" ? record.activityId : "";
+    const activity = session.activities.find((item: LiveActivity) => item.id === activityId);
+    if (!activity) return NextResponse.json({ error: "Activity not found." }, { status: 404 });
+    activity.status = "closed";
+  } else if (Object.keys(patch).length) {
+    session.set(patch);
+  }
+
+  session.markModified("activities");
+  await session.save();
+  return NextResponse.json({
+    session: await serializeEducatorLiveSession(session, result.course.title),
+  });
+}

--- a/apps/commons-courses/app/api/live-sessions/[id]/responses/route.ts
+++ b/apps/commons-courses/app/api/live-sessions/[id]/responses/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Types } from "mongoose";
+import { auth } from "@/lib/auth";
+import { connectDB } from "@/lib/db";
+import LiveParticipant from "@/models/LiveParticipant";
+import LiveResponse from "@/models/LiveResponse";
+import LiveSession from "@/models/LiveSession";
+import type { LiveActivity, LiveActivityOption } from "@/types/live-session";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const currentUser = await auth();
+  if (!currentUser?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+  const { id } = await params;
+  if (!Types.ObjectId.isValid(id)) {
+    return NextResponse.json({ error: "Session not found." }, { status: 404 });
+  }
+  const body = await req.json().catch(() => ({}));
+  const activityId = typeof body.activityId === "string" ? body.activityId : "";
+  const value = body.value;
+  if (!activityId || (!Array.isArray(value) && typeof value !== "string")) {
+    return NextResponse.json({ error: "activityId and a response are required." }, { status: 400 });
+  }
+  if (typeof value === "string" && (!value.trim() || value.length > 10_000)) {
+    return NextResponse.json({ error: "Enter a response under 10,000 characters." }, { status: 400 });
+  }
+  await connectDB();
+  const session = await LiveSession.findById(id);
+  const activity = session?.activities.find((item: LiveActivity) => item.id === activityId);
+  if (!session || !activity) {
+    return NextResponse.json({ error: "Activity not found." }, { status: 404 });
+  }
+  if (activity.status !== "open") {
+    return NextResponse.json({ error: "This activity is not open." }, { status: 409 });
+  }
+  if (session.pace === "facilitator" && session.currentActivityId !== activity.id) {
+    return NextResponse.json({ error: "Wait for the facilitator to open this activity." }, { status: 409 });
+  }
+  const participant = await LiveParticipant.findOne({
+    sessionId: session._id,
+    userId: currentUser.user.id,
+  });
+  if (!participant) {
+    return NextResponse.json({ error: "Join the session before responding." }, { status: 403 });
+  }
+  const selectedValues = Array.isArray(value) ? value.map(String) : [String(value)];
+  const correctOptions = activity.options
+    .filter((option: LiveActivityOption) => option.isCorrect)
+    .map((option: LiveActivityOption) => option.id);
+  const isQuiz = activity.type === "quiz" && correctOptions.length > 0;
+  const correct = isQuiz
+    ? selectedValues.length === correctOptions.length &&
+      selectedValues.every((selected) => correctOptions.includes(selected))
+    : undefined;
+  const response = await LiveResponse.findOneAndUpdate(
+    { sessionId: session._id, activityId, participantId: participant._id },
+    {
+      $set: {
+        courseId: session.courseId,
+        userId: currentUser.user.id,
+        value,
+        correct,
+        pointsAwarded: correct ? activity.points : 0,
+        submittedAt: new Date(),
+      },
+    },
+    { new: true, upsert: true },
+  );
+  participant.lastSeenAt = new Date();
+  participant.status = "active";
+  await participant.save();
+  return NextResponse.json({
+    response: {
+      activityId,
+      value: response.value,
+      correct:
+        activity.showResults && activity.status === "closed" ? response.correct : undefined,
+      pointsAwarded: response.pointsAwarded,
+      submittedAt: response.submittedAt,
+    },
+  });
+}

--- a/apps/commons-courses/app/api/live-sessions/[id]/route.ts
+++ b/apps/commons-courses/app/api/live-sessions/[id]/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Types } from "mongoose";
+import { auth } from "@/lib/auth";
+import { connectDB } from "@/lib/db";
+import {
+  getLearnerResponses,
+  getSessionResults,
+  learnerSafeActivities,
+  serializeEducatorLiveSession,
+} from "@/lib/live-session-data";
+import Course from "@/models/Course";
+import Enrollment from "@/models/Enrollment";
+import LiveParticipant from "@/models/LiveParticipant";
+import LiveSession from "@/models/LiveSession";
+import type { LiveActivity } from "@/types/live-session";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const currentUser = await auth();
+  if (!currentUser?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+  const { id } = await params;
+  if (!Types.ObjectId.isValid(id)) {
+    return NextResponse.json({ error: "Session not found." }, { status: 404 });
+  }
+  await connectDB();
+  const session = await LiveSession.findById(id);
+  if (!session || session.status === "draft") {
+    return NextResponse.json({ error: "Session not found." }, { status: 404 });
+  }
+  const course = await Course.findById(session.courseId).select("title published isFree");
+  if (!course?.published) {
+    return NextResponse.json({ error: "Session not found." }, { status: 404 });
+  }
+  const email = currentUser.user.email?.trim().toLowerCase() || "";
+  if (session.access === "invited" && !session.invitedEmails.includes(email)) {
+    return NextResponse.json({ error: "This session is limited to invited learners." }, { status: 403 });
+  }
+  if (session.access === "enrolled") {
+    const enrolled = await Enrollment.exists({
+      userId: currentUser.user.id,
+      courseId: session.courseId,
+      status: { $ne: "cancelled" },
+    });
+    if (!enrolled) {
+      if (!course.isFree) {
+        return NextResponse.json({ error: "Enroll in the course before joining this session." }, { status: 403 });
+      }
+      await Enrollment.findOneAndUpdate(
+        { userId: currentUser.user.id, courseId: session.courseId },
+        { $setOnInsert: { status: "active", paymentStatus: "free", accessLevel: "full" } },
+        { upsert: true },
+      );
+    }
+  }
+  if (session.status === "ended") {
+    const existing = await LiveParticipant.findOne({
+      sessionId: session._id,
+      userId: currentUser.user.id,
+    });
+    if (!existing) {
+      return NextResponse.json({ error: "This session has ended." }, { status: 410 });
+    }
+  }
+  if (!session.settings.allowLateJoin && session.status === "live") {
+    const existing = await LiveParticipant.exists({
+      sessionId: session._id,
+      userId: currentUser.user.id,
+    });
+    if (!existing) {
+      return NextResponse.json({ error: "Joining is now closed." }, { status: 403 });
+    }
+  }
+  const participant = await LiveParticipant.findOneAndUpdate(
+    { sessionId: session._id, userId: currentUser.user.id },
+    {
+      $set: {
+        displayName: currentUser.user.name || currentUser.user.email || "Learner",
+        email,
+        lastSeenAt: new Date(),
+        status: session.status === "ended" ? "completed" : "active",
+      },
+      $setOnInsert: { courseId: session.courseId, joinedAt: new Date() },
+    },
+    { new: true, upsert: true },
+  );
+  const [base, responses, results] = await Promise.all([
+    serializeEducatorLiveSession(session, course.title),
+    getLearnerResponses(session._id, participant._id),
+    getSessionResults(session, false),
+  ]);
+  const visibleResults = Object.fromEntries(
+    Object.entries(results).filter(([activityId]) => {
+      const activity = session.activities.find((item: LiveActivity) => item.id === activityId);
+      return activity?.showResults && activity.status === "closed";
+    }),
+  );
+  return NextResponse.json({
+    session: {
+      ...base,
+      invitedEmails: undefined,
+      responseCounts: undefined,
+      activities: learnerSafeActivities(base.activities),
+      participant: {
+        id: String(participant._id),
+        displayName: participant.displayName,
+        status: participant.status,
+        joinedAt: participant.joinedAt.toISOString(),
+        lastSeenAt: participant.lastSeenAt.toISOString(),
+      },
+      responses,
+      results: visibleResults,
+    },
+  });
+}

--- a/apps/commons-courses/app/api/live-sessions/resolve/route.ts
+++ b/apps/commons-courses/app/api/live-sessions/resolve/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import LiveSession from "@/models/LiveSession";
+import { connectDB } from "@/lib/db";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => ({}));
+  const code = typeof body.code === "string" ? body.code.replace(/\D/g, "").slice(0, 6) : "";
+  if (code.length !== 6) {
+    return NextResponse.json({ error: "Enter the six-digit session code." }, { status: 400 });
+  }
+  await connectDB();
+  const session = (await LiveSession.findOne({ joinCode: code })
+    .select("_id status")
+    .lean()) as unknown as { _id: unknown; status: "draft" | "lobby" | "live" | "ended" } | null;
+  if (!session || session.status === "draft" || session.status === "ended") {
+    return NextResponse.json({ error: "That session is not open for joining." }, { status: 404 });
+  }
+  return NextResponse.json({ sessionId: String(session._id) });
+}

--- a/apps/commons-courses/app/educator/courses/[slug]/live/[id]/page.tsx
+++ b/apps/commons-courses/app/educator/courses/[slug]/live/[id]/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from "next/navigation";
+import { LiveFacilitatorStudio } from "@/components/educator/live-facilitator-studio";
+import { requireEducatorCourse } from "@/lib/educator-auth";
+
+export default async function LiveFacilitatorPage({ params }: { params: Promise<{ slug: string; id: string }> }) {
+  const { slug, id } = await params;
+  const result = await requireEducatorCourse(slug);
+  if (result.error) redirect("/educator");
+  return <LiveFacilitatorStudio sessionId={id} />;
+}

--- a/apps/commons-courses/app/educator/courses/[slug]/live/page.tsx
+++ b/apps/commons-courses/app/educator/courses/[slug]/live/page.tsx
@@ -1,0 +1,15 @@
+import { redirect } from "next/navigation";
+import { LiveSessionManager } from "@/components/educator/live-session-manager";
+import { requireEducatorCourse } from "@/lib/educator-auth";
+
+export default async function LiveSessionsPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const result = await requireEducatorCourse(slug);
+  if (result.error) redirect("/educator");
+  return <LiveSessionManager courseSlug={slug} courseTitle={result.course.title} />;
+}
+

--- a/apps/commons-courses/app/educator/courses/[slug]/page.tsx
+++ b/apps/commons-courses/app/educator/courses/[slug]/page.tsx
@@ -7,6 +7,7 @@ import {
   ClipboardList,
   CreditCard,
   GraduationCap,
+  Radio,
 } from "lucide-react";
 import { requireEducatorCourse } from "@/lib/educator-auth";
 import Enrollment from "@/models/Enrollment";
@@ -59,12 +60,18 @@ export default async function CourseDashboardPage({
         <Metric icon={ClipboardList} label="Assignments" value={assignments} />
       </div>
 
-      <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
         <ActionCard
           icon={BookOpen}
           title="Build course content"
           body="Organize modules, lesson details, preview access, and course structure."
           href={`/educator/courses/${slug}/content`}
+        />
+        <ActionCard
+          icon={Radio}
+          title="Facilitate live"
+          body="Run paced workbooks, setup checks, practice, polls, quizzes, and reflections in one room."
+          href={`/educator/courses/${slug}/live`}
         />
         <ActionCard
           icon={Award}

--- a/apps/commons-courses/app/join/page.tsx
+++ b/apps/commons-courses/app/join/page.tsx
@@ -1,0 +1,6 @@
+import { JoinLiveSession } from "@/components/live/join-live-session";
+
+export default function JoinPage() {
+  return <JoinLiveSession />;
+}
+

--- a/apps/commons-courses/app/live/[id]/page.tsx
+++ b/apps/commons-courses/app/live/[id]/page.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { FlaskConical, Radio } from "lucide-react";
+import { auth } from "@/lib/auth";
+import { connectDB } from "@/lib/db";
+import LiveSession from "@/models/LiveSession";
+import { LiveLearnerRoom } from "@/components/live/live-learner-room";
+
+export default async function LiveRoomPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  await connectDB();
+  const liveSession = (await LiveSession.findById(id)
+    .select("title status")
+    .lean()) as unknown as { title: string; status: "draft" | "lobby" | "live" | "ended" } | null;
+  if (!liveSession || liveSession.status === "draft") notFound();
+  const currentUser = await auth();
+  if (!currentUser?.user?.id) {
+    const callbackUrl = `/live/${id}`;
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-slate-950 px-5 py-12 text-white">
+        <section className="w-full max-w-md rounded-3xl bg-white p-7 text-slate-950 shadow-2xl sm:p-9">
+          <div className="flex items-center gap-2.5 text-sm font-bold"><span className="flex h-8 w-8 items-center justify-center rounded-lg bg-slate-950 text-white"><FlaskConical className="h-4 w-4" /></span>CommonLab</div>
+          <span className="mt-10 flex h-11 w-11 items-center justify-center rounded-xl bg-[#71E0E7]/25"><Radio className="h-5 w-5" /></span>
+          <p className="mt-6 text-xs font-bold uppercase tracking-[0.18em] text-slate-400">You’re joining live</p>
+          <h1 className="mt-2 text-2xl font-bold tracking-tight">{liveSession.title}</h1>
+          <p className="mt-3 text-sm leading-6 text-slate-500">Use your CommonLab account so your workbook responses, progress, and copilot support stay with you. After signing in, you’ll return directly to this room.</p>
+          <div className="mt-7 grid gap-2">
+            <Link href={`/auth/signup?callbackUrl=${encodeURIComponent(callbackUrl)}`} className="rounded-xl bg-slate-950 px-5 py-3 text-center text-sm font-bold text-white">Create an account</Link>
+            <Link href={`/auth/signin?callbackUrl=${encodeURIComponent(callbackUrl)}`} className="rounded-xl border border-slate-200 px-5 py-3 text-center text-sm font-bold text-slate-700 hover:bg-slate-50">I already have an account</Link>
+          </div>
+        </section>
+      </main>
+    );
+  }
+  return <LiveLearnerRoom sessionId={id} />;
+}

--- a/apps/commons-courses/components/educator/course-dashboard-shell.tsx
+++ b/apps/commons-courses/components/educator/course-dashboard-shell.tsx
@@ -19,6 +19,7 @@ import {
   Menu,
   PanelLeftClose,
   PanelLeftOpen,
+  Radio,
   Users,
   X,
 } from "lucide-react";
@@ -39,6 +40,7 @@ const navGroups = [
       { label: "Dashboard", href: "", icon: LayoutDashboard },
       { label: "Course info", href: "edit", icon: FileText },
       { label: "Content", href: "content", icon: BookOpen },
+      { label: "Live sessions", href: "live", icon: Radio },
       { label: "Experiences", href: "experiences", icon: Gamepad2 },
       { label: "Skill badges", href: "skills", icon: Award },
       { label: "Assignments", href: "assignments", icon: ClipboardList },

--- a/apps/commons-courses/components/educator/live-facilitator-studio.tsx
+++ b/apps/commons-courses/components/educator/live-facilitator-studio.tsx
@@ -1,0 +1,359 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  ArrowDown,
+  ArrowUp,
+  BarChart3,
+  BookOpen,
+  Check,
+  ChevronRight,
+  CircleStop,
+  Clipboard,
+  ExternalLink,
+  GripVertical,
+  Link2,
+  LoaderCircle,
+  LockKeyhole,
+  MonitorUp,
+  MoreHorizontal,
+  Play,
+  Plus,
+  QrCode,
+  Radio,
+  Save,
+  Settings2,
+  Trash2,
+  Users,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type {
+  LiveActivity,
+  LiveActivityResults,
+  LiveActivityType,
+  LiveParticipantRecord,
+  LiveSessionRecord,
+} from "@/types/live-session";
+
+type StudioData = {
+  session: LiveSessionRecord;
+  participants: LiveParticipantRecord[];
+  results: Record<string, LiveActivityResults>;
+};
+
+const activityChoices: Array<{ type: LiveActivityType; label: string; hint: string }> = [
+  { type: "content", label: "Workbook page", hint: "Notes, examples, and resources" },
+  { type: "setup_check", label: "Setup check", hint: "Catch blockers before teaching" },
+  { type: "poll", label: "Poll", hint: "Diagnostic, pulse, or opinion" },
+  { type: "quiz", label: "Quiz", hint: "Retrieval with a correct answer" },
+  { type: "reflection", label: "Reflection", hint: "Open response or exit ticket" },
+  { type: "task", label: "Practice task", hint: "Instructions and evidence hand-in" },
+  { type: "break", label: "Break", hint: "Keep timing visible" },
+];
+
+export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
+  const [data, setData] = useState<StudioData | null>(null);
+  const [tab, setTab] = useState<"plan" | "facilitate" | "share">("plan");
+  const [selectedId, setSelectedId] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [notice, setNotice] = useState("");
+  const [addOpen, setAddOpen] = useState(false);
+
+  const load = useCallback(async (quiet = false) => {
+    if (!quiet) setNotice("");
+    const res = await fetch(`/api/educator/live-sessions/${sessionId}`, { cache: "no-store" });
+    const next = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      if (!quiet) setNotice(next.error || "Could not load this session.");
+      return;
+    }
+    setData(next);
+    setSelectedId((current) => current || next.session.activities[0]?.id || "");
+  }, [sessionId]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => void load(), 0);
+    return () => window.clearTimeout(timer);
+  }, [load]);
+  useEffect(() => {
+    if (data?.session.status !== "live" && data?.session.status !== "lobby") return;
+    const interval = window.setInterval(() => void load(true), 3000);
+    return () => window.clearInterval(interval);
+  }, [data?.session.status, load]);
+
+  const selected = data?.session.activities.find((activity) => activity.id === selectedId);
+  const current = data?.session.activities.find((activity) => activity.id === data.session.currentActivityId);
+  const currentIndex = current ? data!.session.activities.findIndex((activity) => activity.id === current.id) : -1;
+  const nextActivity = data?.session.activities[currentIndex + 1];
+
+  function updateSession(patch: Partial<LiveSessionRecord>) {
+    setData((currentData) => currentData ? { ...currentData, session: { ...currentData.session, ...patch } } : currentData);
+  }
+
+  function updateActivity(activityId: string, patch: Partial<LiveActivity>) {
+    if (!data) return;
+    updateSession({ activities: data.session.activities.map((activity) => activity.id === activityId ? { ...activity, ...patch } : activity) });
+  }
+
+  async function savePlan() {
+    if (!data || saving) return;
+    setSaving(true);
+    setNotice("");
+    const res = await fetch(`/api/educator/live-sessions/${sessionId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: data.session.title,
+        description: data.session.description,
+        pace: data.session.pace,
+        access: data.session.access,
+        invitedEmails: data.session.invitedEmails,
+        scheduledStart: data.session.scheduledStart,
+        settings: data.session.settings,
+        activities: data.session.activities,
+      }),
+    });
+    const next = await res.json().catch(() => ({}));
+    if (res.ok) {
+      setData((value) => value ? { ...value, session: next.session } : value);
+      setNotice("Session plan saved.");
+    } else setNotice(next.error || "Could not save the session plan.");
+    setSaving(false);
+  }
+
+  async function command(commandName: string, activityId?: string) {
+    if (running) return;
+    setRunning(true);
+    setNotice("");
+    const res = await fetch(`/api/educator/live-sessions/${sessionId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ command: commandName, activityId }),
+    });
+    const next = await res.json().catch(() => ({}));
+    if (res.ok) {
+      await load(true);
+      if (commandName === "open_lobby") setTab("share");
+      if (commandName === "start" || commandName === "activate") setTab("facilitate");
+    } else setNotice(next.error || "Could not update the live room.");
+    setRunning(false);
+  }
+
+  function addActivity(type: LiveActivityType) {
+    if (!data) return;
+    const id = crypto.randomUUID();
+    const label = activityChoices.find((choice) => choice.type === type)?.label || "Activity";
+    const activity: LiveActivity = {
+      id,
+      type,
+      title: `New ${label.toLowerCase()}`,
+      status: "draft",
+      required: false,
+      randomizeOptions: type === "quiz",
+      showResults: type === "poll" || type === "quiz" || type === "setup_check",
+      points: type === "quiz" ? 1 : 0,
+      options: ["poll", "quiz", "setup_check"].includes(type)
+        ? [
+            { id: crypto.randomUUID(), label: "Option 1", isCorrect: type === "quiz" },
+            { id: crypto.randomUUID(), label: "Option 2", isCorrect: false },
+          ]
+        : [],
+    };
+    updateSession({ activities: [...data.session.activities, activity] });
+    setSelectedId(id);
+    setAddOpen(false);
+  }
+
+  function moveActivity(id: string, direction: -1 | 1) {
+    if (!data) return;
+    const activities = [...data.session.activities];
+    const index = activities.findIndex((activity) => activity.id === id);
+    const nextIndex = index + direction;
+    if (index < 0 || nextIndex < 0 || nextIndex >= activities.length) return;
+    [activities[index], activities[nextIndex]] = [activities[nextIndex], activities[index]];
+    updateSession({ activities });
+  }
+
+  function removeActivity(id: string) {
+    if (!data) return;
+    const activities = data.session.activities.filter((activity) => activity.id !== id);
+    updateSession({ activities });
+    setSelectedId(activities[0]?.id || "");
+  }
+
+  if (!data) {
+    return <div className="rounded-2xl border border-slate-200 bg-white p-12 text-center text-sm text-slate-500">{notice || "Loading live session…"}</div>;
+  }
+
+  const joinPath = `/live/${data.session.id}`;
+  const joinUrl = typeof window === "undefined" ? joinPath : `${window.location.origin}${joinPath}`;
+  const joinPortal = typeof window === "undefined" ? "/join" : `${window.location.origin}/join`;
+
+  return (
+    <div className="space-y-5" data-copilot-target="live-facilitation-studio">
+      <header className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <SessionStatus status={data.session.status} />
+            <span className="text-xs text-slate-400">Code {formatCode(data.session.joinCode)}</span>
+          </div>
+          <h2 className="mt-2 truncate text-2xl font-bold tracking-tight text-slate-950">{data.session.title}</h2>
+          <p className="mt-1 text-sm text-slate-500">{data.session.activities.length} activities · {data.session.participantCount} learners joined</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {data.session.status === "draft" ? (
+            <button onClick={() => command("open_lobby")} disabled={running} className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-bold text-slate-700 hover:bg-slate-50">
+              <MonitorUp className="h-4 w-4" /> Open lobby
+            </button>
+          ) : null}
+          {data.session.status === "lobby" ? (
+            <button onClick={() => command("start")} disabled={running || !data.session.activities.length} className="inline-flex items-center gap-2 rounded-xl bg-slate-950 px-4 py-2.5 text-sm font-bold text-white disabled:opacity-40">
+              <Play className="h-4 w-4" /> Start session
+            </button>
+          ) : null}
+          {data.session.status === "live" ? (
+            <button onClick={() => command("end")} disabled={running} className="inline-flex items-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-bold text-red-700 hover:bg-red-50">
+              <CircleStop className="h-4 w-4" /> End session
+            </button>
+          ) : null}
+        </div>
+      </header>
+
+      <div className="flex gap-1 overflow-x-auto rounded-xl border border-slate-200 bg-white p-1.5">
+        <Tab active={tab === "plan"} onClick={() => setTab("plan")} icon={BookOpen}>Plan</Tab>
+        <Tab active={tab === "facilitate"} onClick={() => setTab("facilitate")} icon={Radio}>Facilitate</Tab>
+        <Tab active={tab === "share"} onClick={() => setTab("share")} icon={QrCode}>Invite learners</Tab>
+      </div>
+
+      {notice ? <div className={cn("rounded-xl px-4 py-3 text-sm", notice.includes("saved") ? "bg-emerald-50 text-emerald-700" : "bg-amber-50 text-amber-800")}>{notice}</div> : null}
+
+      {tab === "plan" ? (
+        <div className="grid gap-5 xl:grid-cols-[340px_minmax(0,1fr)]">
+          <aside className="rounded-2xl border border-slate-200 bg-white p-3">
+            <div className="flex items-center justify-between px-2 py-2">
+              <div><p className="text-sm font-bold text-slate-950">Run of show</p><p className="text-xs text-slate-400">Learners see this as a workbook</p></div>
+              <button onClick={() => setAddOpen((value) => !value)} className="rounded-lg bg-slate-950 p-2 text-white" aria-label="Add activity"><Plus className="h-4 w-4" /></button>
+            </div>
+            {addOpen ? <AddMenu onAdd={addActivity} /> : null}
+            <div className="mt-2 space-y-1">
+              {data.session.activities.map((activity, index) => (
+                <button key={activity.id} onClick={() => setSelectedId(activity.id)} className={cn("group flex w-full items-center gap-2 rounded-xl px-2 py-2.5 text-left", selectedId === activity.id ? "bg-slate-950 text-white" : "hover:bg-slate-50")}>
+                  <GripVertical className={cn("h-4 w-4 shrink-0", selectedId === activity.id ? "text-slate-500" : "text-slate-300")} />
+                  <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-white/10 text-[10px] font-bold">{index + 1}</span>
+                  <span className="min-w-0 flex-1"><span className="block truncate text-sm font-bold">{activity.title}</span><span className={cn("block text-[10px] uppercase tracking-wide", selectedId === activity.id ? "text-slate-400" : "text-slate-400")}>{activityLabel(activity.type)}{activity.estimatedMinutes ? ` · ${activity.estimatedMinutes} min` : ""}</span></span>
+                  <ChevronRight className="h-3.5 w-3.5 shrink-0 opacity-40" />
+                </button>
+              ))}
+              {!data.session.activities.length ? <p className="px-3 py-8 text-center text-sm text-slate-400">Add the first learning moment.</p> : null}
+            </div>
+          </aside>
+
+          <div className="space-y-5">
+            <section className="rounded-2xl border border-slate-200 bg-white p-5 sm:p-6">
+              <div className="flex items-center justify-between"><div><p className="text-sm font-bold text-slate-950">Session settings</p><p className="text-xs text-slate-400">One room, adaptable delivery</p></div><Settings2 className="h-4 w-4 text-slate-300" /></div>
+              <div className="mt-5 grid gap-4 md:grid-cols-2">
+                <Field label="Session title"><input value={data.session.title} onChange={(event) => updateSession({ title: event.target.value })} className={inputClass} /></Field>
+                <Field label="Delivery pace"><select value={data.session.pace} onChange={(event) => updateSession({ pace: event.target.value as LiveSessionRecord["pace"] })} className={inputClass}><option value="facilitator">Facilitator controls each step</option><option value="learner">Learners move at their own pace</option></select></Field>
+                <Field label="Who can join"><select value={data.session.access} onChange={(event) => updateSession({ access: event.target.value as LiveSessionRecord["access"] })} className={inputClass}><option value="enrolled">Enrolled learners</option><option value="invited">Invited email addresses</option><option value="open">Anyone with the link</option></select></Field>
+                <Field label="Scheduled start"><input type="datetime-local" value={toDateTimeLocal(data.session.scheduledStart)} onChange={(event) => updateSession({ scheduledStart: event.target.value ? new Date(event.target.value).toISOString() : undefined })} className={inputClass} /></Field>
+              </div>
+              {data.session.access === "invited" ? <Field label="Invited emails"><textarea value={data.session.invitedEmails.join("\n")} onChange={(event) => updateSession({ invitedEmails: event.target.value.split(/[\n,;]/).map((email) => email.trim()).filter(Boolean) })} rows={3} placeholder="one@email.com" className={`${inputClass} mt-2 resize-y`} /></Field> : null}
+              <div className="mt-4 flex flex-wrap gap-4"><Toggle checked={data.session.settings.allowLateJoin} onChange={(value) => updateSession({ settings: { ...data.session.settings, allowLateJoin: value } })} label="Allow late join" /><Toggle checked={data.session.settings.showParticipantNames} onChange={(value) => updateSession({ settings: { ...data.session.settings, showParticipantNames: value } })} label="Names in private results" /><Toggle checked={data.session.settings.showLeaderboard} onChange={(value) => updateSession({ settings: { ...data.session.settings, showLeaderboard: value } })} label="Leaderboard" /></div>
+            </section>
+
+            {selected ? <ActivityEditor activity={selected} index={data.session.activities.findIndex((activity) => activity.id === selected.id)} onChange={(patch) => updateActivity(selected.id, patch)} onMove={(direction) => moveActivity(selected.id, direction)} onRemove={() => removeActivity(selected.id)} /> : null}
+            <div className="sticky bottom-4 flex justify-end"><button onClick={savePlan} disabled={saving} className="inline-flex items-center gap-2 rounded-xl bg-slate-950 px-5 py-3 text-sm font-bold text-white shadow-lg disabled:opacity-50">{saving ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />} Save plan</button></div>
+          </div>
+        </div>
+      ) : null}
+
+      {tab === "facilitate" ? (
+        <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_320px]">
+          <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
+            {current ? (
+              <>
+                <div className="border-b border-slate-100 p-6 sm:p-8">
+                  <div className="flex items-center justify-between gap-3"><span className="rounded-full bg-red-50 px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest text-red-700">Open now</span><span className="text-xs text-slate-400">{current.estimatedMinutes ? `${current.estimatedMinutes} min` : activityLabel(current.type)}</span></div>
+                  <p className="mt-6 text-xs font-bold uppercase tracking-[0.18em] text-slate-400">{activityLabel(current.type)}</p>
+                  <h3 className="mt-2 text-3xl font-bold tracking-tight text-slate-950">{current.title}</h3>
+                  {current.prompt ? <p className="mt-4 text-lg leading-8 text-slate-700">{current.prompt}</p> : null}
+                  {current.facilitatorNotes ? <div className="mt-6 rounded-xl bg-amber-50 p-4"><p className="text-[10px] font-bold uppercase tracking-wide text-amber-700">Private facilitator note</p><p className="mt-1 text-sm leading-6 text-amber-900">{current.facilitatorNotes}</p></div> : null}
+                </div>
+                <LiveResults activity={current} results={data.results[current.id]} responses={data.session.responseCounts[current.id] || 0} participants={data.session.participantCount} />
+                <div className="flex flex-col gap-3 border-t border-slate-100 bg-slate-50 p-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+                  <button onClick={() => command("close_activity", current.id)} disabled={running || current.status === "closed"} className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-bold text-slate-700 disabled:opacity-40"><LockKeyhole className="h-4 w-4" /> Close responses</button>
+                  {nextActivity ? <button onClick={() => command("activate", nextActivity.id)} disabled={running} className="inline-flex items-center justify-center gap-2 rounded-xl bg-slate-950 px-5 py-2.5 text-sm font-bold text-white">Next: {nextActivity.title}<ChevronRight className="h-4 w-4" /></button> : <button onClick={() => command("end")} disabled={running} className="inline-flex items-center justify-center gap-2 rounded-xl bg-slate-950 px-5 py-2.5 text-sm font-bold text-white"><Check className="h-4 w-4" /> Finish session</button>}
+                </div>
+              </>
+            ) : (
+              <div className="p-12 text-center"><Radio className="mx-auto h-7 w-7 text-slate-300" /><h3 className="mt-4 text-lg font-bold text-slate-900">The room is ready</h3><p className="mt-2 text-sm text-slate-500">Open the lobby, invite learners, then start when the room is settled.</p>{data.session.status === "draft" ? <button onClick={() => command("open_lobby")} className="mt-5 rounded-xl bg-slate-950 px-5 py-2.5 text-sm font-bold text-white">Open lobby</button> : data.session.status === "lobby" ? <button onClick={() => command("start")} className="mt-5 rounded-xl bg-slate-950 px-5 py-2.5 text-sm font-bold text-white">Start first activity</button> : null}</div>
+            )}
+          </section>
+          <aside className="space-y-5">
+            <section className="rounded-2xl border border-slate-200 bg-white p-5"><div className="flex items-center justify-between"><h3 className="text-sm font-bold text-slate-950">Room</h3><Users className="h-4 w-4 text-slate-300" /></div><div className="mt-4 flex items-end justify-between"><div><p className="text-3xl font-bold text-slate-950">{data.session.participantCount}</p><p className="text-xs text-slate-400">learners joined</p></div><button onClick={() => setTab("share")} className="text-xs font-bold text-slate-700 hover:text-slate-950">Show join screen</button></div><div className="mt-4 max-h-64 space-y-2 overflow-y-auto">{data.participants.map((participant) => <div key={participant.id} className="flex items-center gap-2 rounded-lg bg-slate-50 px-3 py-2"><span className="h-2 w-2 rounded-full bg-emerald-400" /><span className="truncate text-xs font-medium text-slate-700">{participant.displayName}</span></div>)}</div></section>
+            <section className="rounded-2xl border border-slate-200 bg-white p-5"><h3 className="text-sm font-bold text-slate-950">Run of show</h3><div className="mt-3 space-y-1">{data.session.activities.map((activity, index) => <button key={activity.id} onClick={() => command("activate", activity.id)} disabled={data.session.status === "ended"} className={cn("flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left", activity.id === current?.id ? "bg-slate-950 text-white" : "hover:bg-slate-50")}><span className="text-[10px] font-bold opacity-50">{String(index + 1).padStart(2, "0")}</span><span className="min-w-0 flex-1 truncate text-xs font-bold">{activity.title}</span>{activity.status === "closed" ? <Check className="h-3.5 w-3.5 text-emerald-500" /> : null}</button>)}</div></section>
+          </aside>
+        </div>
+      ) : null}
+
+      {tab === "share" ? (
+        <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_360px]">
+          <section className="flex min-h-[440px] flex-col items-center justify-center rounded-2xl bg-slate-950 p-8 text-center text-white sm:p-12">
+            <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#71E0E7]">Join the live session</p>
+            <h3 className="mt-4 max-w-2xl text-3xl font-bold tracking-tight sm:text-4xl">{data.session.title}</h3>
+            <div className="mt-8 grid items-center gap-8 sm:grid-cols-[220px_1fr] sm:text-left">
+              <div className="rounded-2xl bg-white p-3">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={`https://quickchart.io/qr?size=420&margin=1&text=${encodeURIComponent(joinUrl)}`} alt={`QR code to join ${data.session.title}`} className="aspect-square w-full" />
+              </div>
+              <div><p className="text-sm text-slate-400">Scan the QR code, or visit</p><p className="mt-1 break-all text-lg font-bold">{joinPortal}</p><p className="mt-6 text-sm text-slate-400">Enter code</p><p className="mt-1 text-5xl font-bold tracking-[0.16em] text-[#B8F56D]">{formatCode(data.session.joinCode)}</p></div>
+            </div>
+          </section>
+          <aside className="space-y-5">
+            <section className="rounded-2xl border border-slate-200 bg-white p-5"><h3 className="text-sm font-bold text-slate-950">Share options</h3><div className="mt-4 space-y-2"><CopyButton label="Copy direct join link" value={joinUrl} icon={Link2} /><CopyButton label="Copy six-digit code" value={data.session.joinCode} icon={Clipboard} /><a href={joinUrl} target="_blank" className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-sm font-bold text-slate-700 hover:bg-slate-50"><ExternalLink className="h-4 w-4" /> Preview learner view</a></div></section>
+            <section className="rounded-2xl border border-slate-200 bg-white p-5"><h3 className="text-sm font-bold text-slate-950">Join policy</h3><dl className="mt-4 space-y-3 text-xs"><ShareRow label="Access" value={data.session.access === "open" ? "Anyone with link" : data.session.access === "invited" ? "Invited emails" : "Enrolled learners"} /><ShareRow label="Pace" value={data.session.pace === "facilitator" ? "You control it" : "Learners control it"} /><ShareRow label="Late join" value={data.session.settings.allowLateJoin ? "Allowed" : "Locked after start"} /></dl></section>
+          </aside>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+const inputClass = "mt-2 w-full rounded-xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-800 outline-none focus:border-slate-400";
+
+function Tab({ active, onClick, icon: Icon, children }: { active: boolean; onClick: () => void; icon: typeof Radio; children: React.ReactNode }) { return <button onClick={onClick} className={cn("inline-flex min-w-max items-center gap-2 rounded-lg px-4 py-2 text-sm font-bold", active ? "bg-slate-950 text-white" : "text-slate-500 hover:bg-slate-50 hover:text-slate-900")}><Icon className="h-4 w-4" />{children}</button>; }
+function Field({ label, children }: { label: string; children: React.ReactNode }) { return <label className="block text-xs font-bold uppercase tracking-wide text-slate-600">{label}{children}</label>; }
+function Toggle({ checked, onChange, label }: { checked: boolean; onChange: (value: boolean) => void; label: string }) { return <label className="inline-flex cursor-pointer items-center gap-2 text-xs font-bold text-slate-600"><button type="button" role="switch" aria-checked={checked} onClick={() => onChange(!checked)} className={cn("relative h-5 w-9 rounded-full transition", checked ? "bg-slate-950" : "bg-slate-200")}><span className={cn("absolute top-0.5 h-4 w-4 rounded-full bg-white transition", checked ? "left-[18px]" : "left-0.5")} /></button>{label}</label>; }
+
+function AddMenu({ onAdd }: { onAdd: (type: LiveActivityType) => void }) { return <div className="mb-3 grid gap-1 rounded-xl border border-slate-200 bg-slate-50 p-2">{activityChoices.map((choice) => <button key={choice.type} onClick={() => onAdd(choice.type)} className="rounded-lg px-3 py-2 text-left hover:bg-white"><span className="block text-xs font-bold text-slate-800">{choice.label}</span><span className="block text-[10px] text-slate-400">{choice.hint}</span></button>)}</div>; }
+
+function ActivityEditor({ activity, index, onChange, onMove, onRemove }: { activity: LiveActivity; index: number; onChange: (patch: Partial<LiveActivity>) => void; onMove: (direction: -1 | 1) => void; onRemove: () => void }) {
+  function updateOption(id: string, patch: Partial<LiveActivity["options"][number]>) { onChange({ options: activity.options.map((option) => option.id === id ? { ...option, ...patch } : option) }); }
+  function addOption() { onChange({ options: [...activity.options, { id: crypto.randomUUID(), label: `Option ${activity.options.length + 1}`, isCorrect: false }] }); }
+  return <section className="rounded-2xl border border-slate-200 bg-white p-5 sm:p-6">
+    <div className="flex flex-wrap items-center justify-between gap-3"><div><p className="text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400">Activity {index + 1} · {activityLabel(activity.type)}</p><h3 className="mt-1 text-lg font-bold text-slate-950">Design the learning moment</h3></div><div className="flex gap-1"><IconButton label="Move up" onClick={() => onMove(-1)} icon={ArrowUp} /><IconButton label="Move down" onClick={() => onMove(1)} icon={ArrowDown} /><IconButton label="Remove" onClick={onRemove} icon={Trash2} danger /></div></div>
+    <div className="mt-5 grid gap-4 md:grid-cols-2"><Field label="Activity type"><select value={activity.type} onChange={(event) => onChange({ type: event.target.value as LiveActivityType })} className={inputClass}>{activityChoices.map((choice) => <option key={choice.type} value={choice.type}>{choice.label}</option>)}</select></Field><Field label="Estimated time"><input type="number" min={1} value={activity.estimatedMinutes || ""} onChange={(event) => onChange({ estimatedMinutes: Number(event.target.value) || undefined })} className={inputClass} /></Field></div>
+    <Field label="Title"><input value={activity.title} onChange={(event) => onChange({ title: event.target.value })} className={inputClass} /></Field>
+    <Field label="Prompt or key idea"><textarea rows={3} value={activity.prompt || ""} onChange={(event) => onChange({ prompt: event.target.value })} className={`${inputClass} resize-y`} /></Field>
+    <Field label="Learner instructions"><textarea rows={4} value={activity.instructions || ""} onChange={(event) => onChange({ instructions: event.target.value })} className={`${inputClass} resize-y`} /></Field>
+    {(activity.type === "task" || activity.type === "reflection") ? <Field label="Success criteria"><textarea rows={2} value={activity.successCriteria || ""} onChange={(event) => onChange({ successCriteria: event.target.value })} className={`${inputClass} resize-y`} /></Field> : null}
+    <Field label="Private facilitator notes"><textarea rows={2} value={activity.facilitatorNotes || ""} onChange={(event) => onChange({ facilitatorNotes: event.target.value })} className={`${inputClass} resize-y`} /></Field>
+    <div className="mt-4 grid gap-4 md:grid-cols-2"><Field label="Resource link"><input type="url" value={activity.resourceUrl || ""} onChange={(event) => onChange({ resourceUrl: event.target.value })} placeholder="https://…" className={inputClass} /></Field>{activity.type === "quiz" ? <Field label="Points"><input type="number" min={0} value={activity.points} onChange={(event) => onChange({ points: Number(event.target.value) || 0 })} className={inputClass} /></Field> : null}</div>
+    {["poll", "quiz", "setup_check"].includes(activity.type) ? <div className="mt-5 rounded-xl border border-slate-200 p-4"><div className="flex items-center justify-between"><p className="text-xs font-bold uppercase tracking-wide text-slate-600">Response options</p><button onClick={addOption} className="inline-flex items-center gap-1 text-xs font-bold text-slate-700"><Plus className="h-3.5 w-3.5" /> Add option</button></div><div className="mt-3 space-y-2">{activity.options.map((option) => <div key={option.id} className="flex items-center gap-2"><button type="button" onClick={() => activity.type === "quiz" && updateOption(option.id, { isCorrect: !option.isCorrect })} className={cn("flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border", option.isCorrect ? "border-emerald-500 bg-emerald-50 text-emerald-700" : "border-slate-200 text-slate-300")} title={activity.type === "quiz" ? "Mark correct answer" : undefined}>{activity.type === "quiz" ? <Check className="h-4 w-4" /> : <MoreHorizontal className="h-4 w-4" />}</button><input value={option.label} onChange={(event) => updateOption(option.id, { label: event.target.value })} className="min-w-0 flex-1 rounded-lg border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-400" /><button onClick={() => onChange({ options: activity.options.filter((item) => item.id !== option.id) })} className="p-2 text-slate-300 hover:text-red-600"><Trash2 className="h-4 w-4" /></button></div>)}</div><div className="mt-4 flex flex-wrap gap-4"><Toggle checked={activity.randomizeOptions} onChange={(value) => onChange({ randomizeOptions: value })} label="Shuffle per learner" /><Toggle checked={activity.showResults} onChange={(value) => onChange({ showResults: value })} label="Reveal results after close" /></div></div> : null}
+    <div className="mt-5 flex flex-wrap gap-4"><Toggle checked={activity.required} onChange={(value) => onChange({ required: value })} label="Required activity" /></div>
+  </section>;
+}
+
+function LiveResults({ activity, results, responses, participants }: { activity: LiveActivity; results?: LiveActivityResults; responses: number; participants: number }) {
+  const rate = participants ? Math.round((responses / participants) * 100) : 0;
+  return <div className="p-6 sm:p-8"><div className="flex items-center justify-between"><div><p className="text-sm font-bold text-slate-950">Live responses</p><p className="mt-1 text-xs text-slate-400">{responses} of {participants} · {rate}% responded</p></div><BarChart3 className="h-5 w-5 text-slate-300" /></div><div className="mt-3 h-2 overflow-hidden rounded-full bg-slate-100"><div className="h-full rounded-full bg-[#71E0E7] transition-all" style={{ width: `${rate}%` }} /></div>{activity.options.length ? <div className="mt-6 space-y-3">{activity.options.map((option) => { const count = results?.options?.find((item) => item.id === option.id)?.count || 0; const width = responses ? Math.round((count / responses) * 100) : 0; return <div key={option.id}><div className="flex justify-between gap-3 text-xs"><span className="font-medium text-slate-700">{option.label}</span><span className="text-slate-400">{count} · {width}%</span></div><div className="mt-1.5 h-7 overflow-hidden rounded-md bg-slate-100"><div className={cn("h-full rounded-md transition-all", option.isCorrect ? "bg-[#B8F56D]" : "bg-slate-300")} style={{ width: `${width}%` }} /></div></div>; })}</div> : results?.textResponses?.length ? <div className="mt-5 grid gap-2 sm:grid-cols-2">{results.textResponses.slice(-20).map((response) => <div key={response.id} className="rounded-xl bg-slate-50 p-3"><p className="text-sm leading-6 text-slate-700">{response.value}</p>{response.participantName ? <p className="mt-1 text-[10px] font-bold uppercase text-slate-400">{response.participantName}</p> : null}</div>)}</div> : <div className="mt-6 rounded-xl border border-dashed border-slate-200 p-8 text-center text-sm text-slate-400">Responses will appear here.</div>}</div>;
+}
+
+function IconButton({ label, onClick, icon: Icon, danger }: { label: string; onClick: () => void; icon: typeof ArrowUp; danger?: boolean }) { return <button type="button" aria-label={label} title={label} onClick={onClick} className={cn("rounded-lg border border-slate-200 p-2 text-slate-500 hover:bg-slate-50", danger && "hover:border-red-200 hover:bg-red-50 hover:text-red-600")}><Icon className="h-4 w-4" /></button>; }
+function SessionStatus({ status }: { status: LiveSessionRecord["status"] }) { return <span className={cn("inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest", status === "live" ? "bg-red-50 text-red-700" : status === "lobby" ? "bg-cyan-50 text-cyan-700" : status === "ended" ? "bg-slate-100 text-slate-500" : "bg-amber-50 text-amber-700")}><span className={cn("h-1.5 w-1.5 rounded-full", status === "live" ? "animate-pulse bg-red-500" : "bg-current")} />{status}</span>; }
+function CopyButton({ label, value, icon: Icon }: { label: string; value: string; icon: typeof Link2 }) { const [copied, setCopied] = useState(false); return <button onClick={async () => { await navigator.clipboard.writeText(value); setCopied(true); window.setTimeout(() => setCopied(false), 1500); }} className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-left text-sm font-bold text-slate-700 hover:bg-slate-50"><Icon className="h-4 w-4" /><span className="flex-1">{copied ? "Copied" : label}</span>{copied ? <Check className="h-4 w-4 text-emerald-500" /> : null}</button>; }
+function ShareRow({ label, value }: { label: string; value: string }) { return <div className="flex justify-between gap-4"><dt className="text-slate-400">{label}</dt><dd className="text-right font-bold text-slate-700">{value}</dd></div>; }
+function activityLabel(type: LiveActivityType) { return activityChoices.find((choice) => choice.type === type)?.label || type; }
+function formatCode(code: string) { return `${code.slice(0, 3)} ${code.slice(3)}`; }
+function toDateTimeLocal(value?: string) { if (!value) return ""; const date = new Date(value); const local = new Date(date.getTime() - date.getTimezoneOffset() * 60_000); return local.toISOString().slice(0, 16); }

--- a/apps/commons-courses/components/educator/live-session-manager.tsx
+++ b/apps/commons-courses/components/educator/live-session-manager.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import {
+  ArrowRight,
+  CalendarClock,
+  CheckCircle2,
+  LoaderCircle,
+  Plus,
+  Radio,
+  Sparkles,
+  Users,
+} from "lucide-react";
+import type { LiveSessionRecord } from "@/types/live-session";
+
+export function LiveSessionManager({
+  courseSlug,
+  courseTitle,
+}: {
+  courseSlug: string;
+  courseTitle: string;
+}) {
+  const [sessions, setSessions] = useState<LiveSessionRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [title, setTitle] = useState(`${courseTitle} · live workshop`);
+  const [template, setTemplate] = useState<"facilitated_workshop" | "blank">(
+    "facilitated_workshop",
+  );
+  const [notice, setNotice] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const res = await fetch(`/api/educator/courses/${courseSlug}/live-sessions`);
+    const data = await res.json().catch(() => ({}));
+    if (res.ok) setSessions(data.sessions || []);
+    else setNotice(data.error || "Could not load live sessions.");
+    setLoading(false);
+  }, [courseSlug]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => void load(), 0);
+    return () => window.clearTimeout(timer);
+  }, [load]);
+
+  async function createSession() {
+    if (!title.trim() || creating) return;
+    setCreating(true);
+    setNotice("");
+    const res = await fetch(`/api/educator/courses/${courseSlug}/live-sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title, template }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.ok && data.session) {
+      window.location.href = `/educator/courses/${courseSlug}/live/${data.session.id}`;
+      return;
+    }
+    setNotice(data.error || "Could not create the session.");
+    setCreating(false);
+  }
+
+  return (
+    <div className="space-y-7" data-copilot-target="live-session-library">
+      <header className="flex flex-col justify-between gap-4 sm:flex-row sm:items-end">
+        <div>
+          <p className="text-xs font-bold uppercase tracking-[0.18em] text-slate-400">
+            Facilitation
+          </p>
+          <h2 className="mt-2 text-3xl font-bold tracking-tight text-slate-950">
+            Live sessions
+          </h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-500">
+            Turn course material into a paced room with a learner workbook,
+            setup checks, practice, polls, quizzes, and evidence capture.
+          </p>
+        </div>
+        <span className="inline-flex items-center gap-2 rounded-full bg-[#71E0E7]/20 px-3 py-1.5 text-xs font-bold text-slate-700">
+          <Radio className="h-3.5 w-3.5" /> In person or hybrid
+        </span>
+      </header>
+
+      <section className="grid overflow-hidden rounded-2xl border border-slate-200 bg-white lg:grid-cols-[1.05fr_.95fr]">
+        <div className="p-6 sm:p-8">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-slate-950 text-white">
+            <Plus className="h-5 w-5" />
+          </div>
+          <h3 className="mt-5 text-xl font-bold text-slate-950">Prepare a room</h3>
+          <p className="mt-2 text-sm leading-6 text-slate-500">
+            Start with a proven workshop rhythm or build a clean run-of-show from scratch.
+          </p>
+          <label className="mt-6 block text-xs font-bold uppercase tracking-wide text-slate-600">
+            Session title
+            <input
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              className="mt-2 w-full rounded-xl border border-slate-200 px-4 py-3 text-sm font-medium outline-none focus:border-slate-400"
+            />
+          </label>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <TemplateChoice
+              active={template === "facilitated_workshop"}
+              title="Workshop rhythm"
+              body="Setup, diagnostic, content, practice, retrieval, break, and exit reflection."
+              onClick={() => setTemplate("facilitated_workshop")}
+            />
+            <TemplateChoice
+              active={template === "blank"}
+              title="Blank room"
+              body="Start clean and add only the activities this learning moment needs."
+              onClick={() => setTemplate("blank")}
+            />
+          </div>
+          {notice ? <p className="mt-4 text-sm text-red-600">{notice}</p> : null}
+          <button
+            type="button"
+            onClick={createSession}
+            disabled={creating || !title.trim()}
+            className="mt-5 inline-flex items-center gap-2 rounded-xl bg-slate-950 px-5 py-3 text-sm font-bold text-white disabled:opacity-50"
+          >
+            {creating ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+            Create session
+          </button>
+        </div>
+        <div className="border-t border-slate-200 bg-slate-50 p-6 sm:p-8 lg:border-l lg:border-t-0">
+          <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-400">
+            One coherent learning system
+          </p>
+          <div className="mt-5 space-y-5">
+            <Feature title="Before the room" body="Run setup checks and diagnostics before teaching time is lost." />
+            <Feature title="During the room" body="Control the pace, reveal one activity at a time, and see participation live." />
+            <Feature title="After the room" body="Keep learner work and results attached to the course instead of scattered across tools." />
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-lg font-bold text-slate-950">Session library</h3>
+          <span className="text-xs font-medium text-slate-400">{sessions.length} total</span>
+        </div>
+        {loading ? (
+          <div className="rounded-2xl border border-slate-200 bg-white p-10 text-center text-sm text-slate-500">
+            Loading sessions…
+          </div>
+        ) : sessions.length ? (
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {sessions.map((session) => (
+              <Link
+                key={session.id}
+                href={`/educator/courses/${courseSlug}/live/${session.id}`}
+                className="group rounded-2xl border border-slate-200 bg-white p-5 transition hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-md"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <Status value={session.status} />
+                  <ArrowRight className="h-4 w-4 text-slate-300 transition group-hover:translate-x-0.5 group-hover:text-slate-700" />
+                </div>
+                <h4 className="mt-4 text-base font-bold text-slate-950">{session.title}</h4>
+                <div className="mt-5 flex flex-wrap gap-x-4 gap-y-2 text-xs text-slate-500">
+                  <span className="inline-flex items-center gap-1.5"><CheckCircle2 className="h-3.5 w-3.5" />{session.activities.length} activities</span>
+                  <span className="inline-flex items-center gap-1.5"><Users className="h-3.5 w-3.5" />{session.participantCount} joined</span>
+                  <span className="inline-flex items-center gap-1.5"><CalendarClock className="h-3.5 w-3.5" />{session.pace === "facilitator" ? "Facilitator paced" : "Learner paced"}</span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-10 text-center">
+            <Radio className="mx-auto h-6 w-6 text-slate-300" />
+            <p className="mt-3 text-sm font-bold text-slate-800">No live rooms yet</p>
+            <p className="mt-1 text-sm text-slate-500">Create one above and shape it around your session.</p>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function TemplateChoice({ active, title, body, onClick }: { active: boolean; title: string; body: string; onClick: () => void }) {
+  return (
+    <button type="button" onClick={onClick} className={`rounded-xl border p-4 text-left transition ${active ? "border-slate-950 bg-slate-950 text-white" : "border-slate-200 hover:border-slate-300"}`}>
+      <span className="text-sm font-bold">{title}</span>
+      <span className={`mt-1 block text-xs leading-5 ${active ? "text-slate-300" : "text-slate-500"}`}>{body}</span>
+    </button>
+  );
+}
+
+function Feature({ title, body }: { title: string; body: string }) {
+  return <div className="border-l-2 border-[#71E0E7] pl-4"><p className="text-sm font-bold text-slate-900">{title}</p><p className="mt-1 text-sm leading-6 text-slate-500">{body}</p></div>;
+}
+
+function Status({ value }: { value: LiveSessionRecord["status"] }) {
+  const styles = value === "live" ? "bg-red-50 text-red-700" : value === "lobby" ? "bg-cyan-50 text-cyan-700" : value === "ended" ? "bg-slate-100 text-slate-500" : "bg-amber-50 text-amber-700";
+  return <span className={`rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-wide ${styles}`}>{value}</span>;
+}

--- a/apps/commons-courses/components/live/join-live-session.tsx
+++ b/apps/commons-courses/components/live/join-live-session.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import Link from "next/link";
+import { ArrowRight, FlaskConical, LoaderCircle, Radio } from "lucide-react";
+
+export function JoinLiveSession() {
+  const [code, setCode] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [notice, setNotice] = useState("");
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    const cleanCode = code.replace(/\D/g, "");
+    if (cleanCode.length !== 6 || loading) return;
+    setLoading(true);
+    setNotice("");
+    const res = await fetch("/api/live-sessions/resolve", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code: cleanCode }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.ok && data.sessionId) {
+      window.location.href = `/live/${data.sessionId}`;
+      return;
+    }
+    setNotice(data.error || "We could not find that session.");
+    setLoading(false);
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-slate-950 px-5 py-12 text-white">
+      <div className="w-full max-w-md">
+        <Link href="/" className="mb-10 flex items-center justify-center gap-2.5 text-sm font-bold">
+          <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-white text-slate-950"><FlaskConical className="h-4 w-4" /></span>
+          CommonLab
+        </Link>
+        <section className="rounded-3xl bg-white p-6 text-slate-950 shadow-2xl sm:p-8">
+          <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-[#71E0E7]/25"><Radio className="h-5 w-5" /></span>
+          <p className="mt-6 text-xs font-bold uppercase tracking-[0.18em] text-slate-400">Live learning</p>
+          <h1 className="mt-2 text-3xl font-bold tracking-tight">Join your session</h1>
+          <p className="mt-3 text-sm leading-6 text-slate-500">Enter the six-digit code on the facilitator’s screen. You’ll go straight to the right room.</p>
+          <form onSubmit={submit} className="mt-7">
+            <label className="block text-xs font-bold uppercase tracking-wide text-slate-600">Session code
+              <input
+                autoFocus
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                aria-label="Six-digit session code"
+                value={formatInput(code)}
+                onChange={(event) => setCode(event.target.value.replace(/\D/g, "").slice(0, 6))}
+                placeholder="123 456"
+                className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-4 text-center text-3xl font-bold tracking-[0.16em] outline-none focus:border-slate-500"
+              />
+            </label>
+            {notice ? <p className="mt-3 text-sm text-red-600">{notice}</p> : null}
+            <button disabled={code.length !== 6 || loading} className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-slate-950 px-5 py-3.5 text-sm font-bold text-white disabled:opacity-40">
+              {loading ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
+              Continue
+            </button>
+          </form>
+        </section>
+        <p className="mt-5 text-center text-xs leading-5 text-slate-400">Scanning the session QR code skips this step.</p>
+      </div>
+    </main>
+  );
+}
+
+function formatInput(code: string) {
+  const clean = code.replace(/\D/g, "").slice(0, 6);
+  return clean.length > 3 ? `${clean.slice(0, 3)} ${clean.slice(3)}` : clean;
+}
+

--- a/apps/commons-courses/components/live/live-learner-room.tsx
+++ b/apps/commons-courses/components/live/live-learner-room.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  CheckCircle2,
+  Clock3,
+  ExternalLink,
+  FlaskConical,
+  LoaderCircle,
+  LockKeyhole,
+  Radio,
+  Send,
+  Sparkles,
+  Users,
+} from "lucide-react";
+import { CourseAgentDrawer } from "@/components/course-agents/course-agent-drawer";
+import { cn } from "@/lib/utils";
+import type { LearnerLiveSession, LiveActivity, LiveResponseRecord } from "@/types/live-session";
+
+export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
+  const [session, setSession] = useState<LearnerLiveSession | null>(null);
+  const [selectedId, setSelectedId] = useState("");
+  const [values, setValues] = useState<Record<string, string | string[]>>({});
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [notice, setNotice] = useState("");
+
+  const load = useCallback(async (quiet = false) => {
+    if (!quiet) setLoading(true);
+    const res = await fetch(`/api/live-sessions/${sessionId}`, { cache: "no-store" });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      setNotice(data.error || "Could not enter this live session.");
+      if (!quiet) setLoading(false);
+      return;
+    }
+    const next = data.session as LearnerLiveSession;
+    setSession(next);
+    const desired = next.pace === "facilitator" ? next.currentActivityId : selectedId || next.activities[0]?.id;
+    setSelectedId(desired || "");
+    setValues((current) => ({ ...Object.fromEntries(Object.values(next.responses).map((response) => [response.activityId, response.value])), ...current }));
+    setNotice("");
+    if (!quiet) setLoading(false);
+  }, [selectedId, sessionId]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => void load(), 0);
+    return () => window.clearTimeout(timer);
+  }, [sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (!session || session.status === "ended") return;
+    const interval = window.setInterval(() => void load(true), 3000);
+    return () => window.clearInterval(interval);
+  }, [load, session]);
+
+  const activity = session?.activities.find((item) => item.id === selectedId);
+  const activityIndex = session?.activities.findIndex((item) => item.id === selectedId) ?? -1;
+  const response = activity ? session?.responses[activity.id] : undefined;
+  const availableActivities = useMemo(() => session?.activities.filter((item) => item.status !== "draft") || [], [session?.activities]);
+
+  async function submit(valueOverride?: string | string[]) {
+    if (!activity || submitting) return;
+    const value = valueOverride ?? values[activity.id];
+    if ((typeof value === "string" && !value.trim()) || value === undefined) return;
+    setSubmitting(true);
+    setNotice("");
+    const res = await fetch(`/api/live-sessions/${sessionId}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ activityId: activity.id, value }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.ok) {
+      setSession((current) => current ? { ...current, responses: { ...current.responses, [activity.id]: data.response as LiveResponseRecord } } : current);
+      if (session?.pace === "learner") goNext();
+    } else setNotice(data.error || "Could not save your response.");
+    setSubmitting(false);
+  }
+
+  function goNext() {
+    if (!session) return;
+    const index = availableActivities.findIndex((item) => item.id === selectedId);
+    const next = availableActivities[index + 1];
+    if (next) setSelectedId(next.id);
+  }
+
+  if (loading) return <Centered message="Entering the live room…" />;
+  if (!session) return <Centered message={notice || "This session is unavailable."} error />;
+  if (session.status === "lobby") {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-slate-950 px-5 py-12 text-white">
+        <div className="w-full max-w-lg text-center"><span className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-white/10"><Radio className="h-6 w-6 text-[#71E0E7]" /></span><p className="mt-8 text-xs font-bold uppercase tracking-[0.22em] text-[#71E0E7]">You’re in the room</p><h1 className="mt-3 text-3xl font-bold tracking-tight sm:text-4xl">{session.title}</h1><p className="mt-4 text-sm leading-6 text-slate-400">The facilitator will begin shortly. Keep this page open; your workbook will update automatically.</p><div className="mx-auto mt-8 inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-xs font-bold text-slate-300"><Users className="h-4 w-4" />{session.participantCount} joined</div><LoaderCircle className="mx-auto mt-8 h-5 w-5 animate-spin text-slate-500" /></div>
+      </main>
+    );
+  }
+
+  if (session.status === "ended" && !activity) return <Centered message="This live session has ended. Your responses are saved with your course." />;
+
+  return (
+    <main className="min-h-screen bg-slate-50 text-slate-950">
+      <header className="sticky top-0 z-30 border-b border-slate-200 bg-white/95 backdrop-blur">
+        <div className="mx-auto flex h-16 max-w-6xl items-center gap-3 px-4 sm:px-6">
+          <Link href="/dashboard" className="flex h-9 w-9 items-center justify-center rounded-lg bg-slate-950 text-white"><FlaskConical className="h-4 w-4" /></Link>
+          <div className="min-w-0 flex-1"><p className="truncate text-sm font-bold">{session.title}</p><p className="text-[10px] font-bold uppercase tracking-widest text-red-600">{session.status === "ended" ? "Session ended" : "Live now"}</p></div>
+          <span className="hidden items-center gap-1.5 text-xs text-slate-400 sm:inline-flex"><Users className="h-3.5 w-3.5" />{session.participantCount}</span>
+        </div>
+      </header>
+      <div className="mx-auto grid max-w-6xl gap-6 px-4 py-6 sm:px-6 lg:grid-cols-[250px_minmax(0,1fr)] lg:py-10">
+        <aside className="hidden lg:block"><div className="sticky top-24 rounded-2xl border border-slate-200 bg-white p-3"><p className="px-2 py-2 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400">Your workbook</p><div className="mt-1 space-y-1">{session.activities.map((item, index) => { const locked = item.status === "draft"; const done = Boolean(session.responses[item.id]); return <button key={item.id} disabled={locked || session.pace === "facilitator"} onClick={() => setSelectedId(item.id)} className={cn("flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left", item.id === activity?.id ? "bg-slate-950 text-white" : locked ? "text-slate-300" : "text-slate-600 hover:bg-slate-50")}><span className="text-[10px] font-bold opacity-50">{String(index + 1).padStart(2, "0")}</span><span className="min-w-0 flex-1 truncate text-xs font-bold">{item.title}</span>{locked ? <LockKeyhole className="h-3.5 w-3.5" /> : done ? <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" /> : null}</button>; })}</div></div></aside>
+        <section className="min-w-0">
+          <div className="mb-4 flex items-center justify-between text-xs text-slate-400"><span>Activity {activityIndex + 1} of {session.activities.length}</span>{activity?.estimatedMinutes ? <span className="inline-flex items-center gap-1.5"><Clock3 className="h-3.5 w-3.5" />{activity.estimatedMinutes} min</span> : null}</div>
+          {activity ? <LearnerActivity activity={activity} learnerSeed={session.participant.id} value={values[activity.id]} response={response} submitting={submitting} onChange={(value) => setValues((current) => ({ ...current, [activity.id]: value }))} onSubmit={submit} /> : <div className="rounded-2xl border border-slate-200 bg-white p-12 text-center"><LoaderCircle className="mx-auto h-5 w-5 animate-spin text-slate-300" /><p className="mt-4 text-sm text-slate-500">Waiting for the facilitator to open the next activity…</p></div>}
+          {notice ? <p className="mt-4 rounded-xl bg-amber-50 px-4 py-3 text-sm text-amber-800">{notice}</p> : null}
+          {session.pace === "learner" && activity ? <div className="mt-5 flex justify-between"><button disabled={availableActivities.findIndex((item) => item.id === activity.id) <= 0} onClick={() => { const index = availableActivities.findIndex((item) => item.id === activity.id); setSelectedId(availableActivities[index - 1]?.id || activity.id); }} className="inline-flex items-center gap-2 text-sm font-bold text-slate-500 disabled:opacity-30"><ArrowLeft className="h-4 w-4" /> Previous</button><button onClick={goNext} className="inline-flex items-center gap-2 text-sm font-bold text-slate-700">Next <ArrowRight className="h-4 w-4" /></button></div> : null}
+        </section>
+      </div>
+      <CourseAgentDrawer courseSlug={session.courseSlug} role="learner" context={{ page: "live_session", title: activity?.title || session.title, visibleText: [activity?.prompt, activity?.instructions, activity?.successCriteria].filter(Boolean).join("\n") }} />
+    </main>
+  );
+}
+
+function LearnerActivity({ activity, learnerSeed, value, response, submitting, onChange, onSubmit }: { activity: LiveActivity; learnerSeed: string; value?: string | string[]; response?: LiveResponseRecord; submitting: boolean; onChange: (value: string | string[]) => void; onSubmit: (valueOverride?: string | string[]) => void }) {
+  const isChoice = activity.options.length > 0;
+  const result = activity.status === "closed" && activity.showResults;
+  return <article className="overflow-hidden rounded-2xl border border-slate-200 bg-white"><div className="p-6 sm:p-9"><div className="flex items-center justify-between"><span className="rounded-full bg-[#71E0E7]/20 px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest text-slate-700">{labelFor(activity.type)}</span>{activity.required ? <span className="text-[10px] font-bold uppercase tracking-wide text-slate-400">Required</span> : null}</div><h1 className="mt-6 text-3xl font-bold tracking-tight text-slate-950">{activity.title}</h1>{activity.prompt ? <p className="mt-4 text-lg leading-8 text-slate-700">{activity.prompt}</p> : null}{activity.instructions ? <div className="mt-6 whitespace-pre-wrap rounded-xl bg-slate-50 p-4 text-sm leading-7 text-slate-600">{activity.instructions}</div> : null}{activity.successCriteria ? <div className="mt-4 border-l-2 border-[#B8F56D] pl-4"><p className="text-[10px] font-bold uppercase tracking-wide text-slate-400">Done when</p><p className="mt-1 text-sm leading-6 text-slate-700">{activity.successCriteria}</p></div> : null}{activity.resourceUrl ? <a href={activity.resourceUrl} target="_blank" rel="noreferrer" className="mt-5 inline-flex items-center gap-2 text-sm font-bold text-slate-700 underline underline-offset-4">Open activity resource <ExternalLink className="h-4 w-4" /></a> : null}</div>
+    {isChoice ? <div className="border-t border-slate-100 bg-slate-50 p-5 sm:p-7"><div className="grid gap-3 sm:grid-cols-2">{orderedOptions(activity, learnerSeed).map((option) => { const selected = value === option.id || (Array.isArray(value) && value.includes(option.id)); return <button key={option.id} disabled={activity.status !== "open" || Boolean(response)} onClick={() => onChange(option.id)} className={cn("min-h-16 rounded-xl border bg-white p-4 text-left text-sm font-bold transition", selected ? "border-slate-950 ring-1 ring-slate-950" : "border-slate-200 hover:border-slate-400", result && option.isCorrect && "border-emerald-500 bg-emerald-50 ring-1 ring-emerald-500", response && !result && "disabled:opacity-70")}>{option.label}{result && option.isCorrect ? <Check className="ml-2 inline h-4 w-4 text-emerald-600" /> : null}</button>; })}</div>{response ? <Saved /> : <button onClick={() => onSubmit()} disabled={!value || submitting || activity.status !== "open"} className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-slate-950 px-5 py-3 text-sm font-bold text-white disabled:opacity-40">{submitting ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />} Submit response</button>}</div> : activity.type === "content" || activity.type === "break" ? <div className="border-t border-slate-100 bg-slate-50 p-5 sm:p-7">{response ? <Saved /> : <button onClick={() => onSubmit("complete")} disabled={submitting || activity.status !== "open"} className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-slate-950 px-5 py-3 text-sm font-bold text-white disabled:opacity-40"><Check className="h-4 w-4" /> {activity.type === "break" ? "I’m back" : "Mark as viewed"}</button>}</div> : <div className="border-t border-slate-100 bg-slate-50 p-5 sm:p-7"><textarea value={typeof value === "string" ? value : ""} onChange={(event) => onChange(event.target.value)} disabled={activity.status !== "open" || Boolean(response)} rows={6} placeholder={activity.type === "task" ? "Add a short response, link, or note about your artefact…" : "Write your response…"} className="w-full resize-y rounded-xl border border-slate-200 bg-white p-4 text-sm leading-6 outline-none focus:border-slate-400 disabled:bg-slate-100" />{response ? <Saved /> : <button onClick={() => onSubmit()} disabled={!value || submitting || activity.status !== "open"} className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-slate-950 px-5 py-3 text-sm font-bold text-white disabled:opacity-40">{submitting ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />} Save response</button>}</div>}</article>;
+}
+
+function Saved() { return <div className="mt-3 flex items-center justify-center gap-2 rounded-xl bg-emerald-50 px-4 py-3 text-sm font-bold text-emerald-700"><CheckCircle2 className="h-4 w-4" /> Response saved</div>; }
+function Centered({ message, error }: { message: string; error?: boolean }) { return <main className="flex min-h-screen items-center justify-center bg-slate-950 px-5 text-center text-white"><div><span className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-white/10">{error ? <LockKeyhole className="h-5 w-5 text-amber-300" /> : <Sparkles className="h-5 w-5 text-[#71E0E7]" />}</span><p className="mt-5 max-w-md text-sm leading-6 text-slate-300">{message}</p>{error ? <Link href="/join" className="mt-5 inline-block text-sm font-bold text-white underline">Try another code</Link> : null}</div></main>; }
+function orderedOptions(activity: LiveActivity, learnerSeed: string) { if (!activity.randomizeOptions) return activity.options; return [...activity.options].sort((a, b) => seeded(`${learnerSeed}:${activity.id}:${a.id}`) - seeded(`${learnerSeed}:${activity.id}:${b.id}`)); }
+function seeded(value: string) { let hash = 0; for (let i = 0; i < value.length; i += 1) hash = ((hash << 5) - hash + value.charCodeAt(i)) | 0; return Math.abs(hash); }
+function labelFor(type: LiveActivity["type"]) { return ({ content: "Workbook", setup_check: "Setup check", poll: "Quick poll", quiz: "Knowledge check", reflection: "Reflection", task: "Practice", break: "Break" } as const)[type]; }

--- a/apps/commons-courses/docs/live-learning.md
+++ b/apps/commons-courses/docs/live-learning.md
@@ -1,0 +1,55 @@
+# Live learning in Commons Courses
+
+Live sessions are a delivery layer inside a course, not a separate course type. A self-paced or cohort course can use any combination of lessons, skill paths, assignments, immersive experiences, and live rooms.
+
+## Product model
+
+Each room has three durable records:
+
+- `LiveSession`: the reusable run of show and the facilitator-controlled room state.
+- `LiveParticipant`: authenticated presence and re-entry for one learner.
+- `LiveResponse`: one resumable response per learner and activity.
+
+The activity vocabulary is intentionally small and composable:
+
+- workbook page
+- setup check
+- poll
+- quiz
+- reflection
+- practice task
+- break
+
+Facilitator-paced rooms reveal one activity at a time. Learner-paced rooms open the run of show as a workbook. The same session plan therefore works for an in-person workshop, a hybrid cohort, a guided lab, or an asynchronous follow-up.
+
+## Access and entry
+
+Educators can admit enrolled learners, invited email addresses, or anyone with the room link. Every room has a temporary six-digit code, a direct URL, and a QR code. Authentication preserves the intended `/live/<session>` callback, so a first-time learner returns to the room immediately after account creation.
+
+Answer correctness is evaluated on the server. Correct options and aggregate results are not sent to learners until the activity is closed and result reveal is enabled. Randomized options use the learner ID as part of their stable order.
+
+## Facilitation principles
+
+The default workshop rhythm comes directly from the workshop review used to design this feature:
+
+1. Resolve setup blockers before teaching starts.
+2. Capture a short opening diagnostic.
+3. Keep teaching segments concise and give learners a shared follow-along page.
+4. Attach observable success criteria to practice.
+5. Use retrieval and progressive reveal before showing an answer.
+6. Make breaks and transitions visible in the run of show.
+7. Collect exit evidence and a concrete next step.
+
+The educator copilot can read live-room participation, use the current page as facilitation context, and create an approval-gated live plan from uploaded source material. The learner copilot receives only the currently visible activity and is instructed not to move ahead of the facilitator.
+
+## Patterns borrowed, not cloned
+
+- [Kahoot live hosting](https://support.kahoot.com/hc/en-us/articles/360039422694-How-to-host-a-live-kahoot) validates a lobby with a PIN, direct link, QR entry, late join, and post-session reports.
+- [Kahoot assignments](https://support.kahoot.com/hc/en-us/articles/360039411334-How-to-assign-a-kahoot-in-web-platform) distinguishes host-paced delivery from learner-paced work and keeps the same link/code/QR entry model.
+- [Pear Deck session entry](https://help.peardeck.com/migration/en/how-students-join-a-pear-deck-session) demonstrates why the educator must choose between identified login and lower-friction anonymous entry. Commons keeps identity because learner work, access, and copilot personalization need a durable owner, while making account creation return directly to the room.
+- [Pear Deck presenting](https://help.peardeck.com/migration/en/how-to-present-a-pear-deck) supports the private-dashboard/shared-projector split used in the facilitator console.
+- [Mentimeter QR sharing](https://help.mentimeter.com/en/articles/422271-share-the-qr-code) supports showing join instructions again at any point in a presentation.
+- [Wooclap self-paced sessions](https://docs.wooclap.com/en/articles/674825-self-paced-session) supports using an opening diagnostic and letting learners practise independently before a shared correction or debrief.
+
+The Commons distinction is that these patterns sit inside the existing course, identity, enrollment, evidence, and copilot system. Educators should not need a separate quiz product, workbook product, and classroom-management product to facilitate one coherent learning experience.
+

--- a/apps/commons-courses/lib/course-agent-runtime.ts
+++ b/apps/commons-courses/lib/course-agent-runtime.ts
@@ -78,6 +78,8 @@ function fallbackCourseAgentReply(input: RuntimeInput) {
       : null;
   const currentPlace = lesson
     ? `You are in "${lesson.title}" in ${input.course.title}.`
+    : input.context.page === "live_session"
+      ? `You are supporting the learner during the live activity "${input.context.title || "Current activity"}" in ${input.course.title}.`
     : `You are in ${input.context.title || input.context.page} for ${input.course.title}.`;
 
   if (input.role === "learner") {
@@ -104,6 +106,7 @@ function buildRunMessages(input: RuntimeInput) {
           "Act as a learning copilot, not an answer machine.",
           "First identify the learner's current understanding or goal when it is unclear.",
           "Use a short cycle: orient, ask or model one step, invite the learner to try, then give feedback.",
+          "During a live session, stay aligned with the currently visible activity, help resolve setup blockers, and use hints before direct answers. Do not move the learner ahead of the facilitator.",
           "Prefer retrieval prompts, hints, worked analogies, and reflection before a full direct answer.",
           "Adapt examples only from the explicit learner profile. State when an example is an added contextual aid, and preserve the educator's original meaning.",
           "Never describe the learner as a fixed learning-style category.",

--- a/apps/commons-courses/lib/educator-copilot-agent.ts
+++ b/apps/commons-courses/lib/educator-copilot-agent.ts
@@ -120,6 +120,14 @@ export function buildCopilotInstructions({
     ].join("\n"),
 
     [
+      "Live and in-person facilitation:",
+      "- Use list_live_sessions when the educator asks about a live room, participation, the run of show, response coverage, or what needs attention before or during delivery.",
+      "- When asked to turn a deck, outline, or course into a live workshop, read the attachment and current course first, then call create_live_session with a complete facilitation plan. In manual mode, make clear it is queued for approval.",
+      "- The course live-session studio harmonizes paced workbook pages, setup checks, polls, quizzes, practice tasks, reflections, breaks, access control, join codes, and QR entry. Guide educators there with navigate when appropriate.",
+      "- When the live-session page is open, use its visible activity, learner count, response count, and facilitator notes to offer concise in-the-moment support. Do not distract the facilitator with a broad redesign during delivery.",
+    ].join("\n"),
+
+    [
       "Memory and personalization:",
       "- When the educator states a durable preference (tone, structure, quiz style, pacing, terminology) or an important fact about their teaching, save it with remember so future sessions honor it.",
       "- Notice recurring editing choices and teaching patterns. Once a pattern is clear, save a short, specific procedural memory instead of making the educator repeat it.",

--- a/apps/commons-courses/lib/educator-copilot-policy.ts
+++ b/apps/commons-courses/lib/educator-copilot-policy.ts
@@ -13,6 +13,9 @@ export const EDUCATOR_COPILOT_PEDAGOGY = [
   "When creating sandbox activities, keep the task achievable in the current learning sandbox. Simulate expensive or infrastructure-heavy runtimes with scoped, inspectable lightweight environments.",
   "Avoid filler phrases such as 'this matters because'. Show why through the example or scenario.",
   "Do not force a quiz on a pure introduction or orientation. If an introduction is combined with the first substantive concept, quiz only the taught concept.",
+  "For live and in-person learning, design a run of show rather than a content dump: setup check, diagnostic, short teaching moments, guided practice, retrieval, debrief, and exit evidence as appropriate.",
+  "Give hands-on activities realistic timing, explicit learner instructions, observable success criteria, and short private facilitator notes. Use progressive reveal for questions and answers.",
+  "Treat quizzes, polls, reflections, tasks, breaks, workbook pages, immersive experiences, assignments, and skill paths as complementary learning modalities. Recommend the smallest set that serves the learning outcome.",
 ].join("\n");
 
 export const EDUCATOR_COPILOT_SAFETY = [

--- a/apps/commons-courses/lib/educator-copilot-runtime.ts
+++ b/apps/commons-courses/lib/educator-copilot-runtime.ts
@@ -41,6 +41,7 @@ const TOOL_LABELS: Record<string, string> = {
   get_student: "Looking up a student",
   get_course_analytics: "Crunching analytics",
   list_assignments: "Checking assignments and reviews",
+  list_live_sessions: "Checking live sessions",
   read_attachment: "Reading attached file",
   update_lesson: "Drafting a lesson edit",
   add_lesson: "Drafting a new lesson",
@@ -51,6 +52,7 @@ const TOOL_LABELS: Record<string, string> = {
   update_skill_path: "Drafting a skill path edit",
   update_skill_challenge: "Drafting a challenge edit",
   update_experience_world: "Validating a world edit",
+  create_live_session: "Designing a live session",
   navigate: "Preparing navigation",
   highlight: "Locating page element",
   remember: "Saving a preference",
@@ -189,7 +191,7 @@ export async function buildWorkspaceSnapshot({
     ].join("\n")
   );
   lines.push(
-    "- Per course: /educator/courses/<slug> (dashboard), /content (modules & lessons editor), /experiences (immersive worlds), /skills (skill paths), /students, /assignments, /analytics, /edit (course settings), /collaborators, /payments, /access, /notifications"
+    "- Per course: /educator/courses/<slug> (dashboard), /content (modules & lessons editor), /live (live and in-person sessions), /experiences (immersive worlds), /skills (skill paths), /students, /assignments, /analytics, /edit (course settings), /collaborators, /payments, /access, /notifications"
   );
 
   if (pageContext) {

--- a/apps/commons-courses/lib/educator-copilot-tools.ts
+++ b/apps/commons-courses/lib/educator-copilot-tools.ts
@@ -10,11 +10,15 @@ import {
 } from "@/lib/experience-ai";
 import { normalizeExperienceDocument } from "@/lib/experience-schema";
 import { uploadCourseMediaToS3 } from "@/lib/media-storage";
+import { createJoinCode, normalizeActivities } from "@/lib/live-session-input";
 import { indexCourseForSearch } from "@/lib/search-indexers";
 import Assignment from "@/models/Assignment";
 import Course from "@/models/Course";
 import Enrollment from "@/models/Enrollment";
 import ExperienceProject from "@/models/ExperienceProject";
+import LiveParticipant from "@/models/LiveParticipant";
+import LiveResponse from "@/models/LiveResponse";
+import LiveSession from "@/models/LiveSession";
 import Submission from "@/models/Submission";
 import type { IEducatorCopilotMaterial } from "@/models/EducatorCopilotSession";
 import type {
@@ -24,6 +28,7 @@ import type {
   EducatorCopilotPageContext,
 } from "@/types/educator-copilot";
 import type { SkillChallenge, SkillPack, SkillQuestion } from "@/types/skills";
+import type { LiveActivity } from "@/types/live-session";
 
 /** JSON-schema tool catalog handed to the agent run as cliTools. */
 export type CopilotToolDefinition = {
@@ -235,6 +240,22 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
     },
   },
   {
+    name: "list_live_sessions",
+    description:
+      "List live and in-person course sessions with their run of show, room status, join code, participation, and response counts. Use this for facilitation prep, live room checks, and post-session reflection.",
+    parameters: {
+      type: "object",
+      properties: {
+        courseSlug: { type: "string", description: "Optional course slug from list_courses" },
+        status: {
+          type: "string",
+          enum: ["draft", "lobby", "live", "ended"],
+        },
+      },
+      required: [],
+    },
+  },
+  {
     name: "read_attachment",
     description:
       "Read the full extracted text of a file the educator uploaded in this chat session. Use whenever the educator refers to an uploaded file.",
@@ -261,6 +282,66 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
         reason: { type: "string", description: "One line: why this change helps" },
       },
       required: ["courseSlug", "moduleIndex", "lessonIndex", "patch"],
+    },
+  },
+  {
+    name: "create_live_session",
+    description:
+      "Create a complete live or in-person facilitation plan for a managed course. Use after reading source material and the course. Build an intentional run of show from workbook pages, setup checks, polls, quizzes, reflections, practice tasks, and breaks. This is approval-gated in manual mode.",
+    parameters: {
+      type: "object",
+      properties: {
+        courseSlug: { type: "string" },
+        title: { type: "string" },
+        description: { type: "string" },
+        pace: { type: "string", enum: ["facilitator", "learner"] },
+        access: { type: "string", enum: ["enrolled", "invited", "open"] },
+        activities: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              type: {
+                type: "string",
+                enum: [
+                  "content",
+                  "setup_check",
+                  "poll",
+                  "quiz",
+                  "reflection",
+                  "task",
+                  "break",
+                ],
+              },
+              title: { type: "string" },
+              prompt: { type: "string" },
+              instructions: { type: "string" },
+              successCriteria: { type: "string" },
+              facilitatorNotes: { type: "string" },
+              resourceUrl: { type: "string" },
+              estimatedMinutes: { type: "number" },
+              required: { type: "boolean" },
+              randomizeOptions: { type: "boolean" },
+              showResults: { type: "boolean" },
+              points: { type: "number" },
+              options: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    label: { type: "string" },
+                    isCorrect: { type: "boolean" },
+                  },
+                  required: ["label"],
+                },
+              },
+            },
+            required: ["type", "title"],
+          },
+        },
+        reason: { type: "string" },
+      },
+      required: ["courseSlug", "title", "activities"],
     },
   },
   {
@@ -563,6 +644,8 @@ async function runTool(
       return toolCourseAnalytics(ctx, args);
     case "list_assignments":
       return toolListAssignments(ctx, args);
+    case "list_live_sessions":
+      return toolListLiveSessions(ctx, args);
     case "read_attachment":
       return toolReadAttachment(ctx, args);
     case "update_lesson":
@@ -573,6 +656,7 @@ async function runTool(
     case "create_skill_path":
     case "update_skill_path":
     case "update_skill_challenge":
+    case "create_live_session":
       return toolContentWrite(ctx, name, args);
     case "update_experience_world":
       return toolExperienceWrite(ctx, args);
@@ -815,6 +899,98 @@ async function toolListExperiences(
         assetCount: document.assets.length,
         studioHref: `/educator/experience-studio/${String(project._id)}`,
         updatedAt: project.updatedAt,
+      };
+    }),
+  };
+}
+
+async function toolListLiveSessions(
+  ctx: CopilotToolContext,
+  args: Record<string, unknown>,
+) {
+  const courseSlug = cleanString(args.courseSlug);
+  const status = cleanString(args.status);
+  const courses = await Course.find({
+    ...(courseSlug ? { slug: courseSlug } : {}),
+    ...managedFilter(ctx.user),
+  })
+    .select("_id title slug")
+    .lean();
+  if (!courses.length) {
+    return {
+      error: courseSlug
+        ? `No managed course with slug "${courseSlug}".`
+        : "No managed courses were found.",
+    };
+  }
+  const courseById = new Map(
+    courses.map((course) => [String(course._id), course]),
+  );
+  const sessions = await LiveSession.find({
+    courseId: { $in: courses.map((course) => course._id) },
+    ...(status && ["draft", "lobby", "live", "ended"].includes(status)
+      ? { status }
+      : {}),
+  })
+    .sort({ updatedAt: -1 })
+    .limit(80)
+    .lean();
+  const sessionIds = sessions.map((session) => session._id);
+  const [participantRows, responseRows] = await Promise.all([
+    LiveParticipant.aggregate([
+      { $match: { sessionId: { $in: sessionIds } } },
+      { $group: { _id: "$sessionId", count: { $sum: 1 } } },
+    ]),
+    LiveResponse.aggregate([
+      { $match: { sessionId: { $in: sessionIds } } },
+      { $group: { _id: { sessionId: "$sessionId", activityId: "$activityId" }, count: { $sum: 1 } } },
+    ]),
+  ]);
+  const participantsBySession = new Map(
+    participantRows.map((row: { _id: Types.ObjectId; count: number }) => [
+      String(row._id),
+      row.count,
+    ]),
+  );
+  const responsesBySession = new Map<string, Map<string, number>>();
+  for (const row of responseRows as Array<{
+    _id: { sessionId: Types.ObjectId; activityId: string };
+    count: number;
+  }>) {
+    const key = String(row._id.sessionId);
+    const counts = responsesBySession.get(key) || new Map<string, number>();
+    counts.set(row._id.activityId, row.count);
+    responsesBySession.set(key, counts);
+  }
+  return {
+    totalSessions: sessions.length,
+    sessions: sessions.map((session) => {
+      const course = courseById.get(String(session.courseId));
+      const responseCounts = responsesBySession.get(String(session._id));
+      return {
+        sessionId: String(session._id),
+        title: session.title,
+        courseTitle: course?.title,
+        courseSlug: course?.slug,
+        status: session.status,
+        pace: session.pace,
+        access: session.access,
+        joinCode: session.joinCode,
+        participants: participantsBySession.get(String(session._id)) || 0,
+        scheduledStart: session.scheduledStart,
+        currentActivityId: session.currentActivityId,
+        activities: session.activities.map((activity: LiveActivity, index: number) => ({
+          index,
+          id: activity.id,
+          type: activity.type,
+          title: activity.title,
+          status: activity.status,
+          estimatedMinutes: activity.estimatedMinutes,
+          required: activity.required,
+          responses: responseCounts?.get(activity.id) || 0,
+        })),
+        facilitatorHref: `/educator/courses/${course?.slug}/live/${String(session._id)}`,
+        updatedAt: session.updatedAt,
       };
     }),
   };
@@ -1350,7 +1526,8 @@ type ContentWriteAction = Extract<
       | "update_course_overview"
       | "create_skill_path"
       | "update_skill_path"
-      | "update_skill_challenge";
+      | "update_skill_challenge"
+      | "create_live_session";
   }
 >;
 
@@ -1367,6 +1544,38 @@ function buildContentAction(
     status: "proposed" as const,
     safety: "content_write" as const,
   };
+
+  if (name === "create_live_session") {
+    const title = cleanString(args.title);
+    const activities = normalizeActivities(args.activities);
+    if (!title || !activities.length) return null;
+    const pace = args.pace === "learner" ? "learner" : "facilitator";
+    const access =
+      args.access === "open" || args.access === "invited"
+        ? args.access
+        : "enrolled";
+    return {
+      ...base,
+      type: "create_live_session",
+      label: `Create live session “${title}”`,
+      courseSlug,
+      session: {
+        title,
+        description: cleanString(args.description),
+        pace,
+        access,
+        activities,
+      },
+      preview: activities
+        .map(
+          (activity, index) =>
+            `${index + 1}. ${activity.title} · ${activity.type}${
+              activity.estimatedMinutes ? ` · ${activity.estimatedMinutes} min` : ""
+            }`,
+        )
+        .join("\n"),
+    };
+  }
 
   if (name === "update_lesson") {
     const patch = sanitizeLessonPatch(args.patch);
@@ -1691,6 +1900,27 @@ export async function applyEducatorCopilotAction({
   }
 
   try {
+    if (action.type === "create_live_session") {
+      let joinCode = createJoinCode();
+      while (await LiveSession.exists({ joinCode })) joinCode = createJoinCode();
+      const liveSession = await LiveSession.create({
+        ...action.session,
+        courseId: course._id,
+        courseSlug: course.slug,
+        joinCode,
+        settings: {
+          allowLateJoin: true,
+          showParticipantNames: false,
+          showLeaderboard: false,
+        },
+        createdBy: user.id,
+      });
+      return {
+        ...action,
+        status: "applied",
+        result: `Created the live session. Review and facilitate it at /educator/courses/${course.slug}/live/${String(liveSession._id)}.`,
+      };
+    }
     switch (action.type) {
       case "update_course_lesson": {
         const modules = Array.isArray(course.modules) ? course.modules : [];

--- a/apps/commons-courses/lib/live-session-data.ts
+++ b/apps/commons-courses/lib/live-session-data.ts
@@ -1,0 +1,180 @@
+import type { Types } from "mongoose";
+import LiveParticipant from "@/models/LiveParticipant";
+import LiveResponse from "@/models/LiveResponse";
+import type { ILiveSession } from "@/models/LiveSession";
+import type {
+  LiveActivity,
+  LiveActivityResults,
+  LiveParticipantRecord,
+  LiveResponseRecord,
+  LiveSessionRecord,
+} from "@/types/live-session";
+
+type LiveSessionDocumentLike = ILiveSession & {
+  _id: Types.ObjectId;
+  courseId: Types.ObjectId;
+};
+
+export async function serializeEducatorLiveSession(
+  session: LiveSessionDocumentLike,
+  courseTitle: string,
+): Promise<LiveSessionRecord> {
+  const [participantCount, responseCountRows] = await Promise.all([
+    LiveParticipant.countDocuments({ sessionId: session._id }),
+    LiveResponse.aggregate([
+      { $match: { sessionId: session._id } },
+      { $group: { _id: "$activityId", count: { $sum: 1 } } },
+    ]),
+  ]);
+  const responseCounts = Object.fromEntries(
+    responseCountRows.map((row: { _id: string; count: number }) => [row._id, row.count]),
+  );
+  return serializeBase(session, courseTitle, participantCount, responseCounts);
+}
+
+export async function getParticipants(sessionId: Types.ObjectId) {
+  const participants = await LiveParticipant.find({ sessionId })
+    .sort({ joinedAt: 1 })
+    .lean();
+  return participants.map(
+    (participant): LiveParticipantRecord => ({
+      id: String(participant._id),
+      displayName: participant.displayName,
+      status: participant.status,
+      joinedAt: participant.joinedAt.toISOString(),
+      lastSeenAt: participant.lastSeenAt.toISOString(),
+    }),
+  );
+}
+
+export async function getSessionResults(
+  session: LiveSessionDocumentLike,
+  revealNames: boolean,
+) {
+  const responses = await LiveResponse.find({ sessionId: session._id })
+    .populate("participantId", "displayName")
+    .sort({ submittedAt: 1 })
+    .lean();
+  const results: Record<string, LiveActivityResults> = {};
+  for (const activity of session.activities) {
+    const activityResponses = responses.filter(
+      (response) => response.activityId === activity.id,
+    );
+    results[activity.id] = buildActivityResults(
+      activity,
+      activityResponses as unknown as Array<{
+        _id: Types.ObjectId;
+        value: string | string[];
+        correct?: boolean;
+        participantId?: { displayName?: string };
+      }>,
+      revealNames,
+    );
+  }
+  return results;
+}
+
+export async function getLearnerResponses(
+  sessionId: Types.ObjectId,
+  participantId: Types.ObjectId,
+) {
+  const responses = await LiveResponse.find({ sessionId, participantId }).lean();
+  return Object.fromEntries(
+    responses.map((response) => [
+      response.activityId,
+      {
+        activityId: response.activityId,
+        value: response.value as string | string[],
+        correct: response.correct,
+        pointsAwarded: response.pointsAwarded,
+        submittedAt: response.submittedAt.toISOString(),
+      } satisfies LiveResponseRecord,
+    ]),
+  );
+}
+
+export function learnerSafeActivities(activities: LiveActivity[]) {
+  return activities.map((activity) => ({
+    ...activity,
+    facilitatorNotes: undefined,
+    options: activity.options.map((option) => ({
+      id: option.id,
+      label: option.label,
+      isCorrect:
+        activity.status === "closed" && activity.showResults
+          ? Boolean(option.isCorrect)
+          : undefined,
+    })),
+  }));
+}
+
+function serializeBase(
+  session: LiveSessionDocumentLike,
+  courseTitle: string,
+  participantCount: number,
+  responseCounts: Record<string, number>,
+): LiveSessionRecord {
+  return {
+    id: String(session._id),
+    courseId: String(session.courseId),
+    courseSlug: session.courseSlug,
+    courseTitle,
+    title: session.title,
+    description: session.description,
+    joinCode: session.joinCode,
+    status: session.status,
+    pace: session.pace,
+    access: session.access,
+    invitedEmails: session.invitedEmails || [],
+    scheduledStart: session.scheduledStart?.toISOString(),
+    currentActivityId: session.currentActivityId,
+    activities: session.activities || [],
+    settings: session.settings,
+    participantCount,
+    responseCounts,
+    createdAt: session.createdAt.toISOString(),
+    updatedAt: session.updatedAt.toISOString(),
+  };
+}
+
+function buildActivityResults(
+  activity: LiveActivity,
+  responses: Array<{
+    _id: Types.ObjectId;
+    value: string | string[];
+    correct?: boolean;
+    participantId?: { displayName?: string };
+  }>,
+  revealNames: boolean,
+): LiveActivityResults {
+  if (activity.options.length) {
+    return {
+      total: responses.length,
+      correct:
+        activity.type === "quiz"
+          ? responses.filter((response) => response.correct).length
+          : undefined,
+      options: activity.options.map((option) => ({
+        id: option.id,
+        label: option.label,
+        count: responses.filter((response) => {
+          const values = Array.isArray(response.value) ? response.value : [response.value];
+          return values.includes(option.id);
+        }).length,
+      })),
+    };
+  }
+  return {
+    total: responses.length,
+    textResponses: responses.map((response) => ({
+      id: String(response._id),
+      participantName: revealNames
+        ? response.participantId?.displayName || "Learner"
+        : undefined,
+      value: Array.isArray(response.value)
+        ? response.value.join(", ")
+        : String(response.value),
+    })),
+  };
+}
+

--- a/apps/commons-courses/lib/live-session-input.ts
+++ b/apps/commons-courses/lib/live-session-input.ts
@@ -1,0 +1,258 @@
+import { randomInt, randomUUID } from "crypto";
+import type {
+  LiveActivity,
+  LiveActivityOption,
+  LiveActivityType,
+  LiveSessionAccess,
+  LiveSessionPace,
+} from "@/types/live-session";
+
+const activityTypes: LiveActivityType[] = [
+  "content",
+  "setup_check",
+  "poll",
+  "quiz",
+  "reflection",
+  "task",
+  "break",
+];
+
+export function createJoinCode() {
+  return String(randomInt(100_000, 1_000_000));
+}
+
+export function createActivity(
+  input: Partial<LiveActivity> & Pick<LiveActivity, "title" | "type">,
+): LiveActivity {
+  return {
+    id: input.id?.trim() || randomUUID(),
+    type: activityTypes.includes(input.type) ? input.type : "content",
+    title: clean(input.title) || "Untitled activity",
+    prompt: clean(input.prompt),
+    instructions: clean(input.instructions),
+    successCriteria: clean(input.successCriteria),
+    facilitatorNotes: clean(input.facilitatorNotes),
+    resourceUrl: cleanUrl(input.resourceUrl),
+    estimatedMinutes: clampNumber(input.estimatedMinutes, 1, 480),
+    status:
+      input.status === "open" || input.status === "closed"
+        ? input.status
+        : "draft",
+    required: Boolean(input.required),
+    randomizeOptions: Boolean(input.randomizeOptions),
+    showResults: Boolean(input.showResults),
+    points: clampNumber(input.points, 0, 10_000) || 0,
+    options: normalizeOptions(input.options),
+  };
+}
+
+export function normalizeActivities(input: unknown): LiveActivity[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .slice(0, 120)
+    .map((value) => {
+      if (!value || typeof value !== "object") return null;
+      const record = value as Partial<LiveActivity>;
+      const type = activityTypes.includes(record.type as LiveActivityType)
+        ? (record.type as LiveActivityType)
+        : "content";
+      return createActivity({
+        ...record,
+        type,
+        title: clean(record.title) || "Untitled activity",
+      });
+    })
+    .filter((activity): activity is LiveActivity => Boolean(activity));
+}
+
+export function normalizeSessionCreate(input: unknown) {
+  const body = input && typeof input === "object" ? (input as Record<string, unknown>) : {};
+  const title = clean(body.title) || "New live session";
+  const pace: LiveSessionPace = body.pace === "learner" ? "learner" : "facilitator";
+  const access: LiveSessionAccess =
+    body.access === "open" || body.access === "invited" ? body.access : "enrolled";
+  const template = body.template === "blank" ? "blank" : "facilitated_workshop";
+  return {
+    title,
+    description: clean(body.description),
+    pace,
+    access,
+    invitedEmails: normalizeEmails(body.invitedEmails),
+    scheduledStart: normalizeDate(body.scheduledStart),
+    activities: template === "blank" ? [] : createFacilitatedWorkshopTemplate(),
+    settings: {
+      allowLateJoin: true,
+      showParticipantNames: false,
+      showLeaderboard: false,
+    },
+  };
+}
+
+export function normalizeSessionPatch(input: unknown) {
+  const body = input && typeof input === "object" ? (input as Record<string, unknown>) : {};
+  const patch: Record<string, unknown> = {};
+  if ("title" in body) patch.title = clean(body.title) || "Untitled live session";
+  if ("description" in body) patch.description = clean(body.description);
+  if (body.pace === "facilitator" || body.pace === "learner") patch.pace = body.pace;
+  if (body.access === "enrolled" || body.access === "invited" || body.access === "open") {
+    patch.access = body.access;
+  }
+  if ("invitedEmails" in body) patch.invitedEmails = normalizeEmails(body.invitedEmails);
+  if ("scheduledStart" in body) patch.scheduledStart = normalizeDate(body.scheduledStart);
+  if ("activities" in body) patch.activities = normalizeActivities(body.activities);
+  if (body.settings && typeof body.settings === "object") {
+    const settings = body.settings as Record<string, unknown>;
+    patch.settings = {
+      allowLateJoin: settings.allowLateJoin !== false,
+      showParticipantNames: Boolean(settings.showParticipantNames),
+      showLeaderboard: Boolean(settings.showLeaderboard),
+    };
+  }
+  return patch;
+}
+
+export function createFacilitatedWorkshopTemplate(): LiveActivity[] {
+  return [
+    createActivity({
+      type: "setup_check",
+      title: "Room and setup check",
+      prompt: "Are you ready to participate?",
+      instructions:
+        "Confirm the essential account, device, and tool setup before the session moves on.",
+      facilitatorNotes:
+        "Keep this open in the lobby. Resolve blockers before starting the first teaching block.",
+      options: ["Ready", "I need help"].map(option),
+      showResults: true,
+      required: true,
+      estimatedMinutes: 5,
+    }),
+    createActivity({
+      type: "poll",
+      title: "Opening diagnostic",
+      prompt: "How confident are you with today’s topic?",
+      instructions: "Choose the response that best describes you right now.",
+      options: ["1 · New to this", "2", "3", "4", "5 · Very confident"].map(option),
+      showResults: true,
+      required: true,
+      estimatedMinutes: 3,
+    }),
+    createActivity({
+      type: "content",
+      title: "Follow along",
+      prompt: "Key ideas and examples for this teaching block.",
+      instructions:
+        "Use this page as the shared workbook. Add the material learners need while you teach.",
+      estimatedMinutes: 15,
+    }),
+    createActivity({
+      type: "task",
+      title: "Guided practice",
+      prompt: "Try the demonstrated move on the provided example.",
+      instructions: "Work individually or in pairs, then submit a short note or link to your artefact.",
+      successCriteria:
+        "You can show the completed artefact and explain one decision you made.",
+      facilitatorNotes: "Give a time check halfway through and invite one pair to share.",
+      required: true,
+      estimatedMinutes: 20,
+    }),
+    createActivity({
+      type: "quiz",
+      title: "Retrieval check",
+      prompt: "Which option best applies the idea we just practised?",
+      instructions: "Answer on your own first. We will discuss the reasoning together.",
+      options: [
+        { id: randomUUID(), label: "Add the correct answer", isCorrect: true },
+        { id: randomUUID(), label: "Add a plausible distractor", isCorrect: false },
+        { id: randomUUID(), label: "Add another plausible distractor", isCorrect: false },
+      ],
+      randomizeOptions: true,
+      showResults: true,
+      points: 1,
+      required: true,
+      estimatedMinutes: 3,
+    }),
+    createActivity({
+      type: "break",
+      title: "Break",
+      prompt: "Stand up, recharge, and return ready for the next block.",
+      facilitatorNotes: "Close this activity when the room is ready to continue.",
+      estimatedMinutes: 15,
+    }),
+    createActivity({
+      type: "reflection",
+      title: "Exit reflection",
+      prompt: "What will you apply first, and what still feels unclear?",
+      instructions: "Write one concrete next step and one question for the facilitator.",
+      showResults: false,
+      required: true,
+      estimatedMinutes: 5,
+    }),
+  ];
+}
+
+function option(label: string): LiveActivityOption {
+  return { id: randomUUID(), label, isCorrect: false };
+}
+
+function normalizeOptions(input: unknown): LiveActivityOption[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .slice(0, 20)
+    .map((value) => {
+      if (typeof value === "string") return option(value);
+      if (!value || typeof value !== "object") return null;
+      const record = value as Partial<LiveActivityOption>;
+      const label = clean(record.label);
+      if (!label) return null;
+      return {
+        id: clean(record.id) || randomUUID(),
+        label,
+        isCorrect: Boolean(record.isCorrect),
+      };
+    })
+    .filter((value): value is LiveActivityOption => Boolean(value));
+}
+
+function normalizeEmails(input: unknown) {
+  const values = Array.isArray(input)
+    ? input
+    : typeof input === "string"
+      ? input.split(/[\n,;]/)
+      : [];
+  return Array.from(
+    new Set(
+      values
+        .map((value) => clean(value)?.toLowerCase())
+        .filter((value): value is string => Boolean(value && value.includes("@"))),
+    ),
+  ).slice(0, 2_000);
+}
+
+function normalizeDate(input: unknown) {
+  if (!input) return undefined;
+  const date = new Date(String(input));
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function clean(input: unknown) {
+  if (typeof input !== "string") return undefined;
+  const value = input.trim();
+  return value ? value.slice(0, 20_000) : undefined;
+}
+
+function cleanUrl(input: unknown) {
+  const value = clean(input);
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:" ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function clampNumber(input: unknown, min: number, max: number) {
+  if (typeof input !== "number" || !Number.isFinite(input)) return undefined;
+  return Math.min(max, Math.max(min, Math.round(input)));
+}
+

--- a/apps/commons-courses/models/LiveParticipant.ts
+++ b/apps/commons-courses/models/LiveParticipant.ts
@@ -1,0 +1,43 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+export interface ILiveParticipant extends Document {
+  sessionId: mongoose.Types.ObjectId;
+  courseId: mongoose.Types.ObjectId;
+  userId: mongoose.Types.ObjectId;
+  displayName: string;
+  email: string;
+  status: "joined" | "active" | "completed";
+  joinedAt: Date;
+  lastSeenAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const LiveParticipantSchema = new Schema<ILiveParticipant>(
+  {
+    sessionId: {
+      type: Schema.Types.ObjectId,
+      ref: "LiveSession",
+      required: true,
+    },
+    courseId: { type: Schema.Types.ObjectId, ref: "Course", required: true },
+    userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
+    displayName: { type: String, required: true, trim: true },
+    email: { type: String, required: true, lowercase: true, trim: true },
+    status: {
+      type: String,
+      enum: ["joined", "active", "completed"],
+      default: "joined",
+    },
+    joinedAt: { type: Date, default: Date.now },
+    lastSeenAt: { type: Date, default: Date.now },
+  },
+  { timestamps: true },
+);
+
+LiveParticipantSchema.index({ sessionId: 1, userId: 1 }, { unique: true });
+LiveParticipantSchema.index({ sessionId: 1, lastSeenAt: -1 });
+
+export default mongoose.models.LiveParticipant ||
+  mongoose.model<ILiveParticipant>("LiveParticipant", LiveParticipantSchema);
+

--- a/apps/commons-courses/models/LiveResponse.ts
+++ b/apps/commons-courses/models/LiveResponse.ts
@@ -1,0 +1,48 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+export interface ILiveResponse extends Document {
+  sessionId: mongoose.Types.ObjectId;
+  courseId: mongoose.Types.ObjectId;
+  activityId: string;
+  participantId: mongoose.Types.ObjectId;
+  userId: mongoose.Types.ObjectId;
+  value: string | string[];
+  correct?: boolean;
+  pointsAwarded: number;
+  submittedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const LiveResponseSchema = new Schema<ILiveResponse>(
+  {
+    sessionId: {
+      type: Schema.Types.ObjectId,
+      ref: "LiveSession",
+      required: true,
+    },
+    courseId: { type: Schema.Types.ObjectId, ref: "Course", required: true },
+    activityId: { type: String, required: true, trim: true },
+    participantId: {
+      type: Schema.Types.ObjectId,
+      ref: "LiveParticipant",
+      required: true,
+    },
+    userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
+    value: { type: Schema.Types.Mixed, required: true },
+    correct: Boolean,
+    pointsAwarded: { type: Number, default: 0, min: 0 },
+    submittedAt: { type: Date, default: Date.now },
+  },
+  { timestamps: true },
+);
+
+LiveResponseSchema.index(
+  { sessionId: 1, activityId: 1, participantId: 1 },
+  { unique: true },
+);
+LiveResponseSchema.index({ sessionId: 1, activityId: 1, submittedAt: -1 });
+
+export default mongoose.models.LiveResponse ||
+  mongoose.model<ILiveResponse>("LiveResponse", LiveResponseSchema);
+

--- a/apps/commons-courses/models/LiveSession.ts
+++ b/apps/commons-courses/models/LiveSession.ts
@@ -1,0 +1,122 @@
+import mongoose, { Document, Schema } from "mongoose";
+import type {
+  LiveActivity,
+  LiveSessionAccess,
+  LiveSessionPace,
+  LiveSessionSettings,
+  LiveSessionStatus,
+} from "@/types/live-session";
+
+export interface ILiveSession extends Document {
+  courseId: mongoose.Types.ObjectId;
+  courseSlug: string;
+  title: string;
+  description?: string;
+  joinCode: string;
+  status: LiveSessionStatus;
+  pace: LiveSessionPace;
+  access: LiveSessionAccess;
+  invitedEmails: string[];
+  scheduledStart?: Date;
+  currentActivityId?: string;
+  activities: LiveActivity[];
+  settings: LiveSessionSettings;
+  createdBy: mongoose.Types.ObjectId;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const LiveActivityOptionSchema = new Schema(
+  {
+    id: { type: String, required: true, trim: true },
+    label: { type: String, required: true, trim: true },
+    isCorrect: { type: Boolean, default: false },
+  },
+  { _id: false },
+);
+
+const LiveActivitySchema = new Schema<LiveActivity>(
+  {
+    id: { type: String, required: true, trim: true },
+    type: {
+      type: String,
+      enum: [
+        "content",
+        "setup_check",
+        "poll",
+        "quiz",
+        "reflection",
+        "task",
+        "break",
+      ],
+      required: true,
+    },
+    title: { type: String, required: true, trim: true },
+    prompt: { type: String, trim: true },
+    instructions: { type: String, trim: true },
+    successCriteria: { type: String, trim: true },
+    facilitatorNotes: { type: String, trim: true },
+    resourceUrl: { type: String, trim: true },
+    estimatedMinutes: { type: Number, min: 1, max: 480 },
+    status: {
+      type: String,
+      enum: ["draft", "open", "closed"],
+      default: "draft",
+    },
+    required: { type: Boolean, default: false },
+    randomizeOptions: { type: Boolean, default: false },
+    showResults: { type: Boolean, default: false },
+    points: { type: Number, default: 0, min: 0 },
+    options: { type: [LiveActivityOptionSchema], default: [] },
+  },
+  { _id: false },
+);
+
+const LiveSessionSettingsSchema = new Schema<LiveSessionSettings>(
+  {
+    allowLateJoin: { type: Boolean, default: true },
+    showParticipantNames: { type: Boolean, default: false },
+    showLeaderboard: { type: Boolean, default: false },
+  },
+  { _id: false },
+);
+
+const LiveSessionSchema = new Schema<ILiveSession>(
+  {
+    courseId: { type: Schema.Types.ObjectId, ref: "Course", required: true },
+    courseSlug: { type: String, required: true, trim: true },
+    title: { type: String, required: true, trim: true },
+    description: { type: String, trim: true },
+    joinCode: { type: String, required: true, unique: true, trim: true },
+    status: {
+      type: String,
+      enum: ["draft", "lobby", "live", "ended"],
+      default: "draft",
+    },
+    pace: {
+      type: String,
+      enum: ["facilitator", "learner"],
+      default: "facilitator",
+    },
+    access: {
+      type: String,
+      enum: ["enrolled", "invited", "open"],
+      default: "enrolled",
+    },
+    invitedEmails: { type: [String], default: [] },
+    scheduledStart: Date,
+    currentActivityId: String,
+    activities: { type: [LiveActivitySchema], default: [] },
+    settings: { type: LiveSessionSettingsSchema, default: () => ({}) },
+    createdBy: { type: Schema.Types.ObjectId, ref: "User", required: true },
+  },
+  { timestamps: true },
+);
+
+LiveSessionSchema.index({ courseId: 1, createdAt: -1 });
+LiveSessionSchema.index({ courseSlug: 1, status: 1 });
+LiveSessionSchema.index({ status: 1, scheduledStart: 1 });
+
+export default mongoose.models.LiveSession ||
+  mongoose.model<ILiveSession>("LiveSession", LiveSessionSchema);
+

--- a/apps/commons-courses/types/educator-copilot.ts
+++ b/apps/commons-courses/types/educator-copilot.ts
@@ -1,5 +1,6 @@
 import type { ExperienceDocument } from "@/types/experience";
 import type { SkillChallenge, SkillPack } from "@/types/skills";
+import type { LiveActivity, LiveSessionAccess, LiveSessionPace } from "@/types/live-session";
 
 export type EducatorCopilotActionMode = "manual" | "auto";
 
@@ -115,6 +116,17 @@ export type EducatorCopilotAction =
       experienceId: string;
       baseVersion: number;
       document: ExperienceDocument;
+    })
+  | (ActionBase & {
+      type: "create_live_session";
+      courseSlug: string;
+      session: {
+        title: string;
+        description?: string;
+        pace: LiveSessionPace;
+        access: LiveSessionAccess;
+        activities: LiveActivity[];
+      };
     });
 
 export type EducatorCopilotToolActivity = {

--- a/apps/commons-courses/types/live-session.ts
+++ b/apps/commons-courses/types/live-session.ts
@@ -1,0 +1,106 @@
+export type LiveSessionStatus = "draft" | "lobby" | "live" | "ended";
+
+export type LiveSessionPace = "facilitator" | "learner";
+
+export type LiveSessionAccess = "enrolled" | "invited" | "open";
+
+export type LiveActivityType =
+  | "content"
+  | "setup_check"
+  | "poll"
+  | "quiz"
+  | "reflection"
+  | "task"
+  | "break";
+
+export type LiveActivityStatus = "draft" | "open" | "closed";
+
+export type LiveActivityOption = {
+  id: string;
+  label: string;
+  isCorrect?: boolean;
+};
+
+export type LiveActivity = {
+  id: string;
+  type: LiveActivityType;
+  title: string;
+  prompt?: string;
+  instructions?: string;
+  successCriteria?: string;
+  facilitatorNotes?: string;
+  resourceUrl?: string;
+  estimatedMinutes?: number;
+  status: LiveActivityStatus;
+  required: boolean;
+  randomizeOptions: boolean;
+  showResults: boolean;
+  points: number;
+  options: LiveActivityOption[];
+};
+
+export type LiveSessionSettings = {
+  allowLateJoin: boolean;
+  showParticipantNames: boolean;
+  showLeaderboard: boolean;
+};
+
+export type LiveSessionRecord = {
+  id: string;
+  courseId: string;
+  courseSlug: string;
+  courseTitle: string;
+  title: string;
+  description?: string;
+  joinCode: string;
+  status: LiveSessionStatus;
+  pace: LiveSessionPace;
+  access: LiveSessionAccess;
+  invitedEmails: string[];
+  scheduledStart?: string;
+  currentActivityId?: string;
+  activities: LiveActivity[];
+  settings: LiveSessionSettings;
+  participantCount: number;
+  responseCounts: Record<string, number>;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type LiveParticipantRecord = {
+  id: string;
+  displayName: string;
+  status: "joined" | "active" | "completed";
+  joinedAt: string;
+  lastSeenAt: string;
+};
+
+export type LiveResponseRecord = {
+  activityId: string;
+  value: string | string[];
+  correct?: boolean;
+  pointsAwarded?: number;
+  submittedAt: string;
+};
+
+export type LiveActivityResults = {
+  total: number;
+  correct?: number;
+  options?: Array<{ id: string; label: string; count: number }>;
+  textResponses?: Array<{
+    id: string;
+    participantName?: string;
+    value: string;
+  }>;
+};
+
+export type LearnerLiveSession = Omit<
+  LiveSessionRecord,
+  "invitedEmails" | "responseCounts" | "participantCount"
+> & {
+  participantCount: number;
+  participant: LiveParticipantRecord;
+  responses: Record<string, LiveResponseRecord>;
+  results: Record<string, LiveActivityResults>;
+};
+


### PR DESCRIPTION
## What changed

- adds reusable live-session plans with workbook pages, setup checks, polls, quizzes, reflections, tasks, and breaks
- adds a private facilitator console with paced activity control, participation, results, join codes, direct links, and QR entry
- adds seamless learner onboarding and return-to-room behavior, learner-paced workbooks, saved responses, and live Copilot context
- extends Educator Copilot with live-session reads and approval-gated session creation from uploaded material

## Why

Commons Courses needs to support coherent in-person and hybrid facilitation without sending educators across separate quiz, workbook, and classroom-management products.

## Validation

- TypeScript typecheck
- full Commons Courses ESLint
- clean production build against current main

## Impact

Educators can prepare and run live learning inside an existing course. Learners can join by QR, direct link, or six-digit code and return directly to the room after first-time signup.