### PR TITLE
Streamline live enrollment, responsive activities, and QR sharing

### DIFF
--- a/apps/commons-courses/app/api/educator/live-sessions/[id]/qr/route.ts
+++ b/apps/commons-courses/app/api/educator/live-sessions/[id]/qr/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Types } from "mongoose";
+import { connectDB } from "@/lib/db";
+import { requireEducatorCourse } from "@/lib/educator-auth";
+import LiveSession from "@/models/LiveSession";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  if (!Types.ObjectId.isValid(id)) {
+    return NextResponse.json({ error: "Session not found." }, { status: 404 });
+  }
+
+  await connectDB();
+  const session = await LiveSession.findById(id).select(
+    "courseSlug title joinCode",
+  );
+  if (!session) {
+    return NextResponse.json({ error: "Session not found." }, { status: 404 });
+  }
+  const authorization = await requireEducatorCourse(session.courseSlug);
+  if (authorization.error) return authorization.error;
+
+  const format =
+    req.nextUrl.searchParams.get("format") === "svg" ? "svg" : "png";
+  const joinUrl = `${req.nextUrl.origin}/live/${session.id}`;
+  const qrUrl = new URL("https://quickchart.io/qr");
+  qrUrl.searchParams.set("size", format === "svg" ? "1200" : "1600");
+  qrUrl.searchParams.set("margin", "2");
+  qrUrl.searchParams.set("ecLevel", "H");
+  qrUrl.searchParams.set("format", format);
+  qrUrl.searchParams.set("text", joinUrl);
+
+  const qrResponse = await fetch(qrUrl, { cache: "no-store" });
+  if (!qrResponse.ok) {
+    return NextResponse.json(
+      { error: "Could not generate the QR code." },
+      { status: 502 },
+    );
+  }
+
+  const safeTitle = session.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 60);
+  const download = req.nextUrl.searchParams.get("download") === "1";
+  return new NextResponse(await qrResponse.arrayBuffer(), {
+    headers: {
+      "Cache-Control": "private, no-store, max-age=0",
+      "Content-Disposition": `${download ? "attachment" : "inline"}; filename="${safeTitle || "live-session"}-qr.${format}"`,
+      "Content-Type": format === "svg" ? "image/svg+xml" : "image/png",
+    },
+  });
+}

--- a/apps/commons-courses/app/api/enrollments/route.ts
+++ b/apps/commons-courses/app/api/enrollments/route.ts
@@ -38,7 +38,7 @@ export async function POST(req: NextRequest) {
     if (!course.isFree) {
       return NextResponse.json(
         { error: "This course requires payment." },
-        { status: 402 }
+        { status: 402 },
       );
     }
 
@@ -47,6 +47,15 @@ export async function POST(req: NextRequest) {
       courseId,
     });
     if (existing) {
+      if (existing.status === "cancelled") {
+        existing.status = "active";
+        existing.accessLevel = "full";
+        existing.paymentStatus = "free";
+        existing.accessSource = "free";
+        existing.enrolledAt = new Date();
+        await existing.save();
+        return NextResponse.json(existing);
+      }
       return NextResponse.json({ error: "Already enrolled." }, { status: 409 });
     }
 
@@ -63,7 +72,7 @@ export async function POST(req: NextRequest) {
         instructor: course.instructor,
         duration: course.duration,
         settings: course.emailSettings,
-      }
+      },
     );
 
     return NextResponse.json(enrollment, { status: 201 });

