### PR TITLE
Add true full-screen and extended-display presentation modes

### DIFF
--- a/apps/commons-app/components/artifacts/artifact-surface.tsx
+++ b/apps/commons-app/components/artifacts/artifact-surface.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ChevronLeft,
   ChevronRight,
@@ -37,6 +37,7 @@ export function ArtifactSurface({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [fullscreen, setFullscreen] = useState(false);
+  const surfaceRef = useRef<HTMLElement>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -67,6 +68,23 @@ export function ArtifactSurface({
     load();
   }, [load]);
 
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setFullscreen(document.fullscreenElement === surfaceRef.current);
+    };
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () =>
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+  }, []);
+
+  async function toggleFullscreen() {
+    if (document.fullscreenElement === surfaceRef.current) {
+      await document.exitFullscreen();
+      return;
+    }
+    await surfaceRef.current?.requestFullscreen({ navigationUI: "hide" });
+  }
+
   const resolved = useMemo<ArtifactRef>(
     () => ({
       ...artifact,
@@ -80,6 +98,7 @@ export function ArtifactSurface({
 
   return (
     <aside
+      ref={surfaceRef}
       className={cn(
         "relative z-40 flex h-full min-h-0 shrink-0 flex-col overflow-hidden border-l border-stone-200 bg-stone-50 shadow-2xl max-lg:absolute max-lg:inset-0 max-lg:w-full",
         fullscreen
@@ -87,7 +106,12 @@ export function ArtifactSurface({
           : "w-[min(760px,58vw)] min-w-[460px]",
       )}
     >
-      <header className="flex h-14 shrink-0 items-center gap-3 border-b border-stone-200 bg-white px-3">
+      <header
+        className={cn(
+          "flex h-14 shrink-0 items-center gap-3 border-b border-stone-200 bg-white px-3",
+          fullscreen && artifactKind(resolved) === "presentation" && "hidden",
+        )}
+      >
         <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-stone-100 text-stone-600">
           <ArtifactIcon artifact={resolved} className="h-4.5 w-4.5" />
         </span>
@@ -143,7 +167,7 @@ export function ArtifactSurface({
           )}
           <ToolbarButton
             label={fullscreen ? "Exit full screen" : "Full screen"}
-            onClick={() => setFullscreen((value) => !value)}
+            onClick={() => void toggleFullscreen()}
           >
             {fullscreen ? (
               <Minimize2 className="h-4 w-4" />

--- a/apps/commons-courses/app/present/materials/[id]/page.tsx
+++ b/apps/commons-courses/app/present/materials/[id]/page.tsx
@@ -1,0 +1,14 @@
+import { CourseMaterialViewer } from "@/components/course-material-viewer";
+
+export default async function MaterialPresenterPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <main className="h-dvh overflow-hidden bg-slate-950">
+      <CourseMaterialViewer materialId={id} presenter />
+    </main>
+  );
+}

--- a/apps/commons-courses/components/course-material-viewer.tsx
+++ b/apps/commons-courses/components/course-material-viewer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ChevronLeft,
   ChevronRight,
@@ -8,7 +8,9 @@ import {
   Expand,
   FileText,
   LoaderCircle,
+  MonitorUp,
   MousePointer2,
+  PictureInPicture2,
   X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -27,16 +29,30 @@ type MaterialData = {
 export function CourseMaterialViewer({
   materialId,
   compact = false,
+  presenter = false,
 }: {
   materialId: string;
   compact?: boolean;
+  presenter?: boolean;
 }) {
   const [material, setMaterial] = useState<MaterialData | null>(null);
   const [error, setError] = useState("");
   const [slide, setSlide] = useState(0);
   const [full, setFull] = useState(false);
+  const [controlsVisible, setControlsVisible] = useState(true);
+  const [presenterNotice, setPresenterNotice] = useState("");
   const [pointerEnabled, setPointerEnabled] = useState(false);
   const [pointer, setPointer] = useState<{ x: number; y: number } | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const channelRef = useRef<BroadcastChannel | null>(null);
+  const sourceIdRef = useRef("");
+  const stateRef = useRef({
+    slide: 0,
+    pointerEnabled: false,
+    pointer: null as { x: number; y: number } | null,
+  });
+  const controlsTimerRef = useRef<number | null>(null);
+  const receivedStateRef = useRef(false);
   useEffect(() => {
     let cancelled = false;
     fetch(`/api/course-materials/${materialId}`, { cache: "no-store" })
@@ -63,33 +79,168 @@ export function CourseMaterialViewer({
   const visualSlideCount = material?.imageUrls.length || 0;
   const presentationSlideCount = visualSlideCount || slides.length || 1;
   useEffect(() => {
+    stateRef.current = { slide, pointerEnabled, pointer };
+  }, [pointer, pointerEnabled, slide]);
+  useEffect(() => {
+    if (typeof BroadcastChannel === "undefined") return;
+    sourceIdRef.current ||= crypto.randomUUID();
+    const channel = new BroadcastChannel(
+      `commonlab-presentation:${materialId}`,
+    );
+    channelRef.current = channel;
+    channel.onmessage = (
+      event: MessageEvent<{
+        source?: string;
+        type?: string;
+        slide?: number;
+        pointerEnabled?: boolean;
+        pointer?: { x: number; y: number } | null;
+      }>,
+    ) => {
+      const message = event.data;
+      if (!message || message.source === sourceIdRef.current) return;
+      if (message.type === "ready") {
+        channel.postMessage({
+          type: "state",
+          source: sourceIdRef.current,
+          ...stateRef.current,
+        });
+        return;
+      }
+      if (message.type !== "state") return;
+      receivedStateRef.current = true;
+      if (typeof message.slide === "number")
+        setSlide(
+          Math.max(0, Math.min(presentationSlideCount - 1, message.slide)),
+        );
+      if (typeof message.pointerEnabled === "boolean")
+        setPointerEnabled(message.pointerEnabled);
+      setPointer(message.pointer || null);
+    };
+    channel.postMessage({ type: "ready", source: sourceIdRef.current });
+    return () => {
+      channel.close();
+      channelRef.current = null;
+    };
+  }, [materialId, presentationSlideCount]);
+  const broadcastState = useCallback(
+    (next: Partial<typeof stateRef.current>) => {
+      const state = { ...stateRef.current, ...next };
+      stateRef.current = state;
+      channelRef.current?.postMessage({
+        type: "state",
+        source: sourceIdRef.current,
+        ...state,
+      });
+    },
+    [],
+  );
+  useEffect(() => {
+    if (receivedStateRef.current) return;
+    broadcastState({ slide, pointerEnabled, pointer });
+  }, [broadcastState, pointer, pointerEnabled, slide]);
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      const active = document.fullscreenElement === containerRef.current;
+      setFull(active);
+      setControlsVisible(true);
+    };
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () =>
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+  }, []);
+  const revealControls = useCallback(() => {
+    setControlsVisible(true);
+    if (controlsTimerRef.current) window.clearTimeout(controlsTimerRef.current);
+    if (full || presenter) {
+      controlsTimerRef.current = window.setTimeout(
+        () => setControlsVisible(false),
+        2400,
+      );
+    }
+  }, [full, presenter]);
+  useEffect(() => {
+    if (full || presenter) revealControls();
+  }, [full, presenter, revealControls]);
+  useEffect(
+    () => () => {
+      if (controlsTimerRef.current)
+        window.clearTimeout(controlsTimerRef.current);
+    },
+    [],
+  );
+  async function toggleFullscreen() {
+    if (document.fullscreenElement === containerRef.current) {
+      await document.exitFullscreen();
+      return;
+    }
+    try {
+      await containerRef.current?.requestFullscreen({ navigationUI: "hide" });
+    } catch {
+      setPresenterNotice(
+        "Your browser blocked full screen. Use the browser menu or press F11.",
+      );
+    }
+  }
+  function openPresenterWindow() {
+    const popup = window.open(
+      `/present/materials/${materialId}`,
+      `commonlab-presenter-${materialId}`,
+      "popup=yes,width=1440,height=900,menubar=no,toolbar=no,location=no,status=no",
+    );
+    if (popup) {
+      popup.focus();
+      setPresenterNotice(
+        "Presentation window opened. Move it to the extended display, then choose Full screen there.",
+      );
+    } else {
+      setPresenterNotice(
+        "Allow pop-ups for CommonLab, then try Presenter window again.",
+      );
+    }
+  }
+  useEffect(() => {
     if (material?.kind !== "presentation") return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (isEditableTarget(event.target)) return;
       if (["ArrowLeft", "PageUp"].includes(event.key)) {
         event.preventDefault();
-        setSlide((value) => Math.max(0, value - 1));
+        setSlide((value) => {
+          const next = Math.max(0, value - 1);
+          broadcastState({ slide: next });
+          return next;
+        });
       }
       if (["ArrowRight", "PageDown", " "].includes(event.key)) {
         event.preventDefault();
-        setSlide((value) => Math.min(presentationSlideCount - 1, value + 1));
+        setSlide((value) => {
+          const next = Math.min(presentationSlideCount - 1, value + 1);
+          broadcastState({ slide: next });
+          return next;
+        });
       }
       if (event.key === "Home") {
         event.preventDefault();
         setSlide(0);
+        broadcastState({ slide: 0 });
       }
       if (event.key === "End") {
         event.preventDefault();
         setSlide(presentationSlideCount - 1);
+        broadcastState({ slide: presentationSlideCount - 1 });
       }
       if (event.key.toLowerCase() === "l") {
-        setPointerEnabled((value) => !value);
+        setPointerEnabled((value) => {
+          broadcastState({ pointerEnabled: !value, pointer: null });
+          return !value;
+        });
         setPointer(null);
       }
+      if (event.key.toLowerCase() === "f") void toggleFullscreen();
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [material?.kind, presentationSlideCount]);
+  }, [broadcastState, material?.kind, presentationSlideCount]);
   if (error)
     return (
       <div className="rounded-xl bg-amber-50 p-4 text-sm text-amber-800">
@@ -109,7 +260,7 @@ export function CourseMaterialViewer({
         src={`${material.downloadUrl}#toolbar=0&view=FitH`}
         className={cn(
           "w-full border-0 bg-slate-100",
-          full ? "h-[calc(100dvh-64px)]" : compact ? "h-[58vh]" : "h-[72vh]",
+          full || presenter ? "h-dvh" : compact ? "h-[58vh]" : "h-[72vh]",
         )}
       />
     ) : material.kind === "presentation" && visualSlideCount ? (
@@ -119,7 +270,7 @@ export function CourseMaterialViewer({
         alt={`${material.name}, slide ${slide + 1}`}
         className={cn(
           "mx-auto w-full bg-slate-950 object-contain",
-          full ? "h-[calc(100dvh-112px)]" : compact ? "h-[58vh]" : "h-[72vh]",
+          full || presenter ? "h-dvh" : compact ? "h-[58vh]" : "h-[72vh]",
         )}
       />
     ) : material.kind === "presentation" &&
@@ -130,7 +281,7 @@ export function CourseMaterialViewer({
         src={`https://view.officeapps.live.com/op/embed.aspx?src=${encodeURIComponent(material.downloadUrl)}`}
         className={cn(
           "w-full border-0 bg-slate-950",
-          full ? "h-[calc(100dvh-64px)]" : compact ? "h-[58vh]" : "h-[72vh]",
+          full || presenter ? "h-dvh" : compact ? "h-[58vh]" : "h-[72vh]",
         )}
         allowFullScreen
       />
@@ -138,7 +289,7 @@ export function CourseMaterialViewer({
       <div
         className={cn(
           "flex min-h-[420px] items-center justify-center bg-slate-950 p-8 text-white sm:p-14",
-          full && "min-h-[calc(100dvh-64px)]",
+          (full || presenter) && "min-h-dvh",
         )}
       >
         <div className="w-full max-w-5xl">
@@ -153,20 +304,40 @@ export function CourseMaterialViewer({
     );
   return (
     <div
+      ref={containerRef}
+      onPointerMove={revealControls}
       className={cn(
         "overflow-hidden rounded-2xl border border-slate-200 bg-white",
-        full && "fixed inset-0 z-[100] rounded-none border-0 bg-slate-950",
+        (full || presenter) &&
+          "fixed inset-0 z-[100] rounded-none border-0 bg-slate-950",
       )}
     >
-      <div className="flex h-14 items-center gap-3 border-b border-slate-200 bg-white px-4">
+      <div
+        className={cn(
+          "flex h-14 items-center gap-3 border-b border-slate-200 bg-white px-4 transition-opacity duration-300",
+          (full || presenter) &&
+            "absolute inset-x-0 top-0 z-20 border-white/10 bg-slate-950/75 text-white backdrop-blur",
+          (full || presenter) &&
+            !controlsVisible &&
+            "pointer-events-none opacity-0",
+        )}
+      >
         <FileText className="h-4 w-4 text-slate-400" />
-        <p className="min-w-0 flex-1 truncate text-sm font-bold text-slate-800">
+        <p
+          className={cn(
+            "min-w-0 flex-1 truncate text-sm font-bold",
+            full || presenter ? "text-white" : "text-slate-800",
+          )}
+        >
           {material.name}
         </p>
         {material.kind === "presentation" ? (
           <button
             onClick={() => {
-              setPointerEnabled((value) => !value);
+              setPointerEnabled((value) => {
+                broadcastState({ pointerEnabled: !value, pointer: null });
+                return !value;
+              });
               setPointer(null);
             }}
             className={cn(
@@ -176,6 +347,16 @@ export function CourseMaterialViewer({
             title={`${pointerEnabled ? "Turn off" : "Turn on"} laser pointer (L)`}
           >
             <MousePointer2 className="h-4 w-4" />
+          </button>
+        ) : null}
+        {material.kind === "presentation" && !presenter ? (
+          <button
+            onClick={openPresenterWindow}
+            className="inline-flex items-center gap-2 rounded-lg px-2.5 py-2 text-xs font-bold text-slate-500 hover:bg-slate-100"
+            title="Open presenter window for an extended display"
+          >
+            <PictureInPicture2 className="h-4 w-4" />
+            <span className="hidden xl:inline">Presenter window</span>
           </button>
         ) : null}
         {material.downloadUrl ? (
@@ -188,11 +369,14 @@ export function CourseMaterialViewer({
           </a>
         ) : null}
         <button
-          onClick={() => setFull(!full)}
-          className="rounded-lg p-2 text-slate-500 hover:bg-slate-100"
-          title={full ? "Exit presentation" : "Present full screen"}
+          onClick={() => void toggleFullscreen()}
+          className="inline-flex items-center gap-2 rounded-lg px-2.5 py-2 text-xs font-bold text-slate-500 hover:bg-slate-100"
+          title={full ? "Exit full screen (F)" : "Present full screen (F)"}
         >
           {full ? <X className="h-4 w-4" /> : <Expand className="h-4 w-4" />}
+          <span className="hidden xl:inline">
+            {full ? "Exit full screen" : "Full screen"}
+          </span>
         </button>
       </div>
       <div
@@ -203,12 +387,17 @@ export function CourseMaterialViewer({
         onPointerMove={(event) => {
           if (!pointerEnabled || material.kind !== "presentation") return;
           const bounds = event.currentTarget.getBoundingClientRect();
-          setPointer({
+          const nextPointer = {
             x: ((event.clientX - bounds.left) / bounds.width) * 100,
             y: ((event.clientY - bounds.top) / bounds.height) * 100,
-          });
+          };
+          setPointer(nextPointer);
+          broadcastState({ pointer: nextPointer });
         }}
-        onPointerLeave={() => setPointer(null)}
+        onPointerLeave={() => {
+          setPointer(null);
+          broadcastState({ pointer: null });
+        }}
       >
         {stage}
         {pointerEnabled && pointer ? (
@@ -223,10 +412,25 @@ export function CourseMaterialViewer({
       (visualSlideCount > 0 ||
         !material.downloadUrl ||
         material.embeddable === false) ? (
-        <div className="flex h-14 items-center justify-between border-t border-slate-800 bg-slate-950 px-4 text-white">
+        <div
+          className={cn(
+            "flex h-14 items-center justify-between border-t border-slate-800 bg-slate-950 px-4 text-white transition-opacity duration-300",
+            (full || presenter) &&
+              "absolute inset-x-0 bottom-0 z-20 border-white/10 bg-slate-950/75 backdrop-blur",
+            (full || presenter) &&
+              !controlsVisible &&
+              "pointer-events-none opacity-0",
+          )}
+        >
           <button
             disabled={slide <= 0}
-            onClick={() => setSlide((value) => Math.max(0, value - 1))}
+            onClick={() =>
+              setSlide((value) => {
+                const next = Math.max(0, value - 1);
+                broadcastState({ slide: next });
+                return next;
+              })
+            }
             className="inline-flex items-center gap-2 text-xs font-bold disabled:opacity-30"
           >
             <ChevronLeft className="h-4 w-4" /> Previous
@@ -237,13 +441,28 @@ export function CourseMaterialViewer({
           <button
             disabled={slide >= presentationSlideCount - 1}
             onClick={() =>
-              setSlide((value) =>
-                Math.min(presentationSlideCount - 1, value + 1),
-              )
+              setSlide((value) => {
+                const next = Math.min(presentationSlideCount - 1, value + 1);
+                broadcastState({ slide: next });
+                return next;
+              })
             }
             className="inline-flex items-center gap-2 text-xs font-bold disabled:opacity-30"
           >
             Next <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      ) : null}
+      {presenterNotice && !presenter ? (
+        <div className="absolute bottom-16 left-1/2 z-30 max-w-lg -translate-x-1/2 rounded-xl bg-slate-950/90 px-4 py-3 text-center text-xs font-bold text-white shadow-2xl">
+          <MonitorUp className="mr-2 inline h-4 w-4" />
+          {presenterNotice}
+          <button
+            onClick={() => setPresenterNotice("")}
+            className="ml-3 opacity-60 hover:opacity-100"
+            aria-label="Dismiss"
+          >
+            <X className="inline h-3.5 w-3.5" />
           </button>
         </div>
       ) : null}


### PR DESCRIPTION
## Summary\n- use the browser Fullscreen API for genuine edge-to-edge PowerPoint/PDF presentation\n- add a dedicated authenticated presenter window for extended displays\n- synchronize slide navigation and laser pointer between facilitator and presentation windows\n- fade controls during presentation and restore them on pointer movement\n- upgrade Commons artifact full screen from an in-app overlay to browser full screen\n\n## Controls\n- Arrow keys, Page Up/Down, Space: navigate\n- Home/End: first/last slide\n- L: laser pointer\n- F: full screen\n\n## Verification\n- commons-courses TypeScript passed\n- commons-app TypeScript passed\n- commons-courses tests passed (6/6)\n- commons-courses production build passed\n- git diff --check