### PR TITLE
Enforce private live access and rendered workshop decks

### DIFF
--- a/apps/commons-courses/app/api/course-materials/[id]/download/route.ts
+++ b/apps/commons-courses/app/api/course-materials/[id]/download/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { mongo, Types } from "mongoose";
+import { auth } from "@/lib/auth";
+import { connectDB } from "@/lib/db";
+import { getCourseCollaboratorRole } from "@/lib/educator-auth";
+import Course from "@/models/Course";
+import CourseMaterial from "@/models/CourseMaterial";
+import Enrollment from "@/models/Enrollment";
+import LiveParticipant from "@/models/LiveParticipant";
+import LiveSession from "@/models/LiveSession";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const currentUser = await auth();
+  if (!currentUser?.user?.id) return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  const { id } = await params;
+  if (!Types.ObjectId.isValid(id)) return NextResponse.json({ error: "Material not found." }, { status: 404 });
+  await connectDB();
+  const material = await CourseMaterial.findById(id);
+  if (!material?.gridFsId || material.storage !== "gridfs") return NextResponse.json({ error: "Material not found." }, { status: 404 });
+  const course = await Course.findById(material.courseId);
+  if (!course?.published) return NextResponse.json({ error: "Material not found." }, { status: 404 });
+  const manages = currentUser.user.role === "admin" || course.educator?.userId?.toString() === currentUser.user.id || Boolean(getCourseCollaboratorRole(course, { userId: currentUser.user.id, email: currentUser.user.email }));
+  if (!manages && material.visibility === "live") {
+    const sessionIds = await LiveSession.find({ courseId: material.courseId, "activities.materialId": String(material._id) }).distinct("_id");
+    const attended = await LiveParticipant.exists({ sessionId: { $in: sessionIds }, userId: currentUser.user.id });
+    if (!attended) return NextResponse.json({ error: "This material is limited to live-session participants." }, { status: 403 });
+  } else if (!manages) {
+    const enrolled = await Enrollment.exists({ userId: currentUser.user.id, courseId: material.courseId, status: { $ne: "cancelled" } });
+    if (!enrolled) return NextResponse.json({ error: "This material is limited to course participants." }, { status: 403 });
+  }
+  const db = CourseMaterial.db.db;
+  if (!db) return NextResponse.json({ error: "Material storage is unavailable." }, { status: 503 });
+  const stream = new mongo.GridFSBucket(db, { bucketName: "courseMaterials" }).openDownloadStream(new mongo.ObjectId(String(material.gridFsId)));
+  const body = new ReadableStream({
+    start(controller) {
+      stream.on("data", (chunk) => controller.enqueue(new Uint8Array(chunk)));
+      stream.on("end", () => controller.close());
+      stream.on("error", (error) => controller.error(error));
+    },
+    cancel() { stream.destroy(); },
+  });
+  return new NextResponse(body, {
+    headers: {
+      "Content-Type": material.mimeType,
+      "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent(material.name)}`,
+      "Content-Length": String(material.size),
+      "Cache-Control": "private, no-store",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/apps/commons-courses/app/api/course-materials/[id]/route.ts
+++ b/apps/commons-courses/app/api/course-materials/[id]/route.ts
@@ -43,6 +43,23 @@ export async function GET(
     });
     if (!enrolled) return NextResponse.json({ error: "This material is limited to course participants." }, { status: 403 });
   }
+  if (material.storage === "gridfs" && material.gridFsId) {
+    return NextResponse.json({
+      material: {
+        id: String(material._id),
+        name: material.name,
+        mimeType: material.mimeType,
+        kind: material.kind,
+        content: material.textPreview || "",
+        imageUrls: (material.slideGridFsIds || []).map(
+          (_item: unknown, index: number) => `/api/course-materials/${material._id}/slides/${index}`,
+        ),
+        downloadUrl: `/api/course-materials/${material._id}/download`,
+        embeddable: false,
+      },
+    }, { headers: { "Cache-Control": "private, no-store" } });
+  }
+  if (!material.fileId) return NextResponse.json({ error: "Material file is unavailable." }, { status: 410 });
   const accessToken = process.env.AGENT_COMMONS_API_KEY || currentUser.accessToken;
   if (!accessToken) return NextResponse.json({ error: "Material storage is temporarily unavailable." }, { status: 503 });
   const response = await readEducatorCopilotFile(material.fileId, {
@@ -61,6 +78,7 @@ export async function GET(
       content: response.data.content || "",
       imageUrls: response.data.imageUrls || [],
       downloadUrl,
+      embeddable: true,
     },
   }, { headers: { "Cache-Control": "private, no-store" } });
 }