--- a/apps/commons-courses/app/api/live-sessions/[id]/route.ts
+++ b/apps/commons-courses/app/api/live-sessions/[id]/route.ts
@@ -32,16 +32,31 @@ export async function GET(
   if (!session || session.status === "draft") {
     return NextResponse.json({ error: "Session not found." }, { status: 404 });
   }
-  const course = await Course.findById(session.courseId).select("title published isFree educator collaborators theme");
+  const course = await Course.findById(session.courseId).select(
+    "title published isFree educator collaborators theme",
+  );
   if (!course?.published) {
     return NextResponse.json({ error: "Session not found." }, { status: 404 });
   }
   const email = currentUser.user.email?.trim().toLowerCase() || "";
-  const managesCourse = currentUser.user.role === "admin"
-    || course.educator?.userId?.toString() === currentUser.user.id
-    || Boolean(getCourseCollaboratorRole(course, { userId: currentUser.user.id, email: currentUser.user.email }));
-  if (!managesCourse && session.access === "invited" && !session.invitedEmails.includes(email)) {
-    return NextResponse.json({ error: "This session is limited to invited learners." }, { status: 403 });
+  const managesCourse =
+    currentUser.user.role === "admin" ||
+    course.educator?.userId?.toString() === currentUser.user.id ||
+    Boolean(
+      getCourseCollaboratorRole(course, {
+        userId: currentUser.user.id,
+        email: currentUser.user.email,
+      }),
+    );
+  if (
+    !managesCourse &&
+    session.access === "invited" &&
+    !session.invitedEmails.includes(email)
+  ) {
+    return NextResponse.json(
+      { error: "This session is limited to invited learners." },
+      { status: 403 },
+    );
   }
   if (!managesCourse && session.access === "enrolled") {
     const enrolled = await Enrollment.exists({
@@ -51,7 +66,16 @@ export async function GET(
     });
     if (!enrolled) {
       return NextResponse.json(
-        { error: "This is a private course session. Ask your educator to add you before joining." },
+        {
+          code: "ENROLLMENT_REQUIRED",
+          error: `Enroll in ${course.title} to join this live session.`,
+          course: {
+            id: String(course._id),
+            title: course.title,
+            slug: session.courseSlug,
+            isFree: course.isFree,
+          },
+        },
         { status: 403 },
       );
     }
@@ -62,23 +86,34 @@ export async function GET(
       userId: currentUser.user.id,
     });
     if (!existing) {
-      return NextResponse.json({ error: "This session has ended." }, { status: 410 });
+      return NextResponse.json(
+        { error: "This session has ended." },
+        { status: 410 },
+      );
     }
   }
-  if (!managesCourse && !session.settings.allowLateJoin && session.status === "live") {
+  if (
+    !managesCourse &&
+    !session.settings.allowLateJoin &&
+    session.status === "live"
+  ) {
     const existing = await LiveParticipant.exists({
       sessionId: session._id,
       userId: currentUser.user.id,
     });
     if (!existing) {
-      return NextResponse.json({ error: "Joining is now closed." }, { status: 403 });
+      return NextResponse.json(
+        { error: "Joining is now closed." },
+        { status: 403 },
+      );
     }
   }
   const participant = await LiveParticipant.findOneAndUpdate(
     { sessionId: session._id, userId: currentUser.user.id },
     {
       $set: {
-        displayName: currentUser.user.name || currentUser.user.email || "Learner",
+        displayName:
+          currentUser.user.name || currentUser.user.email || "Learner",
         email,
         lastSeenAt: new Date(),
         status: session.status === "ended" ? "completed" : "active",
@@ -94,11 +129,14 @@ export async function GET(
   ]);
   const visibleResults = Object.fromEntries(
     Object.entries(results).filter(([activityId]) => {
-      const activity = session.activities.find((item: LiveActivity) => item.id === activityId);
+      const activity = session.activities.find(
+        (item: LiveActivity) => item.id === activityId,
+      );
       return activity?.showResults && activity.status === "closed";
     }),
   );
-  return NextResponse.json({
+  return NextResponse.json(
+    {
     session: {
       ...base,
       invitedEmails: undefined,
@@ -114,5 +152,7 @@ export async function GET(
       responses,
       results: visibleResults,
     },
-  }, { headers: { "Cache-Control": "private, no-store, max-age=0" } });
+    },
+    { headers: { "Cache-Control": "private, no-store, max-age=0" } },
+  );
 }

--- a/apps/commons-courses/app/api/live-sessions/[id]/state/route.ts
+++ b/apps/commons-courses/app/api/live-sessions/[id]/state/route.ts
@@ -18,11 +18,17 @@ export async function GET(
 ) {
   const currentUser = await auth();
   if (!currentUser?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized." }, { status: 401, headers: noStore });
+    return NextResponse.json(
+      { error: "Unauthorized." },
+      { status: 401, headers: noStore },
+    );
   }
   const { id } = await params;
   if (!Types.ObjectId.isValid(id)) {
-    return NextResponse.json({ error: "Session not found." }, { status: 404, headers: noStore });
+    return NextResponse.json(
+      { error: "Session not found." },
+      { status: 404, headers: noStore },
+    );
   }
 
   await connectDB();
@@ -30,22 +36,46 @@ export async function GET(
     "courseId status pace access invitedEmails currentActivityId stateVersion activities.id activities.status settings.allowLateJoin",
   );
   if (!session || session.status === "draft") {
-    return NextResponse.json({ error: "Session not found." }, { status: 404, headers: noStore });
+    return NextResponse.json(
+      { error: "Session not found." },
+      { status: 404, headers: noStore },
+    );
   }
 
   const [course, participant] = await Promise.all([
-    Course.findById(session.courseId).select("published educator collaborators"),
-    LiveParticipant.exists({ sessionId: session._id, userId: currentUser.user.id }),
+    Course.findById(session.courseId).select(
+      "published educator collaborators",
+    ),
+    LiveParticipant.exists({
+      sessionId: session._id,
+      userId: currentUser.user.id,
+    }),
   ]);
   if (!course?.published) {
-    return NextResponse.json({ error: "Session not found." }, { status: 404, headers: noStore });
+    return NextResponse.json(
+      { error: "Session not found." },
+      { status: 404, headers: noStore },
+    );
   }
   const email = currentUser.user.email?.trim().toLowerCase() || "";
-  const managesCourse = currentUser.user.role === "admin"
-    || course.educator?.userId?.toString() === currentUser.user.id
-    || Boolean(getCourseCollaboratorRole(course, { userId: currentUser.user.id, email: currentUser.user.email }));
-  if (!managesCourse && session.access === "invited" && !session.invitedEmails.includes(email)) {
-    return NextResponse.json({ error: "This session is limited to invited learners." }, { status: 403, headers: noStore });
+  const managesCourse =
+    currentUser.user.role === "admin" ||
+    course.educator?.userId?.toString() === currentUser.user.id ||
+    Boolean(
+      getCourseCollaboratorRole(course, {
+        userId: currentUser.user.id,
+        email: currentUser.user.email,
+      }),
+    );
+  if (
+    !managesCourse &&
+    session.access === "invited" &&
+    !session.invitedEmails.includes(email)
+  ) {
+    return NextResponse.json(
+      { error: "This session is limited to invited learners." },
+      { status: 403, headers: noStore },
+    );
   }
   if (!managesCourse && session.access === "enrolled") {
     const enrolled = await Enrollment.exists({
@@ -54,25 +84,43 @@ export async function GET(
       status: { $ne: "cancelled" },
     });
     if (!enrolled) {
-      return NextResponse.json({ error: "You no longer have access to this course." }, { status: 403, headers: noStore });
+      return NextResponse.json(
+        {
+          code: "ENROLLMENT_REQUIRED",
+          error: "Enroll in this course to continue in the live session.",
+        },
+        { status: 403, headers: noStore },
+      );
     }
   }
-  if (!participant || (session.status === "live" && !session.settings.allowLateJoin)) {
+  if (
+    !participant ||
+    (session.status === "live" && !session.settings.allowLateJoin)
+  ) {
     if (!participant) {
-      return NextResponse.json({ error: "Re-enter the live room to continue." }, { status: 409, headers: noStore });
+      return NextResponse.json(
+        { error: "Re-enter the live room to continue." },
+        { status: 409, headers: noStore },
+      );
     }
   }
 
-  return NextResponse.json({
+  return NextResponse.json(
+    {
     state: {
       status: session.status,
       pace: session.pace,
       currentActivityId: resolveCurrentActivityId(session),
       stateVersion: session.stateVersion || 0,
       activityStatuses: Object.fromEntries(
-        session.activities.map((activity: LiveActivity) => [activity.id, activity.status]),
+          session.activities.map((activity: LiveActivity) => [
+            activity.id,
+            activity.status,
+          ]),
       ),
       serverTime: new Date().toISOString(),
     },
-  }, { headers: noStore });
+    },
+    { headers: noStore },
+  );
 }

--- a/apps/commons-courses/components/educator/live-facilitator-studio.tsx
+++ b/apps/commons-courses/components/educator/live-facilitator-studio.tsx
@@ -10,6 +10,7 @@ import {
   ChevronRight,
   CircleStop,
   Clipboard,
+  Download,
   ExternalLink,
   GripVertical,
   Link2,
@@ -23,6 +24,7 @@ import {
   Radio,
   Save,
   Settings2,
+  Share2,
   Trash2,
   Users,
 } from "lucide-react";
@@ -211,6 +213,7 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
   const joinPath = `/live/${data.session.id}`;
   const joinUrl = typeof window === "undefined" ? joinPath : `${window.location.origin}${joinPath}`;
   const joinPortal = typeof window === "undefined" ? "/join" : `${window.location.origin}/join`;
+  const qrPath = `/api/educator/live-sessions/${data.session.id}/qr`;
 
   return (
     <div style={getCourseThemeStyle(data.session.courseTheme) as CSSProperties} className="space-y-5" data-copilot-target="live-facilitation-studio">
@@ -328,13 +331,13 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
             <div className="mt-8 grid items-center gap-8 sm:grid-cols-[220px_1fr] sm:text-left">
               <div className="rounded-2xl bg-white p-3">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={`https://quickchart.io/qr?size=420&margin=1&text=${encodeURIComponent(joinUrl)}`} alt={`QR code to join ${data.session.title}`} className="aspect-square w-full" />
+                <img src={`${qrPath}?format=png`} alt={`QR code to join ${data.session.title}`} className="aspect-square w-full" />
               </div>
               <div><p className="text-sm text-slate-400">Scan the QR code, or visit</p><p className="mt-1 break-all text-lg font-bold">{joinPortal}</p><p className="mt-6 text-sm text-slate-400">Enter code</p><p className="mt-1 text-5xl font-bold tracking-[0.16em] text-[#B8F56D]">{formatCode(data.session.joinCode)}</p></div>
             </div>
           </section>
           <aside className="space-y-5">
-            <section className="rounded-2xl border border-slate-200 bg-white p-5"><h3 className="text-sm font-bold text-slate-950">Share options</h3><div className="mt-4 space-y-2"><CopyButton label="Copy direct join link" value={joinUrl} icon={Link2} /><CopyButton label="Copy six-digit code" value={data.session.joinCode} icon={Clipboard} /><a href={joinUrl} target="_blank" className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-sm font-bold text-slate-700 hover:bg-slate-50"><ExternalLink className="h-4 w-4" /> Preview learner view</a></div></section>
+            <section className="rounded-2xl border border-slate-200 bg-white p-5"><h3 className="text-sm font-bold text-slate-950">Share options</h3><p className="mt-1 text-xs leading-5 text-slate-400">Use the QR code in slides, handouts, messages, or signage.</p><div className="mt-4 space-y-2"><a href={`${qrPath}?format=png&download=1`} download className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-sm font-bold text-slate-700 hover:bg-slate-50"><Download className="h-4 w-4" /> Download QR code · PNG</a><a href={`${qrPath}?format=svg&download=1`} download className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-sm font-bold text-slate-700 hover:bg-slate-50"><Download className="h-4 w-4" /> Download QR code · SVG</a><ShareQrButton qrUrl={`${qrPath}?format=png`} joinUrl={joinUrl} title={data.session.title} /><CopyButton label="Copy direct join link" value={joinUrl} icon={Link2} /><CopyButton label="Copy six-digit code" value={data.session.joinCode} icon={Clipboard} /><a href={joinUrl} target="_blank" className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-sm font-bold text-slate-700 hover:bg-slate-50"><ExternalLink className="h-4 w-4" /> Preview learner view</a></div></section>
             <section className="rounded-2xl border border-slate-200 bg-white p-5"><h3 className="text-sm font-bold text-slate-950">Join policy</h3><dl className="mt-4 space-y-3 text-xs"><ShareRow label="Access" value={data.session.access === "open" ? "Anyone with link" : data.session.access === "invited" ? "Invited emails" : "Enrolled learners"} /><ShareRow label="Pace" value={data.session.pace === "facilitator" ? "You control it" : "Learners control it"} /><ShareRow label="Late join" value={data.session.settings.allowLateJoin ? "Allowed" : "Locked after start"} /></dl></section>
           </aside>
         </div>
@@ -376,6 +379,7 @@ function LiveResults({ activity, results, responses, participants }: { activity:
 function IconButton({ label, onClick, icon: Icon, danger }: { label: string; onClick: () => void; icon: typeof ArrowUp; danger?: boolean }) { return <button type="button" aria-label={label} title={label} onClick={onClick} className={cn("rounded-lg border border-slate-200 p-2 text-slate-500 hover:bg-slate-50", danger && "hover:border-red-200 hover:bg-red-50 hover:text-red-600")}><Icon className="h-4 w-4" /></button>; }
 function SessionStatus({ status }: { status: LiveSessionRecord["status"] }) { return <span className={cn("inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest", status === "live" ? "bg-red-50 text-red-700" : status === "lobby" ? "bg-cyan-50 text-cyan-700" : status === "ended" ? "bg-slate-100 text-slate-500" : "bg-amber-50 text-amber-700")}><span className={cn("h-1.5 w-1.5 rounded-full", status === "live" ? "animate-pulse bg-red-500" : "bg-current")} />{status}</span>; }
 function CopyButton({ label, value, icon: Icon }: { label: string; value: string; icon: typeof Link2 }) { const [copied, setCopied] = useState(false); return <button onClick={async () => { await navigator.clipboard.writeText(value); setCopied(true); window.setTimeout(() => setCopied(false), 1500); }} className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-left text-sm font-bold text-slate-700 hover:bg-slate-50"><Icon className="h-4 w-4" /><span className="flex-1">{copied ? "Copied" : label}</span>{copied ? <Check className="h-4 w-4 text-emerald-500" /> : null}</button>; }
+function ShareQrButton({ qrUrl, joinUrl, title }: { qrUrl: string; joinUrl: string; title: string }) { const [status, setStatus] = useState<"idle" | "sharing" | "copied">("idle"); async function share() { if (status === "sharing") return; setStatus("sharing"); try { if (navigator.share) { const response = await fetch(qrUrl); const blob = response.ok ? await response.blob() : null; const file = blob ? new File([blob], "live-session-qr.png", { type: "image/png" }) : null; if (file && navigator.canShare?.({ files: [file] })) await navigator.share({ title, text: "Scan this QR code to join the live session.", files: [file] }); else await navigator.share({ title, text: "Join the live session", url: joinUrl }); setStatus("idle"); return; } await navigator.clipboard.writeText(joinUrl); setStatus("copied"); window.setTimeout(() => setStatus("idle"), 1500); } catch (error) { if (!(error instanceof DOMException && error.name === "AbortError")) { await navigator.clipboard.writeText(joinUrl).catch(() => undefined); setStatus("copied"); window.setTimeout(() => setStatus("idle"), 1500); } else setStatus("idle"); } } return <button type="button" onClick={share} className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-left text-sm font-bold text-slate-700 hover:bg-slate-50"><Share2 className="h-4 w-4" /><span className="flex-1">{status === "sharing" ? "Preparing QR code…" : status === "copied" ? "Join link copied" : "Share QR code"}</span>{status === "sharing" ? <LoaderCircle className="h-4 w-4 animate-spin text-slate-400" /> : status === "copied" ? <Check className="h-4 w-4 text-emerald-500" /> : null}</button>; }
 function ShareRow({ label, value }: { label: string; value: string }) { return <div className="flex justify-between gap-4"><dt className="text-slate-400">{label}</dt><dd className="text-right font-bold text-slate-700">{value}</dd></div>; }
 function activityLabel(type: LiveActivityType) { return activityChoices.find((choice) => choice.type === type)?.label || type; }
 function formatCode(code: string) { return `${code.slice(0, 3)} ${code.slice(3)}`; }

--- a/apps/commons-courses/components/live/live-learner-room.tsx
+++ b/apps/commons-courses/components/live/live-learner-room.tsx
@@ -1,28 +1,50 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
 import Link from "next/link";
 import {
   ArrowLeft,
   ArrowRight,
+  BookOpen,
   Check,
   CheckCircle2,
+  ChevronDown,
   Clock3,
   ExternalLink,
   FlaskConical,
+  GraduationCap,
   LoaderCircle,
   LockKeyhole,
   Radio,
   Send,
-  Sparkles,
   Users,
+  X,
 } from "lucide-react";
 import { CourseAgentDrawer } from "@/components/course-agents/course-agent-drawer";
 import { CourseMaterialViewer } from "@/components/course-material-viewer";
 import { cn } from "@/lib/utils";
 import { getCourseThemeStyle } from "@/lib/course-theme";
-import type { LearnerLiveSession, LiveActivity, LiveResponseRecord } from "@/types/live-session";
+import type {
+  LearnerLiveSession,
+  LiveActivity,
+  LiveResponseRecord,
+} from "@/types/live-session";
 import type { LiveSessionState } from "@/types/live-session";
+
+type EnrollmentGate = {
+  courseId?: string;
+  courseTitle?: string;
+  courseSlug?: string;
+  isFree?: boolean;
+  message: string;
+};
 
 export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
   const [session, setSession] = useState<LearnerLiveSession | null>(null);
@@ -31,44 +53,85 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [notice, setNotice] = useState("");
-  const [connection, setConnection] = useState<"connecting" | "synced" | "reconnecting" | "offline">("connecting");
+  const [enrollmentGate, setEnrollmentGate] = useState<EnrollmentGate | null>(
+    null,
+  );
+  const [enrolling, setEnrolling] = useState(false);
+  const [workbookOpen, setWorkbookOpen] = useState(false);
+  const [connection, setConnection] = useState<
+    "connecting" | "synced" | "reconnecting" | "offline"
+  >("connecting");
   const stateVersionRef = useRef(-1);
   const requestRef = useRef(0);
   const lastSyncRef = useRef(0);
   const sessionStatus = session?.status;
 
-  const load = useCallback(async (quiet = false) => {
+  const load = useCallback(
+    async (quiet = false) => {
     const requestId = ++requestRef.current;
     if (!quiet) setLoading(true);
-    const res = await fetch(`/api/live-sessions/${sessionId}`, { cache: "no-store" }).catch(() => null);
+      const res = await fetch(`/api/live-sessions/${sessionId}`, {
+        cache: "no-store",
+      }).catch(() => null);
     if (!res) {
-      if (requestId === requestRef.current) setConnection(navigator.onLine ? "reconnecting" : "offline");
+        if (requestId === requestRef.current)
+          setConnection(navigator.onLine ? "reconnecting" : "offline");
       if (!quiet) setLoading(false);
       return;
     }
     const data = await res.json().catch(() => ({}));
     if (requestId !== requestRef.current) return;
     if (!res.ok) {
+        if (data.code === "ENROLLMENT_REQUIRED") {
+          setEnrollmentGate({
+            courseId: data.course?.id,
+            courseTitle: data.course?.title,
+            courseSlug: data.course?.slug,
+            isFree: data.course?.isFree,
+            message:
+              data.error || "Enroll in this course to join the live session.",
+          });
+          setSession(null);
+          setNotice("");
+        } else {
       setNotice(data.error || "Could not enter this live session.");
+        }
       if (!quiet) setLoading(false);
       return;
     }
     const next = data.session as LearnerLiveSession;
+      setEnrollmentGate(null);
     setSession(next);
     stateVersionRef.current = next.stateVersion;
     lastSyncRef.current = Date.now();
     setConnection("synced");
     setSelectedId((current) => {
-      const visible = next.activities.filter((item) => item.status !== "draft");
-      const desired = next.pace === "facilitator"
-        ? next.currentActivityId || visible.find((item) => item.status === "open")?.id
+        const visible = next.activities.filter(
+          (item) => item.status !== "draft",
+        );
+        const desired =
+          next.pace === "facilitator"
+            ? next.currentActivityId ||
+              visible.find((item) => item.status === "open")?.id
         : current || visible[0]?.id;
-      return visible.some((item) => item.id === desired) ? desired || "" : visible[0]?.id || "";
+        return visible.some((item) => item.id === desired)
+          ? desired || ""
+          : visible[0]?.id || "";
     });
-    setValues((current) => ({ ...Object.fromEntries(Object.values(next.responses).map((response) => [response.activityId, response.value])), ...current }));
+      setValues((current) => ({
+        ...Object.fromEntries(
+          Object.values(next.responses).map((response) => [
+            response.activityId,
+            response.value,
+          ]),
+        ),
+        ...current,
+      }));
     setNotice("");
     if (!quiet) setLoading(false);
-  }, [sessionId]);
+    },
+    [sessionId],
+  );
 
   useEffect(() => {
     const timer = window.setTimeout(() => void load(), 0);
@@ -80,9 +143,17 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
     let timer = 0;
     async function poll() {
       try {
-        const res = await fetch(`/api/live-sessions/${sessionId}/state`, { cache: "no-store" });
+        const res = await fetch(`/api/live-sessions/${sessionId}/state`, {
+          cache: "no-store",
+        });
         const payload = await res.json().catch(() => ({}));
-        if (!res.ok) throw new Error(payload.error || "Room state unavailable");
+        if (!res.ok) {
+          if (payload.code === "ENROLLMENT_REQUIRED") {
+            await load(true);
+            return;
+          }
+          throw new Error(payload.error || "Room state unavailable");
+        }
         if (cancelled) return;
         const state = payload.state as LiveSessionState;
         lastSyncRef.current = Date.now();
@@ -90,7 +161,9 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
         if (state.stateVersion !== stateVersionRef.current) {
           await load(true);
         } else {
-          setSession((current) => current ? {
+          setSession((current) =>
+            current
+              ? {
             ...current,
             status: state.status,
             pace: state.pace,
@@ -99,13 +172,16 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
               ...item,
               status: state.activityStatuses[item.id] || item.status,
             })),
-          } : current);
+                }
+              : current,
+          );
           if (state.pace === "facilitator" && state.currentActivityId) {
             setSelectedId(state.currentActivityId);
           }
         }
       } catch {
-        if (!cancelled) setConnection(navigator.onLine ? "reconnecting" : "offline");
+        if (!cancelled)
+          setConnection(navigator.onLine ? "reconnecting" : "offline");
       } finally {
         if (!cancelled) timer = window.setTimeout(poll, 1200);
       }
@@ -131,15 +207,30 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
     return () => window.clearInterval(timer);
   }, []);
 
+  useEffect(() => {
+    if (!workbookOpen) return;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setWorkbookOpen(false);
+    };
+    window.addEventListener("keydown", closeOnEscape);
+    return () => window.removeEventListener("keydown", closeOnEscape);
+  }, [workbookOpen]);
+
   const activity = session?.activities.find((item) => item.id === selectedId);
-  const activityIndex = session?.activities.findIndex((item) => item.id === selectedId) ?? -1;
+  const activityIndex =
+    session?.activities.findIndex((item) => item.id === selectedId) ?? -1;
   const response = activity ? session?.responses[activity.id] : undefined;
-  const availableActivities = useMemo(() => session?.activities.filter((item) => item.status !== "draft") || [], [session?.activities]);
+  const availableActivities = useMemo(
+    () => session?.activities.filter((item) => item.status !== "draft") || [],
+    [session?.activities],
+  );
+  const activityPosition = activityIndex >= 0 ? activityIndex + 1 : null;
 
   async function submit(valueOverride?: string | string[]) {
     if (!activity || submitting) return;
     const value = valueOverride ?? values[activity.id];
-    if ((typeof value === "string" && !value.trim()) || value === undefined) return;
+    if ((typeof value === "string" && !value.trim()) || value === undefined)
+      return;
     setSubmitting(true);
     setNotice("");
     const res = await fetch(`/api/live-sessions/${sessionId}/responses`, {
@@ -149,7 +240,17 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
     });
     const data = await res.json().catch(() => ({}));
     if (res.ok) {
-      setSession((current) => current ? { ...current, responses: { ...current.responses, [activity.id]: data.response as LiveResponseRecord } } : current);
+      setSession((current) =>
+        current
+          ? {
+              ...current,
+              responses: {
+                ...current.responses,
+                [activity.id]: data.response as LiveResponseRecord,
+              },
+            }
+          : current,
+      );
       if (session?.pace === "learner") goNext();
     } else setNotice(data.error || "Could not save your response.");
     setSubmitting(false);
@@ -157,56 +258,664 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
 
   function goNext() {
     if (!session) return;
-    const index = availableActivities.findIndex((item) => item.id === selectedId);
+    const index = availableActivities.findIndex(
+      (item) => item.id === selectedId,
+    );
     const next = availableActivities[index + 1];
     if (next) setSelectedId(next.id);
   }
 
+  async function enrollAndEnter() {
+    if (!enrollmentGate?.courseId || enrolling) return;
+    setEnrolling(true);
+    setNotice("");
+    const res = await fetch("/api/enrollments", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ courseId: enrollmentGate.courseId }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.ok || res.status === 409) {
+      await load();
+    } else {
+      setNotice(data.error || "Could not enroll in this course.");
+    }
+    setEnrolling(false);
+  }
+
   if (loading) return <Centered message="Entering the live room…" />;
-  if (!session) return <Centered message={notice || "This session is unavailable."} error />;
+  if (enrollmentGate) {
+    return (
+      <EnrollmentRequired
+        gate={enrollmentGate}
+        notice={notice}
+        enrolling={enrolling}
+        onEnroll={enrollAndEnter}
+      />
+    );
+  }
+  if (!session)
+    return (
+      <Centered message={notice || "This session is unavailable."} error />
+    );
   if (session.status === "lobby") {
     return (
-      <main style={getCourseThemeStyle(session.courseTheme) as CSSProperties} className="flex min-h-screen items-center justify-center bg-[var(--course-primary)] px-5 py-12 text-[var(--course-on-primary)]">
-        <div className="w-full max-w-lg text-center"><span className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-white/10"><Radio className="h-6 w-6 text-[var(--course-accent)]" /></span><p className="mt-8 text-xs font-bold uppercase tracking-[0.22em] text-[var(--course-accent)]">You’re in the room</p><h1 className="mt-3 text-3xl font-bold tracking-tight sm:text-4xl">{session.title}</h1><p className="mt-4 text-sm leading-6 opacity-70">The facilitator will begin shortly. Keep this page open; your workbook will update automatically.</p><div className="mx-auto mt-8 inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-xs font-bold"><Users className="h-4 w-4" />{session.participantCount} joined</div><LoaderCircle className="mx-auto mt-8 h-5 w-5 animate-spin opacity-50" /></div>
+      <main
+        style={getCourseThemeStyle(session.courseTheme) as CSSProperties}
+        className="flex min-h-screen items-center justify-center bg-[var(--course-primary)] px-5 py-12 text-[var(--course-on-primary)]"
+      >
+        <div className="w-full max-w-lg text-center">
+          <span className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-white/10">
+            <Radio className="h-6 w-6 text-[var(--course-accent)]" />
+          </span>
+          <p className="mt-8 text-xs font-bold uppercase tracking-[0.22em] text-[var(--course-accent)]">
+            You’re in the room
+          </p>
+          <h1 className="mt-3 text-3xl font-bold tracking-tight sm:text-4xl">
+            {session.title}
+          </h1>
+          <p className="mt-4 text-sm leading-6 opacity-70">
+            The facilitator will begin shortly. Keep this page open; your
+            workbook will update automatically.
+          </p>
+          <div className="mx-auto mt-8 inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-xs font-bold">
+            <Users className="h-4 w-4" />
+            {session.participantCount} joined
+          </div>
+          <LoaderCircle className="mx-auto mt-8 h-5 w-5 animate-spin opacity-50" />
+        </div>
       </main>
     );
   }
 
-  if (session.status === "ended" && !activity) return <Centered message="This live session has ended. Your responses are saved with your course." />;
+  if (session.status === "ended" && !activity)
+    return (
+      <Centered message="This live session has ended. Your responses are saved with your course." />
+    );
 
   return (
-    <main style={getCourseThemeStyle(session.courseTheme) as CSSProperties} className="min-h-screen bg-[var(--course-background)] text-[var(--course-text)]">
+    <main
+      style={getCourseThemeStyle(session.courseTheme) as CSSProperties}
+      className="min-h-screen bg-[var(--course-background)] text-[var(--course-text)]"
+    >
       <header className="sticky top-0 z-30 border-b border-slate-200 bg-[var(--course-surface)]/95 backdrop-blur">
-        <div className="mx-auto flex h-16 max-w-6xl items-center gap-3 px-4 sm:px-6">
-          <Link href="/dashboard" className="flex h-9 w-9 items-center justify-center rounded-lg bg-[var(--course-primary)] text-[var(--course-on-primary)]"><FlaskConical className="h-4 w-4" /></Link>
-          <div className="min-w-0 flex-1"><p className="truncate text-sm font-bold">{session.title}</p><p className="text-[10px] font-bold uppercase tracking-widest text-red-600">{session.status === "ended" ? "Session ended" : "Live now"}</p></div>
-          <span className={cn("inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] font-bold", connection === "synced" ? "bg-emerald-50 text-emerald-700" : "bg-amber-50 text-amber-700")}><span className={cn("h-1.5 w-1.5 rounded-full", connection === "synced" ? "bg-emerald-500" : "animate-pulse bg-amber-500")} />{connection === "synced" ? "In sync" : connection === "offline" ? "Offline" : "Reconnecting"}</span>
-          <span className="hidden items-center gap-1.5 text-xs text-slate-400 sm:inline-flex"><Users className="h-3.5 w-3.5" />{session.participantCount}</span>
+        <div className="mx-auto flex h-16 max-w-[1600px] items-center gap-2 px-3 sm:gap-3 sm:px-6 lg:px-10">
+          <Link
+            href="/dashboard"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[var(--course-primary)] text-[var(--course-on-primary)]"
+          >
+            <FlaskConical className="h-4 w-4" />
+          </Link>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-xs font-bold sm:text-sm">
+              {session.title}
+            </p>
+            <p className="text-[9px] font-bold uppercase tracking-widest text-red-600 sm:text-[10px]">
+              {session.status === "ended" ? "Session ended" : "Live now"}
+            </p>
+          </div>
+          <span
+            className={cn(
+              "hidden items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] font-bold sm:inline-flex",
+              connection === "synced"
+                ? "bg-emerald-50 text-emerald-700"
+                : "bg-amber-50 text-amber-700",
+            )}
+          >
+            <span
+              className={cn(
+                "h-1.5 w-1.5 rounded-full",
+                connection === "synced"
+                  ? "bg-emerald-500"
+                  : "animate-pulse bg-amber-500",
+              )}
+            />
+            {connection === "synced"
+              ? "In sync"
+              : connection === "offline"
+                ? "Offline"
+                : "Reconnecting"}
+          </span>
+          <span className="hidden items-center gap-1.5 text-xs opacity-50 lg:inline-flex">
+            <Users className="h-3.5 w-3.5" />
+            {session.participantCount}
+          </span>
+          <button
+            type="button"
+            onClick={() => setWorkbookOpen(true)}
+            aria-expanded={workbookOpen}
+            aria-controls="live-workbook-drawer"
+            className="inline-flex h-9 shrink-0 items-center gap-2 rounded-lg border border-slate-200 bg-[var(--course-surface)] px-3 text-xs font-bold shadow-sm hover:border-slate-300"
+          >
+            <BookOpen className="h-4 w-4" />
+            <span className="hidden sm:inline">Activities</span>
+            <span className="rounded bg-[var(--course-background)] px-1.5 py-0.5 text-[10px]">
+              {activityPosition || "–"}/{session.activities.length}
+            </span>
+            <ChevronDown className="hidden h-3.5 w-3.5 opacity-50 sm:block" />
+          </button>
         </div>
       </header>
-      <div className="mx-auto grid max-w-6xl gap-6 px-4 py-6 sm:px-6 lg:grid-cols-[250px_minmax(0,1fr)] lg:py-10">
-        <aside className="hidden lg:block"><div className="sticky top-24 rounded-2xl border border-slate-200 bg-white p-3"><p className="px-2 py-2 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400">Your workbook</p><div className="mt-1 space-y-1">{session.activities.map((item, index) => { const locked = item.status === "draft"; const done = Boolean(session.responses[item.id]); return <button key={item.id} disabled={locked || session.pace === "facilitator"} onClick={() => setSelectedId(item.id)} className={cn("flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left", item.id === activity?.id ? "bg-slate-950 text-white" : locked ? "text-slate-300" : "text-slate-600 hover:bg-slate-50")}><span className="text-[10px] font-bold opacity-50">{String(index + 1).padStart(2, "0")}</span><span className="min-w-0 flex-1 truncate text-xs font-bold">{item.title}</span>{locked ? <LockKeyhole className="h-3.5 w-3.5" /> : done ? <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" /> : null}</button>; })}</div></div></aside>
+      <div className="mx-auto w-full max-w-[1600px] px-3 py-4 sm:px-6 sm:py-6 lg:px-10 lg:py-8">
         <section className="min-w-0">
-          <div className="mb-4 flex items-center justify-between text-xs text-slate-400"><span>Activity {activityIndex + 1} of {session.activities.length}</span>{activity?.estimatedMinutes ? <span className="inline-flex items-center gap-1.5"><Clock3 className="h-3.5 w-3.5" />{activity.estimatedMinutes} min</span> : null}</div>
-          {activity ? <LearnerActivity activity={activity} learnerSeed={session.participant.id} value={values[activity.id]} response={response} submitting={submitting} onChange={(value) => setValues((current) => ({ ...current, [activity.id]: value }))} onSubmit={submit} /> : <div className="rounded-2xl border border-slate-200 bg-white p-12 text-center"><Radio className="mx-auto h-6 w-6 text-slate-300" /><p className="mt-4 text-sm font-bold text-slate-700">The room is live. No activity is open yet.</p><p className="mt-2 text-xs leading-5 text-slate-400">Keep this page open. The next activity will appear here as soon as the facilitator presents it.</p>{connection !== "synced" ? <button onClick={() => void load(true)} className="mt-5 rounded-lg border border-slate-200 px-3 py-2 text-xs font-bold text-slate-700">Reconnect now</button> : null}</div>}
-          {notice ? <p className="mt-4 rounded-xl bg-amber-50 px-4 py-3 text-sm text-amber-800">{notice}</p> : null}
-          {session.pace === "learner" && activity ? <div className="mt-5 flex justify-between"><button disabled={availableActivities.findIndex((item) => item.id === activity.id) <= 0} onClick={() => { const index = availableActivities.findIndex((item) => item.id === activity.id); setSelectedId(availableActivities[index - 1]?.id || activity.id); }} className="inline-flex items-center gap-2 text-sm font-bold text-slate-500 disabled:opacity-30"><ArrowLeft className="h-4 w-4" /> Previous</button><button onClick={goNext} className="inline-flex items-center gap-2 text-sm font-bold text-slate-700">Next <ArrowRight className="h-4 w-4" /></button></div> : null}
+          <div className="mb-3 flex items-center justify-between text-xs opacity-50 sm:mb-4">
+            <span>
+              {activityPosition
+                ? `Activity ${activityPosition} of ${session.activities.length}`
+                : "Waiting for the current activity"}
+            </span>
+            {activity?.estimatedMinutes ? (
+              <span className="inline-flex items-center gap-1.5">
+                <Clock3 className="h-3.5 w-3.5" />
+                {activity.estimatedMinutes} min
+              </span>
+            ) : null}
+          </div>
+          {activity ? (
+            <LearnerActivity
+              activity={activity}
+              learnerSeed={session.participant.id}
+              value={values[activity.id]}
+              response={response}
+              submitting={submitting}
+              onChange={(value) =>
+                setValues((current) => ({ ...current, [activity.id]: value }))
+              }
+              onSubmit={submit}
+            />
+          ) : (
+            <div className="flex min-h-[55dvh] items-center justify-center rounded-2xl border border-slate-200 bg-[var(--course-surface)] p-8 text-center">
+              <div>
+                <Radio className="mx-auto h-6 w-6 opacity-25" />
+                <p className="mt-4 text-sm font-bold">
+                  Ready for the next activity
+                </p>
+                <p className="mt-2 text-xs leading-5 opacity-50">
+                  You are enrolled and connected. The activity will appear when
+                  your facilitator presents it.
+                </p>
+                {connection !== "synced" ? (
+                  <button
+                    onClick={() => void load(true)}
+                    className="mt-5 rounded-lg border border-slate-200 px-3 py-2 text-xs font-bold"
+                  >
+                    Reconnect now
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          )}
+          {notice ? (
+            <p className="mt-4 rounded-xl bg-amber-50 px-4 py-3 text-sm text-amber-800">
+              {notice}
+            </p>
+          ) : null}
+          {session.pace === "learner" && activity ? (
+            <div className="mt-5 flex justify-between">
+              <button
+                disabled={
+                  availableActivities.findIndex(
+                    (item) => item.id === activity.id,
+                  ) <= 0
+                }
+                onClick={() => {
+                  const index = availableActivities.findIndex(
+                    (item) => item.id === activity.id,
+                  );
+                  setSelectedId(
+                    availableActivities[index - 1]?.id || activity.id,
+                  );
+                }}
+                className="inline-flex items-center gap-2 text-sm font-bold text-slate-500 disabled:opacity-30"
+              >
+                <ArrowLeft className="h-4 w-4" /> Previous
+              </button>
+              <button
+                onClick={goNext}
+                className="inline-flex items-center gap-2 text-sm font-bold text-slate-700"
+              >
+                Next <ArrowRight className="h-4 w-4" />
+              </button>
+            </div>
+          ) : null}
         </section>
       </div>
-      <CourseAgentDrawer courseSlug={session.courseSlug} role="learner" context={{ page: "live_session", title: activity?.title || session.title, visibleText: [activity?.prompt, activity?.instructions, activity?.successCriteria].filter(Boolean).join("\n") }} />
+      <WorkbookDrawer
+        open={workbookOpen}
+        session={session}
+        selectedId={activity?.id}
+        onClose={() => setWorkbookOpen(false)}
+        onSelect={(activityId) => {
+          setSelectedId(activityId);
+          setWorkbookOpen(false);
+        }}
+      />
+      <CourseAgentDrawer
+        courseSlug={session.courseSlug}
+        role="learner"
+        context={{
+          page: "live_session",
+          title: activity?.title || session.title,
+          visibleText: [
+            activity?.prompt,
+            activity?.instructions,
+            activity?.successCriteria,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        }}
+      />
     </main>
   );
 }
 
-function LearnerActivity({ activity, learnerSeed, value, response, submitting, onChange, onSubmit }: { activity: LiveActivity; learnerSeed: string; value?: string | string[]; response?: LiveResponseRecord; submitting: boolean; onChange: (value: string | string[]) => void; onSubmit: (valueOverride?: string | string[]) => void }) {
-  const isChoice = activity.options.length > 0;
-  const result = activity.status === "closed" && activity.showResults;
-  return <article className="overflow-hidden rounded-2xl border border-slate-200 bg-[var(--course-surface)]"><div className="p-6 sm:p-9"><div className="flex items-center justify-between"><span className="rounded-full bg-[var(--course-accent)] px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest text-[var(--course-on-accent)]">{labelFor(activity.type)}</span>{activity.required ? <span className="text-[10px] font-bold uppercase tracking-wide opacity-50">Required</span> : null}</div><h1 className="mt-6 text-3xl font-bold tracking-tight">{activity.title}</h1>{activity.prompt ? <p className="mt-4 text-lg leading-8 opacity-80">{activity.prompt}</p> : null}{activity.instructions ? <div className="mt-6 whitespace-pre-wrap rounded-xl bg-[var(--course-background)] p-4 text-sm leading-7 opacity-80">{activity.instructions}</div> : null}{activity.successCriteria ? <div className="mt-4 border-l-2 border-[var(--course-highlight)] pl-4"><p className="text-[10px] font-bold uppercase tracking-wide opacity-50">Done when</p><p className="mt-1 text-sm leading-6 opacity-80">{activity.successCriteria}</p></div> : null}{activity.resourceUrl ? <a href={activity.resourceUrl} target="_blank" rel="noreferrer" className="mt-5 inline-flex items-center gap-2 text-sm font-bold underline underline-offset-4">Open activity resource <ExternalLink className="h-4 w-4" /></a> : null}</div>{activity.materialId ? <div className="border-t border-slate-100 p-4 sm:p-6"><CourseMaterialViewer materialId={activity.materialId} compact /></div> : null}
-    {isChoice ? <div className="border-t border-slate-100 bg-slate-50 p-5 sm:p-7"><div className="grid gap-3 sm:grid-cols-2">{orderedOptions(activity, learnerSeed).map((option) => { const selected = value === option.id || (Array.isArray(value) && value.includes(option.id)); return <button key={option.id} disabled={activity.status !== "open" || Boolean(response)} onClick={() => onChange(option.id)} className={cn("min-h-16 rounded-xl border bg-white p-4 text-left text-sm font-bold transition", selected ? "border-slate-950 ring-1 ring-slate-950" : "border-slate-200 hover:border-slate-400", result && option.isCorrect && "border-emerald-500 bg-emerald-50 ring-1 ring-emerald-500", response && !result && "disabled:opacity-70")}>{option.label}{result && option.isCorrect ? <Check className="ml-2 inline h-4 w-4 text-emerald-600" /> : null}</button>; })}</div>{response ? <Saved /> : <button onClick={() => onSubmit()} disabled={!value || submitting || activity.status !== "open"} className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-slate-950 px-5 py-3 text-sm font-bold text-white disabled:opacity-40">{submitting ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />} Submit response</button>}</div> : activity.type === "content" || activity.type === "break" ? <div className="border-t border-slate-100 bg-slate-50 p-5 sm:p-7">{response ? <Saved /> : <button onClick={() => onSubmit("complete")} disabled={submitting || activity.status !== "open"} className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-slate-950 px-5 py-3 text-sm font-bold text-white disabled:opacity-40"><Check className="h-4 w-4" /> {activity.type === "break" ? "I’m back" : "Mark as viewed"}</button>}</div> : <div className="border-t border-slate-100 bg-slate-50 p-5 sm:p-7"><textarea value={typeof value === "string" ? value : ""} onChange={(event) => onChange(event.target.value)} disabled={activity.status !== "open" || Boolean(response)} rows={6} placeholder={activity.type === "task" ? "Add a short response, link, or note about your artefact…" : "Write your response…"} className="w-full resize-y rounded-xl border border-slate-200 bg-white p-4 text-sm leading-6 outline-none focus:border-slate-400 disabled:bg-slate-100" />{response ? <Saved /> : <button onClick={() => onSubmit()} disabled={!value || submitting || activity.status !== "open"} className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-slate-950 px-5 py-3 text-sm font-bold text-white disabled:opacity-40">{submitting ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />} Save response</button>}</div>}</article>;
+function EnrollmentRequired({
+  gate,
+  notice,
+  enrolling,
+  onEnroll,
+}: {
+  gate: EnrollmentGate;
+  notice: string;
+  enrolling: boolean;
+  onEnroll: () => void;
+}) {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-slate-950 px-4 py-10 text-white sm:px-6">
+      <div className="w-full max-w-md rounded-3xl border border-white/10 bg-white/[0.06] p-6 shadow-2xl backdrop-blur sm:p-8">
+        <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[#71E0E7]/15 text-[#71E0E7]">
+          <GraduationCap className="h-6 w-6" />
+        </span>
+        <p className="mt-7 text-xs font-bold uppercase tracking-[0.2em] text-[#71E0E7]">
+          Enrollment required
+        </p>
+        <h1 className="mt-3 text-2xl font-bold tracking-tight sm:text-3xl">
+          Join the course to enter this room
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-slate-300">{gate.message}</p>
+        {gate.courseTitle ? (
+          <div className="mt-6 rounded-2xl border border-white/10 bg-white/[0.05] p-4">
+            <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
+              Course
+            </p>
+            <p className="mt-1 text-sm font-bold text-white">
+              {gate.courseTitle}
+            </p>
+          </div>
+        ) : null}
+        {notice ? (
+          <p className="mt-4 rounded-xl bg-amber-400/10 px-4 py-3 text-sm text-amber-200">
+            {notice}
+          </p>
+        ) : null}
+        <div className="mt-6 space-y-3">
+          {gate.isFree && gate.courseId ? (
+            <button
+              type="button"
+              onClick={onEnroll}
+              disabled={enrolling}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[#B8F56D] px-5 py-3.5 text-sm font-bold text-slate-950 transition hover:bg-[#c7fa83] disabled:opacity-60"
+            >
+              {enrolling ? (
+                <LoaderCircle className="h-4 w-4 animate-spin" />
+              ) : (
+                <GraduationCap className="h-4 w-4" />
+              )}
+              {enrolling ? "Enrolling…" : "Enroll and join live session"}
+            </button>
+          ) : gate.courseSlug ? (
+            <Link
+              href={`/courses/${gate.courseSlug}`}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-white px-5 py-3.5 text-sm font-bold text-slate-950"
+            >
+              View enrollment options <ArrowRight className="h-4 w-4" />
+            </Link>
+          ) : null}
+          <Link
+            href="/join"
+            className="block w-full py-2 text-center text-xs font-bold text-slate-400 hover:text-white"
+          >
+            Use a different session code
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
 }
 
-function Saved() { return <div className="mt-3 flex items-center justify-center gap-2 rounded-xl bg-emerald-50 px-4 py-3 text-sm font-bold text-emerald-700"><CheckCircle2 className="h-4 w-4" /> Response saved</div>; }
-function Centered({ message, error }: { message: string; error?: boolean }) { return <main className="flex min-h-screen items-center justify-center bg-slate-950 px-5 text-center text-white"><div><span className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-white/10">{error ? <LockKeyhole className="h-5 w-5 text-amber-300" /> : <Sparkles className="h-5 w-5 text-[#71E0E7]" />}</span><p className="mt-5 max-w-md text-sm leading-6 text-slate-300">{message}</p>{error ? <Link href="/join" className="mt-5 inline-block text-sm font-bold text-white underline">Try another code</Link> : null}</div></main>; }
-function orderedOptions(activity: LiveActivity, learnerSeed: string) { if (!activity.randomizeOptions) return activity.options; return [...activity.options].sort((a, b) => seeded(`${learnerSeed}:${activity.id}:${a.id}`) - seeded(`${learnerSeed}:${activity.id}:${b.id}`)); }
-function seeded(value: string) { let hash = 0; for (let i = 0; i < value.length; i += 1) hash = ((hash << 5) - hash + value.charCodeAt(i)) | 0; return Math.abs(hash); }
-function labelFor(type: LiveActivity["type"]) { return ({ content: "Workbook", setup_check: "Setup check", poll: "Quick poll", quiz: "Knowledge check", reflection: "Reflection", task: "Practice", break: "Break" } as const)[type]; }
+function WorkbookDrawer({
+  open,
+  session,
+  selectedId,
+  onClose,
+  onSelect,
+}: {
+  open: boolean;
+  session: LearnerLiveSession;
+  selectedId?: string;
+  onClose: () => void;
+  onSelect: (activityId: string) => void;
+}) {
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="workbook-title"
+    >
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute inset-0 bg-slate-950/45 backdrop-blur-[2px]"
+        aria-label="Close activities"
+      />
+      <section
+        id="live-workbook-drawer"
+        className="absolute inset-x-0 bottom-0 flex max-h-[82dvh] flex-col rounded-t-3xl border border-slate-200 bg-[var(--course-surface)] text-[var(--course-text)] shadow-2xl sm:inset-y-0 sm:left-auto sm:right-0 sm:max-h-none sm:w-[390px] sm:rounded-none sm:rounded-l-3xl"
+      >
+        <div className="flex items-start gap-4 border-b border-slate-200 px-5 py-5 sm:px-6">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-[var(--course-primary)] text-[var(--course-on-primary)]">
+            <BookOpen className="h-4 w-4" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <h2 id="workbook-title" className="font-bold">
+              Activities
+            </h2>
+            <p className="mt-1 text-xs opacity-55">
+              {session.pace === "facilitator"
+                ? "Your facilitator controls what appears next."
+                : "Move through the available workbook activities."}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-slate-200"
+            aria-label="Close activities"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3 sm:p-4">
+          <div className="space-y-1.5">
+            {session.activities.map((item, index) => {
+              const locked = item.status === "draft";
+              const selected = item.id === selectedId;
+              const done = Boolean(session.responses[item.id]);
+              const canSelect =
+                !locked && (session.pace === "learner" || selected);
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  disabled={!canSelect}
+                  onClick={() => onSelect(item.id)}
+                  className={cn(
+                    "flex w-full items-center gap-3 rounded-xl border px-3 py-3 text-left transition",
+                    selected
+                      ? "border-transparent bg-[var(--course-primary)] text-[var(--course-on-primary)]"
+                      : "border-transparent hover:border-slate-200 hover:bg-[var(--course-background)]",
+                    !canSelect && !selected && "cursor-default opacity-45",
+                  )}
+                >
+                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-current/10 text-[10px] font-bold">
+                    {String(index + 1).padStart(2, "0")}
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-sm font-bold leading-5">
+                      {item.title || `Activity ${index + 1}`}
+                    </span>
+                    <span className="mt-0.5 block text-[10px] font-bold uppercase tracking-wide opacity-50">
+                      {selected
+                        ? "Showing now"
+                        : done
+                          ? "Completed"
+                          : locked
+                            ? "Upcoming"
+                            : labelFor(item.type)}
+                    </span>
+                  </span>
+                  {locked ? (
+                    <LockKeyhole className="h-3.5 w-3.5 shrink-0" />
+                  ) : done ? (
+                    <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-500" />
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function LearnerActivity({
+  activity,
+  learnerSeed,
+  value,
+  response,
+  submitting,
+  onChange,
+  onSubmit,
+}: {
+  activity: LiveActivity;
+  learnerSeed: string;
+  value?: string | string[];
+  response?: LiveResponseRecord;
+  submitting: boolean;
+  onChange: (value: string | string[]) => void;
+  onSubmit: (valueOverride?: string | string[]) => void;
+}) {
+  const isChoice = activity.options.length > 0;
+  const result = activity.status === "closed" && activity.showResults;
+  return (
+    <article className="overflow-hidden rounded-2xl border border-slate-200 bg-[var(--course-surface)]">
+      <div className="p-6 sm:p-9">
+        <div className="flex items-center justify-between">
+          <span className="rounded-full bg-[var(--course-accent)] px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest text-[var(--course-on-accent)]">
+            {labelFor(activity.type)}
+          </span>
+          {activity.required ? (
+            <span className="text-[10px] font-bold uppercase tracking-wide opacity-50">
+              Required
+            </span>
+          ) : null}
+        </div>
+        <h1 className="mt-6 text-3xl font-bold tracking-tight">
+          {activity.title}
+        </h1>
+        {activity.prompt ? (
+          <p className="mt-4 text-lg leading-8 opacity-80">{activity.prompt}</p>
+        ) : null}
+        {activity.instructions ? (
+          <div className="mt-6 whitespace-pre-wrap rounded-xl bg-[var(--course-background)] p-4 text-sm leading-7 opacity-80">
+            {activity.instructions}
+          </div>
+        ) : null}
+        {activity.successCriteria ? (
+          <div className="mt-4 border-l-2 border-[var(--course-highlight)] pl-4">
+            <p className="text-[10px] font-bold uppercase tracking-wide opacity-50">
+              Done when
+            </p>
+            <p className="mt-1 text-sm leading-6 opacity-80">
+              {activity.successCriteria}
+            </p>
+          </div>
+        ) : null}
+        {activity.resourceUrl ? (
+          <a
+            href={activity.resourceUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-5 inline-flex items-center gap-2 text-sm font-bold underline underline-offset-4"
+          >
+            Open activity resource <ExternalLink className="h-4 w-4" />
+          </a>
+        ) : null}
+      </div>
+      {activity.materialId ? (
+        <div className="border-t border-slate-100 p-4 sm:p-6">
+          <CourseMaterialViewer materialId={activity.materialId} compact />
+        </div>
+      ) : null}
+      {isChoice ? (
+        <div className="border-t border-slate-100 bg-slate-50 p-5 sm:p-7">
+          <div className="grid gap-3 sm:grid-cols-2">
+            {orderedOptions(activity, learnerSeed).map((option) => {
+              const selected =
+                value === option.id ||
+                (Array.isArray(value) && value.includes(option.id));
+              return (
+                <button
+                  key={option.id}
+                  disabled={activity.status !== "open" || Boolean(response)}
+                  onClick={() => onChange(option.id)}
+                  className={cn(
+                    "min-h-16 rounded-xl border bg-white p-4 text-left text-sm font-bold transition",
+                    selected
+                      ? "border-slate-950 ring-1 ring-slate-950"
+                      : "border-slate-200 hover:border-slate-400",
+                    result &&
+                      option.isCorrect &&
+                      "border-emerald-500 bg-emerald-50 ring-1 ring-emerald-500",
+                    response && !result && "disabled:opacity-70",
+                  )}
+                >
+                  {option.label}
+                  {result && option.isCorrect ? (
+                    <Check className="ml-2 inline h-4 w-4 text-emerald-600" />
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+          {response ? (
+            <Saved />
+          ) : (
+            <button
+              onClick={() => onSubmit()}
+              disabled={!value || submitting || activity.status !== "open"}
+              className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-slate-950 px-5 py-3 text-sm font-bold text-white disabled:opacity-40"
+            >
+              {submitting ? (
+                <LoaderCircle className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}{" "}
+              Submit response
+            </button>
+          )}
+        </div>
+      ) : activity.type === "content" || activity.type === "break" ? (
+        <div className="border-t border-slate-100 bg-slate-50 p-5 sm:p-7">
+          {response ? (
+            <Saved />
+          ) : (
+            <button
+              onClick={() => onSubmit("complete")}
+              disabled={submitting || activity.status !== "open"}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-slate-950 px-5 py-3 text-sm font-bold text-white disabled:opacity-40"
+            >
+              <Check className="h-4 w-4" />{" "}
+              {activity.type === "break" ? "I’m back" : "Mark as viewed"}
+            </button>
+          )}
+        </div>
+      ) : (
+        <div className="border-t border-slate-100 bg-slate-50 p-5 sm:p-7">
+          <textarea
+            value={typeof value === "string" ? value : ""}
+            onChange={(event) => onChange(event.target.value)}
+            disabled={activity.status !== "open" || Boolean(response)}
+            rows={6}
+            placeholder={
+              activity.type === "task"
+                ? "Add a short response, link, or note about your artefact…"
+                : "Write your response…"
+            }
+            className="w-full resize-y rounded-xl border border-slate-200 bg-white p-4 text-sm leading-6 outline-none focus:border-slate-400 disabled:bg-slate-100"
+          />
+          {response ? (
+            <Saved />
+          ) : (
+            <button
+              onClick={() => onSubmit()}
+              disabled={!value || submitting || activity.status !== "open"}
+              className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-slate-950 px-5 py-3 text-sm font-bold text-white disabled:opacity-40"
+            >
+              {submitting ? (
+                <LoaderCircle className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}{" "}
+              Save response
+            </button>
+          )}
+        </div>
+      )}
+    </article>
+  );
+}
+
+function Saved() {
+  return (
+    <div className="mt-3 flex items-center justify-center gap-2 rounded-xl bg-emerald-50 px-4 py-3 text-sm font-bold text-emerald-700">
+      <CheckCircle2 className="h-4 w-4" /> Response saved
+    </div>
+  );
+}
+function Centered({ message, error }: { message: string; error?: boolean }) {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-white px-5 text-center text-slate-950">
+      <div>
+        <span className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-slate-100">
+          {error ? (
+            <LockKeyhole className="h-5 w-5 text-amber-600" />
+          ) : (
+            <LoaderCircle className="h-5 w-5 animate-spin text-slate-500" />
+          )}
+        </span>
+        <p className="mt-5 max-w-md text-sm leading-6 text-slate-500">
+          {message}
+        </p>
+        {error ? (
+          <Link
+            href="/join"
+            className="mt-5 inline-block text-sm font-bold text-slate-900 underline"
+          >
+            Try another code
+          </Link>
+        ) : null}
+      </div>
+    </main>
+  );
+}
+function orderedOptions(activity: LiveActivity, learnerSeed: string) {
+  if (!activity.randomizeOptions) return activity.options;
+  return [...activity.options].sort(
+    (a, b) =>
+      seeded(`${learnerSeed}:${activity.id}:${a.id}`) -
+      seeded(`${learnerSeed}:${activity.id}:${b.id}`),
+  );
+}
+function seeded(value: string) {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1)
+    hash = ((hash << 5) - hash + value.charCodeAt(i)) | 0;
+  return Math.abs(hash);
+}
+function labelFor(type: LiveActivity["type"]) {
+  return (
+    {
+      content: "Workbook",
+      setup_check: "Setup check",
+      poll: "Quick poll",
+      quiz: "Knowledge check",
+      reflection: "Reflection",
+      task: "Practice",
+      break: "Break",
+    } as const
+  )[type];
+}


### PR DESCRIPTION
## Summary\n- show a dedicated enrollment-required state and one-click enrollment for eligible free live courses\n- replace the permanent workbook sidebar with a full-width activity canvas and responsive activity drawer/bottom sheet\n- eliminate Activity 0 and blank numbered rows from the learner experience\n- default pre-brand loading and error states to a clean light canvas\n- add authenticated PNG/SVG QR downloads plus native QR sharing for educators\n\n## Verification\n- pnpm --filter commons-courses exec tsc --noEmit\n- pnpm --filter commons-courses test (6/6)\n- pnpm --filter commons-courses build\n- git diff --check