### PR TITLE
Fix live learner activity synchronization

### DIFF
--- a/apps/commons-courses/app/api/educator/live-sessions/[id]/route.ts
+++ b/apps/commons-courses/app/api/educator/live-sessions/[id]/route.ts
@@ -27,11 +27,16 @@ export async function GET(
 ) {
   const { id } = await params;
   const authResult = await authorize(id);
-  if (!authResult) return NextResponse.json({ error: "Session not found." }, { status: 404 });
+  if (!authResult)
+    return NextResponse.json({ error: "Session not found." }, { status: 404 });
   if (authResult.error) return authResult.error;
   const { session, result } = authResult;
   const [serialized, participants, results] = await Promise.all([
-    serializeEducatorLiveSession(session, result.course.title, result.course.theme),
+    serializeEducatorLiveSession(
+      session,
+      result.course.title,
+      result.course.theme,
+    ),
     getParticipants(session._id),
     getSessionResults(session, session.settings.showParticipantNames),
   ]);
@@ -44,24 +49,30 @@ export async function PATCH(
 ) {
   const { id } = await params;
   const authResult = await authorize(id);
-  if (!authResult) return NextResponse.json({ error: "Session not found." }, { status: 404 });
+  if (!authResult)
+    return NextResponse.json({ error: "Session not found." }, { status: 404 });
   if (authResult.error) return authResult.error;
   const { session, result } = authResult;
   const body = await req.json().catch(() => ({}));
-  const record = body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+  const record =
+    body && typeof body === "object" ? (body as Record<string, unknown>) : {};
   const patch = normalizeSessionPatch(body);
 
   if (record.command === "open_lobby") {
     session.status = "lobby";
   } else if (record.command === "start") {
     session.status = "live";
-    const current = session.activities.find((activity: LiveActivity) => activity.id === session.currentActivityId && activity.status === "open");
+    const current = session.activities.find(
+      (activity: LiveActivity) =>
+        activity.id === session.currentActivityId && activity.status === "open",
+    );
     const first = current || session.activities[0];
     if (first) {
       if (session.pace === "learner") {
         for (const activity of session.activities) activity.status = "open";
       } else {
-        for (const activity of session.activities) activity.status = activity.id === first.id ? "open" : "closed";
+        for (const activity of session.activities)
+          activity.status = activity.id === first.id ? "open" : "closed";
       }
       session.currentActivityId = first.id;
     }
@@ -71,20 +82,37 @@ export async function PATCH(
       if (activity.status === "open") activity.status = "closed";
     }
   } else if (record.command === "activate") {
-    const activityId = typeof record.activityId === "string" ? record.activityId : "";
-    if (!session.activities.some((activity: LiveActivity) => activity.id === activityId)) {
-      return NextResponse.json({ error: "Activity not found." }, { status: 404 });
+    const activityId =
+      typeof record.activityId === "string" ? record.activityId : "";
+    if (
+      !session.activities.some(
+        (activity: LiveActivity) => activity.id === activityId,
+      )
+    ) {
+      return NextResponse.json(
+        { error: "Activity not found." },
+        { status: 404 },
+      );
     }
     session.status = "live";
     session.currentActivityId = activityId;
     for (const activity of session.activities) {
       if (activity.id === activityId) activity.status = "open";
-      else if (activity.status === "open") activity.status = "closed";
+      else if (session.pace === "facilitator" && activity.status === "open") {
+        activity.status = "closed";
+      }
     }
   } else if (record.command === "close_activity") {
-    const activityId = typeof record.activityId === "string" ? record.activityId : "";
-    const activity = session.activities.find((item: LiveActivity) => item.id === activityId);
-    if (!activity) return NextResponse.json({ error: "Activity not found." }, { status: 404 });
+    const activityId =
+      typeof record.activityId === "string" ? record.activityId : "";
+    const activity = session.activities.find(
+      (item: LiveActivity) => item.id === activityId,
+    );
+    if (!activity)
+      return NextResponse.json(
+        { error: "Activity not found." },
+        { status: 404 },
+      );
     activity.status = "closed";
   } else if (Object.keys(patch).length) {
     session.set(patch);
@@ -94,6 +122,10 @@ export async function PATCH(
   session.markModified("activities");
   await session.save();
   return NextResponse.json({
-    session: await serializeEducatorLiveSession(session, result.course.title, result.course.theme),
+    session: await serializeEducatorLiveSession(
+      session,
+      result.course.title,
+      result.course.theme,
+    ),
   });
 }

--- a/apps/commons-courses/app/api/live-sessions/[id]/state/route.ts
+++ b/apps/commons-courses/app/api/live-sessions/[id]/state/route.ts
@@ -3,7 +3,10 @@ import { Types } from "mongoose";
 import { auth } from "@/lib/auth";
 import { connectDB } from "@/lib/db";
 import { getCourseCollaboratorRole } from "@/lib/educator-auth";
-import { resolveCurrentActivityId } from "@/lib/live-session-data";
+import {
+  learnerSafeActivities,
+  resolveCurrentActivityId,
+} from "@/lib/live-session-data";
 import Course from "@/models/Course";
 import Enrollment from "@/models/Enrollment";
 import LiveParticipant from "@/models/LiveParticipant";
@@ -33,7 +36,7 @@ export async function GET(
 
   await connectDB();
   const session = await LiveSession.findById(id).select(
-    "courseId status pace access invitedEmails currentActivityId stateVersion activities.id activities.status settings.allowLateJoin",
+    "courseId status pace access invitedEmails currentActivityId stateVersion activities settings.allowLateJoin",
   );
   if (!session || session.status === "draft") {
     return NextResponse.json(
@@ -105,21 +108,29 @@ export async function GET(
     }
   }
 
+  const currentActivityId = resolveCurrentActivityId(session);
+  const currentActivity = session.activities.find(
+    (activity: LiveActivity) => activity.id === currentActivityId,
+  );
+
   return NextResponse.json(
     {
-    state: {
-      status: session.status,
-      pace: session.pace,
-      currentActivityId: resolveCurrentActivityId(session),
-      stateVersion: session.stateVersion || 0,
-      activityStatuses: Object.fromEntries(
+      state: {
+        status: session.status,
+        pace: session.pace,
+        currentActivityId,
+        currentActivity: currentActivity
+          ? learnerSafeActivities([currentActivity])[0]
+          : undefined,
+        stateVersion: session.stateVersion || 0,
+        activityStatuses: Object.fromEntries(
           session.activities.map((activity: LiveActivity) => [
             activity.id,
             activity.status,
           ]),
-      ),
-      serverTime: new Date().toISOString(),
-    },
+        ),
+        serverTime: new Date().toISOString(),
+      },
     },
     { headers: noStore },
   );

--- a/apps/commons-courses/components/live/live-learner-room.tsx
+++ b/apps/commons-courses/components/live/live-learner-room.tsx
@@ -31,6 +31,10 @@ import { CourseAgentDrawer } from "@/components/course-agents/course-agent-drawe
 import { CourseMaterialViewer } from "@/components/course-material-viewer";
 import { cn } from "@/lib/utils";
 import { getCourseThemeStyle } from "@/lib/course-theme";
+import {
+  learnerAvailableActivities,
+  resolveLearnerActivitySelection,
+} from "@/lib/live-learner-selection";
 import type {
   LearnerLiveSession,
   LiveActivity,
@@ -62,26 +66,44 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
     "connecting" | "synced" | "reconnecting" | "offline"
   >("connecting");
   const stateVersionRef = useRef(-1);
+  const observedStateVersionRef = useRef(-1);
+  const presentedActivityRef = useRef("");
+  const sessionRef = useRef<LearnerLiveSession | null>(null);
   const requestRef = useRef(0);
   const lastSyncRef = useRef(0);
   const sessionStatus = session?.status;
 
+  const applySelection = useCallback((next: LearnerLiveSession) => {
+    const lastPresentedActivityId = presentedActivityRef.current;
+    setSelectedId((selectedActivityId) =>
+      resolveLearnerActivitySelection({
+        activities: next.activities,
+        currentActivityId: next.currentActivityId,
+        lastPresentedActivityId,
+        pace: next.pace,
+        responses: next.responses,
+        selectedActivityId,
+      }),
+    );
+    presentedActivityRef.current = next.currentActivityId || "";
+  }, []);
+
   const load = useCallback(
     async (quiet = false) => {
-    const requestId = ++requestRef.current;
-    if (!quiet) setLoading(true);
+      const requestId = ++requestRef.current;
+      if (!quiet) setLoading(true);
       const res = await fetch(`/api/live-sessions/${sessionId}`, {
         cache: "no-store",
       }).catch(() => null);
-    if (!res) {
+      if (!res) {
         if (requestId === requestRef.current)
           setConnection(navigator.onLine ? "reconnecting" : "offline");
-      if (!quiet) setLoading(false);
-      return;
-    }
-    const data = await res.json().catch(() => ({}));
-    if (requestId !== requestRef.current) return;
-    if (!res.ok) {
+        if (!quiet) setLoading(false);
+        return;
+      }
+      const data = await res.json().catch(() => ({}));
+      if (requestId !== requestRef.current) return;
+      if (!res.ok) {
         if (data.code === "ENROLLMENT_REQUIRED") {
           setEnrollmentGate({
             courseId: data.course?.id,
@@ -93,31 +115,28 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
           });
           setSession(null);
           setNotice("");
-        } else {
-      setNotice(data.error || "Could not enter this live session.");
+        } else if (!quiet) {
+          setNotice(data.error || "Could not enter this live session.");
         }
-      if (!quiet) setLoading(false);
-      return;
-    }
-    const next = data.session as LearnerLiveSession;
+        if (!quiet) setLoading(false);
+        return;
+      }
+      const next = data.session as LearnerLiveSession;
+      if (next.stateVersion < observedStateVersionRef.current) {
+        if (!quiet) setLoading(false);
+        return;
+      }
       setEnrollmentGate(null);
-    setSession(next);
-    stateVersionRef.current = next.stateVersion;
-    lastSyncRef.current = Date.now();
-    setConnection("synced");
-    setSelectedId((current) => {
-        const visible = next.activities.filter(
-          (item) => item.status !== "draft",
-        );
-        const desired =
-          next.pace === "facilitator"
-            ? next.currentActivityId ||
-              visible.find((item) => item.status === "open")?.id
-        : current || visible[0]?.id;
-        return visible.some((item) => item.id === desired)
-          ? desired || ""
-          : visible[0]?.id || "";
-    });
+      sessionRef.current = next;
+      setSession(next);
+      stateVersionRef.current = next.stateVersion;
+      observedStateVersionRef.current = Math.max(
+        observedStateVersionRef.current,
+        next.stateVersion,
+      );
+      lastSyncRef.current = Date.now();
+      setConnection("synced");
+      applySelection(next);
       setValues((current) => ({
         ...Object.fromEntries(
           Object.values(next.responses).map((response) => [
@@ -127,10 +146,49 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
         ),
         ...current,
       }));
-    setNotice("");
-    if (!quiet) setLoading(false);
+      setNotice("");
+      if (!quiet) setLoading(false);
     },
-    [sessionId],
+    [applySelection, sessionId],
+  );
+
+  const applyLiveState = useCallback(
+    (state: LiveSessionState) => {
+      observedStateVersionRef.current = Math.max(
+        observedStateVersionRef.current,
+        state.stateVersion,
+      );
+      const current = sessionRef.current;
+      if (!current) return;
+      const activities = current.activities.map((item) => {
+        const updated =
+          state.currentActivity?.id === item.id
+            ? { ...item, ...state.currentActivity }
+            : item;
+        return {
+          ...updated,
+          status: state.activityStatuses[item.id] || updated.status,
+        };
+      });
+      if (
+        state.currentActivity &&
+        !activities.some((item) => item.id === state.currentActivity?.id)
+      ) {
+        activities.push(state.currentActivity);
+      }
+      const next: LearnerLiveSession = {
+        ...current,
+        status: state.status,
+        pace: state.pace,
+        currentActivityId: state.currentActivityId,
+        stateVersion: state.stateVersion,
+        activities,
+      };
+      sessionRef.current = next;
+      setSession(next);
+      applySelection(next);
+    },
+    [applySelection],
   );
 
   useEffect(() => {
@@ -158,26 +216,9 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
         const state = payload.state as LiveSessionState;
         lastSyncRef.current = Date.now();
         setConnection("synced");
+        applyLiveState(state);
         if (state.stateVersion !== stateVersionRef.current) {
           await load(true);
-        } else {
-          setSession((current) =>
-            current
-              ? {
-            ...current,
-            status: state.status,
-            pace: state.pace,
-            currentActivityId: state.currentActivityId,
-            activities: current.activities.map((item) => ({
-              ...item,
-              status: state.activityStatuses[item.id] || item.status,
-            })),
-                }
-              : current,
-          );
-          if (state.pace === "facilitator" && state.currentActivityId) {
-            setSelectedId(state.currentActivityId);
-          }
         }
       } catch {
         if (!cancelled)
@@ -196,7 +237,7 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
       window.removeEventListener("online", reconnect);
       window.removeEventListener("focus", reconnect);
     };
-  }, [load, sessionId, sessionStatus]);
+  }, [applyLiveState, load, sessionId, sessionStatus]);
 
   useEffect(() => {
     const timer = window.setInterval(() => {
@@ -221,8 +262,15 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
     session?.activities.findIndex((item) => item.id === selectedId) ?? -1;
   const response = activity ? session?.responses[activity.id] : undefined;
   const availableActivities = useMemo(
-    () => session?.activities.filter((item) => item.status !== "draft") || [],
-    [session?.activities],
+    () =>
+      session
+        ? learnerAvailableActivities(
+            session.activities,
+            session.currentActivityId,
+            session.responses,
+          )
+        : [],
+    [session],
   );
   const activityPosition = activityIndex >= 0 ? activityIndex + 1 : null;
 
@@ -644,7 +692,10 @@ function WorkbookDrawer({
               const selected = item.id === selectedId;
               const done = Boolean(session.responses[item.id]);
               const canSelect =
-                !locked && (session.pace === "learner" || selected);
+                selected ||
+                (session.pace === "learner" &&
+                  !locked &&
+                  (item.status === "open" || done));
               return (
                 <button
                   key={item.id}
@@ -673,7 +724,9 @@ function WorkbookDrawer({
                           ? "Completed"
                           : locked
                             ? "Upcoming"
-                            : labelFor(item.type)}
+                            : item.status === "closed"
+                              ? "Closed"
+                              : labelFor(item.type)}
                     </span>
                   </span>
                   {locked ? (
@@ -724,7 +777,7 @@ function LearnerActivity({
           ) : null}
         </div>
         <h1 className="mt-6 text-3xl font-bold tracking-tight">
-          {activity.title}
+          {activity.title || labelFor(activity.type)}
         </h1>
         {activity.prompt ? (
           <p className="mt-4 text-lg leading-8 opacity-80">{activity.prompt}</p>
@@ -793,6 +846,8 @@ function LearnerActivity({
           </div>
           {response ? (
             <Saved />
+          ) : activity.status !== "open" ? (
+            <ResponsesClosed />
           ) : (
             <button
               onClick={() => onSubmit()}
@@ -812,6 +867,8 @@ function LearnerActivity({
         <div className="border-t border-slate-100 bg-slate-50 p-5 sm:p-7">
           {response ? (
             <Saved />
+          ) : activity.status !== "open" ? (
+            <ResponsesClosed />
           ) : (
             <button
               onClick={() => onSubmit("complete")}
@@ -822,6 +879,10 @@ function LearnerActivity({
               {activity.type === "break" ? "I’m back" : "Mark as viewed"}
             </button>
           )}
+        </div>
+      ) : activity.status !== "open" && !response ? (
+        <div className="border-t border-slate-100 bg-slate-50 p-5 sm:p-7">
+          <ResponsesClosed />
         </div>
       ) : (
         <div className="border-t border-slate-100 bg-slate-50 p-5 sm:p-7">
@@ -863,6 +924,13 @@ function Saved() {
   return (
     <div className="mt-3 flex items-center justify-center gap-2 rounded-xl bg-emerald-50 px-4 py-3 text-sm font-bold text-emerald-700">
       <CheckCircle2 className="h-4 w-4" /> Response saved
+    </div>
+  );
+}
+function ResponsesClosed() {
+  return (
+    <div className="flex items-center justify-center gap-2 rounded-xl bg-slate-100 px-4 py-3 text-sm font-bold text-slate-600">
+      <LockKeyhole className="h-4 w-4" /> Responses are closed
     </div>
   );
 }

--- a/apps/commons-courses/components/live/live-learner-room.tsx
+++ b/apps/commons-courses/components/live/live-learner-room.tsx
@@ -113,6 +113,7 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
             message:
               data.error || "Enroll in this course to join the live session.",
           });
+          sessionRef.current = null;
           setSession(null);
           setNotice("");
         } else if (!quiet) {
@@ -288,17 +289,18 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
     });
     const data = await res.json().catch(() => ({}));
     if (res.ok) {
-      setSession((current) =>
-        current
-          ? {
-              ...current,
-              responses: {
-                ...current.responses,
-                [activity.id]: data.response as LiveResponseRecord,
-              },
-            }
-          : current,
-      );
+      setSession((current) => {
+        if (!current) return current;
+        const next = {
+          ...current,
+          responses: {
+            ...current.responses,
+            [activity.id]: data.response as LiveResponseRecord,
+          },
+        };
+        sessionRef.current = next;
+        return next;
+      });
       if (session?.pace === "learner") goNext();
     } else setNotice(data.error || "Could not save your response.");
     setSubmitting(false);

--- a/apps/commons-courses/lib/live-activity-serialization.test.mts
+++ b/apps/commons-courses/lib/live-activity-serialization.test.mts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  LiveActivity,
+  LiveActivityOption,
+} from "../types/live-session.ts";
+import { learnerSafeActivities } from "./live-activity-serialization.ts";
+
+function mongooseLike<T extends object>(value: T) {
+  return {
+    _doc: value,
+    toObject: () => value,
+  } as unknown as T;
+}
+
+test("serializes complete learner fields from Mongoose-like subdocuments", () => {
+  const option = mongooseLike<LiveActivityOption>({
+    id: "answer-a",
+    label: "The visible answer",
+    isCorrect: true,
+  });
+  const activity = mongooseLike<LiveActivity>({
+    id: "current",
+    type: "poll",
+    title: "The visible title",
+    prompt: "The visible prompt",
+    facilitatorNotes: "Private",
+    status: "open",
+    required: true,
+    randomizeOptions: false,
+    showResults: true,
+    points: 0,
+    options: [option],
+  });
+
+  assert.deepEqual(learnerSafeActivities([activity]), [
+    {
+      id: "current",
+      type: "poll",
+      title: "The visible title",
+      prompt: "The visible prompt",
+      facilitatorNotes: undefined,
+      status: "open",
+      required: true,
+      randomizeOptions: false,
+      showResults: true,
+      points: 0,
+      options: [
+        {
+          id: "answer-a",
+          label: "The visible answer",
+          isCorrect: undefined,
+        },
+      ],
+    },
+  ]);
+});

--- a/apps/commons-courses/lib/live-activity-serialization.ts
+++ b/apps/commons-courses/lib/live-activity-serialization.ts
@@ -1,0 +1,28 @@
+import type { LiveActivity, LiveActivityOption } from "@/types/live-session";
+
+type DocumentLike<T> = T & { toObject?: () => T };
+
+function plain<T>(value: DocumentLike<T>): T {
+  return typeof value.toObject === "function" ? value.toObject() : value;
+}
+
+export function learnerSafeActivities(activities: LiveActivity[]) {
+  return activities.map((source) => {
+    const activity = plain(source as DocumentLike<LiveActivity>);
+    return {
+      ...activity,
+      facilitatorNotes: undefined,
+      options: activity.options.map((sourceOption) => {
+        const option = plain(sourceOption as DocumentLike<LiveActivityOption>);
+        return {
+          id: option.id,
+          label: option.label,
+          isCorrect:
+            activity.status === "closed" && activity.showResults
+              ? Boolean(option.isCorrect)
+              : undefined,
+        };
+      }),
+    } satisfies LiveActivity;
+  });
+}

--- a/apps/commons-courses/lib/live-learner-selection.test.mts
+++ b/apps/commons-courses/lib/live-learner-selection.test.mts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { LiveActivity } from "../types/live-session.ts";
+import { resolveLearnerActivitySelection } from "./live-learner-selection.ts";
+
+function activity(id: string, status: LiveActivity["status"]): LiveActivity {
+  return {
+    id,
+    status,
+    type: "content",
+    title: id,
+    required: false,
+    randomizeOptions: false,
+    showResults: false,
+    points: 0,
+    options: [],
+  };
+}
+
+const activities = [
+  activity("closed-first", "closed"),
+  activity("presented", "open"),
+  activity("upcoming", "draft"),
+];
+
+test("facilitator pace always resolves to the presented activity", () => {
+  assert.equal(
+    resolveLearnerActivitySelection({
+      activities,
+      currentActivityId: "presented",
+      lastPresentedActivityId: "presented",
+      pace: "facilitator",
+      responses: {},
+      selectedActivityId: "closed-first",
+    }),
+    "presented",
+  );
+});
+
+test("learner pace follows a newly presented activity once", () => {
+  assert.equal(
+    resolveLearnerActivitySelection({
+      activities,
+      currentActivityId: "presented",
+      lastPresentedActivityId: "closed-first",
+      pace: "learner",
+      responses: {},
+      selectedActivityId: "closed-first",
+    }),
+    "presented",
+  );
+});
+
+test("learner pace does not fall back to an unanswered closed activity", () => {
+  assert.equal(
+    resolveLearnerActivitySelection({
+      activities,
+      pace: "learner",
+      responses: {},
+      selectedActivityId: "closed-first",
+    }),
+    "presented",
+  );
+});
+
+test("learner pace preserves browsing after following the presenter", () => {
+  assert.equal(
+    resolveLearnerActivitySelection({
+      activities: [activity("presented", "open"), activity("browse", "open")],
+      currentActivityId: "presented",
+      lastPresentedActivityId: "presented",
+      pace: "learner",
+      responses: {},
+      selectedActivityId: "browse",
+    }),
+    "browse",
+  );
+});

--- a/apps/commons-courses/lib/live-learner-selection.ts
+++ b/apps/commons-courses/lib/live-learner-selection.ts
@@ -1,0 +1,67 @@
+import type {
+  LiveActivity,
+  LiveResponseRecord,
+  LiveSessionPace,
+} from "@/types/live-session";
+
+type SelectionInput = {
+  activities: LiveActivity[];
+  currentActivityId?: string;
+  lastPresentedActivityId?: string;
+  pace: LiveSessionPace;
+  responses: Record<string, LiveResponseRecord>;
+  selectedActivityId?: string;
+};
+
+export function resolveLearnerActivitySelection({
+  activities,
+  currentActivityId,
+  lastPresentedActivityId,
+  pace,
+  responses,
+  selectedActivityId,
+}: SelectionInput) {
+  const current = activities.find(
+    (activity) =>
+      activity.id === currentActivityId && activity.status !== "draft",
+  );
+  const firstOpen = activities.find((activity) => activity.status === "open");
+
+  if (pace === "facilitator") return current?.id || firstOpen?.id || "";
+
+  // A facilitator presenting something is an intentional live-room action,
+  // even in learner-paced rooms. Follow it once, then let the learner browse.
+  if (current && current.id !== lastPresentedActivityId) return current.id;
+
+  const selected = activities.find(
+    (activity) => activity.id === selectedActivityId,
+  );
+  if (
+    selected &&
+    (selected.status === "open" ||
+      selected.id === current?.id ||
+      Boolean(responses[selected.id]))
+  ) {
+    return selected.id;
+  }
+
+  return (
+    current?.id ||
+    firstOpen?.id ||
+    activities.find((activity) => Boolean(responses[activity.id]))?.id ||
+    ""
+  );
+}
+
+export function learnerAvailableActivities(
+  activities: LiveActivity[],
+  currentActivityId: string | undefined,
+  responses: Record<string, LiveResponseRecord>,
+) {
+  return activities.filter(
+    (activity) =>
+      activity.status === "open" ||
+      activity.id === currentActivityId ||
+      Boolean(responses[activity.id]),
+  );
+}

--- a/apps/commons-courses/lib/live-session-data.ts
+++ b/apps/commons-courses/lib/live-session-data.ts
@@ -3,6 +3,7 @@ import { normalizeCourseTheme, type CourseTheme } from "@/lib/course-theme";
 import LiveParticipant from "@/models/LiveParticipant";
 import LiveResponse from "@/models/LiveResponse";
 import type { ILiveSession } from "@/models/LiveSession";
+export { learnerSafeActivities } from "@/lib/live-activity-serialization";
 import type {
   LiveActivity,
   LiveActivityResults,
@@ -29,9 +30,18 @@ export async function serializeEducatorLiveSession(
     ]),
   ]);
   const responseCounts = Object.fromEntries(
-    responseCountRows.map((row: { _id: string; count: number }) => [row._id, row.count]),
+    responseCountRows.map((row: { _id: string; count: number }) => [
+      row._id,
+      row.count,
+    ]),
   );
-  return serializeBase(session, courseTitle, courseTheme, participantCount, responseCounts);
+  return serializeBase(
+    session,
+    courseTitle,
+    courseTheme,
+    participantCount,
+    responseCounts,
+  );
 }
 
 export async function getParticipants(sessionId: Types.ObjectId) {
@@ -80,7 +90,10 @@ export async function getLearnerResponses(
   sessionId: Types.ObjectId,
   participantId: Types.ObjectId,
 ) {
-  const responses = await LiveResponse.find({ sessionId, participantId }).lean();
+  const responses = await LiveResponse.find({
+    sessionId,
+    participantId,
+  }).lean();
   return Object.fromEntries(
     responses.map((response) => [
       response.activityId,
@@ -93,21 +106,6 @@ export async function getLearnerResponses(
       } satisfies LiveResponseRecord,
     ]),
   );
-}
-
-export function learnerSafeActivities(activities: LiveActivity[]) {
-  return activities.map((activity) => ({
-    ...activity,
-    facilitatorNotes: undefined,
-    options: activity.options.map((option) => ({
-      id: option.id,
-      label: option.label,
-      isCorrect:
-        activity.status === "closed" && activity.showResults
-          ? Boolean(option.isCorrect)
-          : undefined,
-    })),
-  }));
 }
 
 function serializeBase(
@@ -143,12 +141,18 @@ function serializeBase(
   };
 }
 
-export function resolveCurrentActivityId(session: Pick<ILiveSession, "status" | "currentActivityId" | "activities">) {
+export function resolveCurrentActivityId(
+  session: Pick<ILiveSession, "status" | "currentActivityId" | "activities">,
+) {
   if (session.status !== "live" && session.status !== "ended") return undefined;
   const selected = session.activities.find(
-    (activity) => activity.id === session.currentActivityId && activity.status !== "draft",
+    (activity) =>
+      activity.id === session.currentActivityId && activity.status !== "draft",
   );
-  return selected?.id || session.activities.find((activity) => activity.status === "open")?.id;
+  return (
+    selected?.id ||
+    session.activities.find((activity) => activity.status === "open")?.id
+  );
 }
 
 function buildActivityResults(
@@ -172,7 +176,9 @@ function buildActivityResults(
         id: option.id,
         label: option.label,
         count: responses.filter((response) => {
-          const values = Array.isArray(response.value) ? response.value : [response.value];
+          const values = Array.isArray(response.value)
+            ? response.value
+            : [response.value];
           return values.includes(option.id);
         }).length,
       })),

--- a/apps/commons-courses/types/live-session.ts
+++ b/apps/commons-courses/types/live-session.ts
@@ -74,6 +74,7 @@ export type LiveSessionState = {
   status: LiveSessionStatus;
   pace: LiveSessionPace;
   currentActivityId?: string;
+  currentActivity?: LiveActivity;
   stateVersion: number;
   activityStatuses: Record<string, LiveActivityStatus>;
   serverTime: string;


### PR DESCRIPTION
## What changed

- serialize complete learner-safe activity data from Mongoose subdocuments
- include the current activity in lightweight live-state polling
- apply facilitator changes immediately before background reconciliation
- prevent older full responses from overwriting newer live state
- follow newly presented activities in both pacing modes
- keep closed, unanswered activities out of learner navigation
- preserve multiple open activities in learner-paced rooms
- add clear closed-response UI instead of a broken disabled form

## Root cause

Activity subdocuments were spread as plain objects, which exposed Mongoose internals instead of the actual title, prompt, type, and options. State-version changes also waited for a second full request before applying the facilitator-selected activity, while learner-paced selection defaulted to the first non-draft activity even when it was closed.

## Validation

- `pnpm test` — 11 passing
- `pnpm exec tsc --noEmit`
- targeted ESLint
- `pnpm build` — Next.js production build passed
- `git diff --check`