--- a/apps/commons-courses/app/api/course-materials/[id]/slides/[index]/route.ts
+++ b/apps/commons-courses/app/api/course-materials/[id]/slides/[index]/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { mongo, Types } from "mongoose";
+import { auth } from "@/lib/auth";
+import { connectDB } from "@/lib/db";
+import { getCourseCollaboratorRole } from "@/lib/educator-auth";
+import Course from "@/models/Course";
+import CourseMaterial from "@/models/CourseMaterial";
+import Enrollment from "@/models/Enrollment";
+import LiveParticipant from "@/models/LiveParticipant";
+import LiveSession from "@/models/LiveSession";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string; index: string }> },
+) {
+  const currentUser = await auth();
+  if (!currentUser?.user?.id) return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  const { id, index: rawIndex } = await params;
+  if (!Types.ObjectId.isValid(id)) return NextResponse.json({ error: "Slide not found." }, { status: 404 });
+  const index = Number(rawIndex);
+  if (!Number.isInteger(index) || index < 0) return NextResponse.json({ error: "Slide not found." }, { status: 404 });
+  await connectDB();
+  const material = await CourseMaterial.findById(id);
+  const slideId = material?.slideGridFsIds?.[index];
+  if (!material || !slideId) return NextResponse.json({ error: "Slide not found." }, { status: 404 });
+  const course = await Course.findById(material.courseId);
+  if (!course?.published) return NextResponse.json({ error: "Slide not found." }, { status: 404 });
+  const manages = currentUser.user.role === "admin" || course.educator?.userId?.toString() === currentUser.user.id || Boolean(getCourseCollaboratorRole(course, { userId: currentUser.user.id, email: currentUser.user.email }));
+  if (!manages && material.visibility === "live") {
+    const sessionIds = await LiveSession.find({ courseId: material.courseId, "activities.materialId": String(material._id) }).distinct("_id");
+    const attended = await LiveParticipant.exists({ sessionId: { $in: sessionIds }, userId: currentUser.user.id });
+    if (!attended) return NextResponse.json({ error: "This material is limited to live-session participants." }, { status: 403 });
+  } else if (!manages) {
+    const enrolled = await Enrollment.exists({ userId: currentUser.user.id, courseId: material.courseId, status: { $ne: "cancelled" } });
+    if (!enrolled) return NextResponse.json({ error: "This material is limited to course participants." }, { status: 403 });
+  }
+  const db = CourseMaterial.db.db;
+  if (!db) return NextResponse.json({ error: "Slide storage is unavailable." }, { status: 503 });
+  const stream = new mongo.GridFSBucket(db, { bucketName: "courseMaterials" }).openDownloadStream(new mongo.ObjectId(String(slideId)));
+  const body = new ReadableStream({
+    start(controller) {
+      stream.on("data", (chunk) => controller.enqueue(new Uint8Array(chunk)));
+      stream.on("end", () => controller.close());
+      stream.on("error", (error) => controller.error(error));
+    },
+    cancel() { stream.destroy(); },
+  });
+  return new NextResponse(body, { headers: { "Content-Type": "image/png", "Cache-Control": "private, max-age=300", "X-Content-Type-Options": "nosniff" } });
+}

--- a/apps/commons-courses/app/api/educator/courses/[slug]/materials/route.ts
+++ b/apps/commons-courses/app/api/educator/courses/[slug]/materials/route.ts
@@ -60,6 +60,7 @@ export async function POST(
     ownerUserId: result.session.userId,
     ownerPrincipalId: principalId,
     fileId: item.fileId,
+    storage: "commons",
     name: item.name || files[index].name,
     mimeType: item.mimeType || files[index].type,
     size: files[index].size,

--- a/apps/commons-courses/app/api/live-sessions/[id]/route.ts
+++ b/apps/commons-courses/app/api/live-sessions/[id]/route.ts
@@ -46,13 +46,9 @@ export async function GET(
       status: { $ne: "cancelled" },
     });
     if (!enrolled) {
-      if (!course.isFree) {
-        return NextResponse.json({ error: "Enroll in the course before joining this session." }, { status: 403 });
-      }
-      await Enrollment.findOneAndUpdate(
-        { userId: currentUser.user.id, courseId: session.courseId },
-        { $setOnInsert: { status: "active", paymentStatus: "free", accessLevel: "full" } },
-        { upsert: true },
+      return NextResponse.json(
+        { error: "This is a private course session. Ask your educator to add you before joining." },
+        { status: 403 },
       );
     }
   }

--- a/apps/commons-courses/components/course-material-viewer.tsx
+++ b/apps/commons-courses/components/course-material-viewer.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { ChevronLeft, ChevronRight, Download, Expand, FileText, LoaderCircle, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-type MaterialData = { id: string; name: string; mimeType: string; kind: "presentation" | "pdf"; content: string; imageUrls: string[]; downloadUrl?: string };
+type MaterialData = { id: string; name: string; mimeType: string; kind: "presentation" | "pdf"; content: string; imageUrls: string[]; downloadUrl?: string; embeddable?: boolean };
 
 export function CourseMaterialViewer({ materialId, compact = false }: { materialId: string; compact?: boolean }) {
   const [material, setMaterial] = useState<MaterialData | null>(null);
@@ -28,7 +28,7 @@ export function CourseMaterialViewer({ materialId, compact = false }: { material
   if (!material) return <div className="flex min-h-48 items-center justify-center rounded-xl bg-slate-50"><LoaderCircle className="h-5 w-5 animate-spin text-slate-300" /></div>;
   const stage = material.kind === "pdf" && material.downloadUrl ? (
     <iframe title={material.name} src={`${material.downloadUrl}#toolbar=0&view=FitH`} className={cn("w-full border-0 bg-slate-100", full ? "h-[calc(100dvh-64px)]" : compact ? "h-[58vh]" : "h-[72vh]")} />
-  ) : material.kind === "presentation" && material.downloadUrl ? (
+  ) : material.kind === "presentation" && material.downloadUrl && material.embeddable !== false ? (
     <iframe title={material.name} src={`https://view.officeapps.live.com/op/embed.aspx?src=${encodeURIComponent(material.downloadUrl)}`} className={cn("w-full border-0 bg-slate-950", full ? "h-[calc(100dvh-64px)]" : compact ? "h-[58vh]" : "h-[72vh]")} allowFullScreen />
   ) : material.imageUrls.length ? (
     // eslint-disable-next-line @next/next/no-img-element
@@ -39,7 +39,7 @@ export function CourseMaterialViewer({ materialId, compact = false }: { material
   return <div className={cn("overflow-hidden rounded-2xl border border-slate-200 bg-white", full && "fixed inset-0 z-[100] rounded-none border-0 bg-slate-950")}>
     <div className="flex h-14 items-center gap-3 border-b border-slate-200 bg-white px-4"><FileText className="h-4 w-4 text-slate-400" /><p className="min-w-0 flex-1 truncate text-sm font-bold text-slate-800">{material.name}</p>{material.downloadUrl ? <a href={material.downloadUrl} className="rounded-lg p-2 text-slate-500 hover:bg-slate-100" title="Download original"><Download className="h-4 w-4" /></a> : null}<button onClick={() => setFull(!full)} className="rounded-lg p-2 text-slate-500 hover:bg-slate-100" title={full ? "Exit presentation" : "Present full screen"}>{full ? <X className="h-4 w-4" /> : <Expand className="h-4 w-4" />}</button></div>
     {stage}
-    {material.kind === "presentation" && !material.downloadUrl ? <div className="flex h-14 items-center justify-between border-t border-slate-800 bg-slate-950 px-4 text-white"><button disabled={slide <= 0} onClick={() => setSlide((value) => Math.max(0, value - 1))} className="inline-flex items-center gap-2 text-xs font-bold disabled:opacity-30"><ChevronLeft className="h-4 w-4" /> Previous</button><span className="text-xs text-slate-400">{slide + 1} / {Math.max(slides.length, material.imageUrls.length, 1)}</span><button disabled={slide >= Math.max(slides.length, material.imageUrls.length, 1) - 1} onClick={() => setSlide((value) => value + 1)} className="inline-flex items-center gap-2 text-xs font-bold disabled:opacity-30">Next <ChevronRight className="h-4 w-4" /></button></div> : null}
+    {material.kind === "presentation" && (!material.downloadUrl || material.embeddable === false) ? <div className="flex h-14 items-center justify-between border-t border-slate-800 bg-slate-950 px-4 text-white"><button disabled={slide <= 0} onClick={() => setSlide((value) => Math.max(0, value - 1))} className="inline-flex items-center gap-2 text-xs font-bold disabled:opacity-30"><ChevronLeft className="h-4 w-4" /> Previous</button><span className="text-xs text-slate-400">{slide + 1} / {Math.max(slides.length, material.imageUrls.length, 1)}</span><button disabled={slide >= Math.max(slides.length, material.imageUrls.length, 1) - 1} onClick={() => setSlide((value) => value + 1)} className="inline-flex items-center gap-2 text-xs font-bold disabled:opacity-30">Next <ChevronRight className="h-4 w-4" /></button></div> : null}
   </div>;
 }
 

--- a/apps/commons-courses/lib/course-material-data.ts
+++ b/apps/commons-courses/lib/course-material-data.ts
@@ -12,6 +12,7 @@ export function serializeCourseMaterial(material: ICourseMaterial): CourseMateri
     kind: material.kind,
     visibility: material.visibility,
     fileId: material.fileId,
+    storage: material.storage || "commons",
     status: material.status,
     textPreview: material.textPreview,
     createdAt: material.createdAt.toISOString(),

--- a/apps/commons-courses/models/CourseMaterial.ts
+++ b/apps/commons-courses/models/CourseMaterial.ts
@@ -5,7 +5,10 @@ export interface ICourseMaterial extends Document {
   courseSlug: string;
   ownerUserId: mongoose.Types.ObjectId;
   ownerPrincipalId: string;
-  fileId: string;
+  fileId?: string;
+  storage: "commons" | "gridfs";
+  gridFsId?: mongoose.Types.ObjectId;
+  slideGridFsIds: mongoose.Types.ObjectId[];
   name: string;
   mimeType: string;
   size: number;
@@ -22,7 +25,10 @@ const CourseMaterialSchema = new Schema<ICourseMaterial>({
   courseSlug: { type: String, required: true, trim: true },
   ownerUserId: { type: Schema.Types.ObjectId, ref: "User", required: true },
   ownerPrincipalId: { type: String, required: true, trim: true },
-  fileId: { type: String, required: true, trim: true },
+  fileId: { type: String, trim: true },
+  storage: { type: String, enum: ["commons", "gridfs"], default: "commons" },
+  gridFsId: Schema.Types.ObjectId,
+  slideGridFsIds: { type: [Schema.Types.ObjectId], default: [] },
   name: { type: String, required: true, trim: true },
   mimeType: { type: String, required: true, trim: true },
   size: { type: Number, required: true, min: 0 },
@@ -33,7 +39,7 @@ const CourseMaterialSchema = new Schema<ICourseMaterial>({
 }, { timestamps: true });
 
 CourseMaterialSchema.index({ courseId: 1, createdAt: -1 });
-CourseMaterialSchema.index({ fileId: 1 }, { unique: true });
+CourseMaterialSchema.index({ fileId: 1 }, { unique: true, sparse: true });
 
 export default mongoose.models.CourseMaterial ||
   mongoose.model<ICourseMaterial>("CourseMaterial", CourseMaterialSchema);

--- a/apps/commons-courses/types/course-material.ts
+++ b/apps/commons-courses/types/course-material.ts
@@ -7,7 +7,8 @@ export type CourseMaterialRecord = {
   size: number;
   kind: "presentation" | "pdf";
   visibility: "course" | "live";
-  fileId: string;
+  fileId?: string;
+  storage: "commons" | "gridfs";
   status: string;
   textPreview?: string;
   createdAt: string;


### PR DESCRIPTION
## Summary
- stop free courses from silently enrolling anyone holding a private live link
- support protected original downloads and rendered slide frames for privately provisioned workshop decks
- keep standard educator uploads on Commons S3/Library storage

## Production course preparation
- Moringa workshop source is owned by bashybaranaba@gmail.com
- 28 facilitator-paced activities total 540 minutes
- original 67-slide deck plus 65 rendered presentation frames are private to the educator and verified live attendees
- live room remains enrolled-only and is staged in the lobby for Saturday 08:30 EAT

## Verification
- npx tsc --noEmit
- npm run lint -- --max-warnings=0
- npm test