### PR TITLE
Add live learner copilot controls

### DIFF
--- a/apps/commons-courses/app/api/course-agents/chat/route.ts
+++ b/apps/commons-courses/app/api/course-agents/chat/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Types } from "mongoose";
 import { auth } from "@/lib/auth";
 import { defaultCourseAgents } from "@/lib/course-agent-defaults";
 import { connectDB } from "@/lib/db";
@@ -13,8 +14,14 @@ import { scopedVectorSearch } from "@/lib/vector-search";
 import Course from "@/models/Course";
 import Enrollment from "@/models/Enrollment";
 import LearnerProfile from "@/models/LearnerProfile";
-import type { CourseAgentConfig, CourseAgentMessage } from "@/types/course-agent";
+import LiveSession from "@/models/LiveSession";
+import { normalizeLiveLearnerCopilotPolicy } from "@/lib/live-copilot-policy";
+import type {
+  CourseAgentConfig,
+  CourseAgentMessage,
+} from "@/types/course-agent";
 import type { LearnerProfileData } from "@/types/learner-profile";
+import type { LiveLearnerCopilotPolicy } from "@/types/live-session";
 
 type ChatBody = {
   courseSlug?: string;
@@ -24,6 +31,7 @@ type ChatBody = {
   messages?: CourseAgentMessage[];
   context?: {
     page: string;
+    liveSessionId?: string;
     title?: string;
     moduleIndex?: number;
     lessonIndex?: number;
@@ -54,7 +62,7 @@ export async function POST(req: NextRequest) {
   if (!body.courseSlug || !body.agentId || !body.message || !body.context) {
     return NextResponse.json(
       { error: "courseSlug, agentId, message, and context are required." },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
@@ -85,6 +93,42 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Forbidden." }, { status: 403 });
   }
 
+  let liveCopilotPolicy = null;
+  if (role === "learner" && body.context.page === "live_session") {
+    if (
+      !body.context.liveSessionId ||
+      !Types.ObjectId.isValid(body.context.liveSessionId)
+    ) {
+      return NextResponse.json(
+        { error: "A valid live session is required for copilot access." },
+        { status: 403 },
+      );
+    }
+    const liveSession = (await LiveSession.findOne({
+      _id: body.context.liveSessionId,
+      courseSlug: body.courseSlug,
+    })
+      .select("settings.learnerCopilot")
+      .lean()) as {
+      settings?: { learnerCopilot?: Partial<LiveLearnerCopilotPolicy> };
+    } | null;
+    if (!liveSession) {
+      return NextResponse.json(
+        { error: "Live session not found." },
+        { status: 404 },
+      );
+    }
+    liveCopilotPolicy = normalizeLiveLearnerCopilotPolicy(
+      liveSession.settings?.learnerCopilot,
+    );
+  }
+  if (liveCopilotPolicy && !liveCopilotPolicy.enabled) {
+    return NextResponse.json(
+      { error: "The learner copilot is disabled for this live session." },
+      { status: 403 },
+    );
+  }
+
   const agents =
     course.agents && course.agents.length > 0
       ? (course.agents as CourseAgentConfig[])
@@ -93,11 +137,14 @@ export async function POST(req: NextRequest) {
   if (!agent) {
     return NextResponse.json(
       { error: "This agent is not available in this context." },
-      { status: 403 }
+      { status: 403 },
     );
   }
 
-  const searchScope = await buildSearchScope({ courseSlug: body.courseSlug, role });
+  const searchScope = await buildSearchScope({
+    courseSlug: body.courseSlug,
+    role,
+  });
   if (!searchScope.ok) return searchScope.error;
 
   const learnerProgress =
@@ -117,13 +164,22 @@ export async function POST(req: NextRequest) {
           )
           .lean()) as Partial<LearnerProfileData> | null)
       : null;
-  const searchResults = await scopedVectorSearch({
-    scope: searchScope,
-    query: body.message,
-    limit: 5,
-  });
+  const searchResults =
+    liveCopilotPolicy?.useCourseMaterials === false
+      ? []
+      : await scopedVectorSearch({
+          scope: searchScope,
+          query: body.message,
+          limit: 5,
+        });
   const educatorAnalytics =
-    role === "educator" ? await buildCourseAnalyticsForAgent(course._id as never) : null;
+    role === "educator"
+      ? await buildCourseAnalyticsForAgent(course._id as never)
+      : null;
+  const agentContext =
+    liveCopilotPolicy?.explainCurrentActivity === false
+      ? { ...body.context, visibleText: undefined }
+      : body.context;
 
   const reply = await runCourseAgent({
     course,
@@ -131,7 +187,8 @@ export async function POST(req: NextRequest) {
     role,
     message: body.message,
     messages: body.messages || [],
-    context: body.context,
+    context: agentContext,
+    liveCopilotPolicy,
     searchResults,
     learnerProgress,
     learnerProfile,

--- a/apps/commons-courses/app/api/live-sessions/[id]/state/route.ts
+++ b/apps/commons-courses/app/api/live-sessions/[id]/state/route.ts
@@ -3,6 +3,7 @@ import { Types } from "mongoose";
 import { auth } from "@/lib/auth";
 import { connectDB } from "@/lib/db";
 import { getCourseCollaboratorRole } from "@/lib/educator-auth";
+import { normalizeLiveLearnerCopilotPolicy } from "@/lib/live-copilot-policy";
 import {
   learnerSafeActivities,
   resolveCurrentActivityId,
@@ -36,7 +37,7 @@ export async function GET(
 
   await connectDB();
   const session = await LiveSession.findById(id).select(
-    "courseId status pace access invitedEmails currentActivityId stateVersion activities settings.allowLateJoin",
+    "courseId status pace access invitedEmails currentActivityId stateVersion activities settings",
   );
   if (!session || session.status === "draft") {
     return NextResponse.json(
@@ -122,6 +123,9 @@ export async function GET(
         currentActivity: currentActivity
           ? learnerSafeActivities([currentActivity])[0]
           : undefined,
+        learnerCopilot: normalizeLiveLearnerCopilotPolicy(
+          session.settings?.learnerCopilot,
+        ),
         stateVersion: session.stateVersion || 0,
         activityStatuses: Object.fromEntries(
           session.activities.map((activity: LiveActivity) => [

--- a/apps/commons-courses/components/educator/live-facilitator-studio.tsx
+++ b/apps/commons-courses/components/educator/live-facilitator-studio.tsx
@@ -46,13 +46,33 @@ type StudioData = {
   results: Record<string, LiveActivityResults>;
 };
 
-const activityChoices: Array<{ type: LiveActivityType; label: string; hint: string }> = [
-  { type: "content", label: "Workbook page", hint: "Notes, examples, and resources" },
-  { type: "setup_check", label: "Setup check", hint: "Catch blockers before teaching" },
+const activityChoices: Array<{
+  type: LiveActivityType;
+  label: string;
+  hint: string;
+}> = [
+  {
+    type: "content",
+    label: "Workbook page",
+    hint: "Notes, examples, and resources",
+  },
+  {
+    type: "setup_check",
+    label: "Setup check",
+    hint: "Catch blockers before teaching",
+  },
   { type: "poll", label: "Poll", hint: "Diagnostic, pulse, or opinion" },
   { type: "quiz", label: "Quiz", hint: "Retrieval with a correct answer" },
-  { type: "reflection", label: "Reflection", hint: "Open response or exit ticket" },
-  { type: "task", label: "Practice task", hint: "Instructions and evidence hand-in" },
+  {
+    type: "reflection",
+    label: "Reflection",
+    hint: "Open response or exit ticket",
+  },
+  {
+    type: "task",
+    label: "Practice task",
+    hint: "Instructions and evidence hand-in",
+  },
   { type: "break", label: "Break", hint: "Keep timing visible" },
 ];
 
@@ -66,17 +86,24 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
   const [addOpen, setAddOpen] = useState(false);
   const [materials, setMaterials] = useState<CourseMaterialRecord[]>([]);
 
-  const load = useCallback(async (quiet = false) => {
-    if (!quiet) setNotice("");
-    const res = await fetch(`/api/educator/live-sessions/${sessionId}`, { cache: "no-store" });
-    const next = await res.json().catch(() => ({}));
-    if (!res.ok) {
-      if (!quiet) setNotice(next.error || "Could not load this session.");
-      return;
-    }
-    setData(next);
-    setSelectedId((current) => current || next.session.activities[0]?.id || "");
-  }, [sessionId]);
+  const load = useCallback(
+    async (quiet = false) => {
+      if (!quiet) setNotice("");
+      const res = await fetch(`/api/educator/live-sessions/${sessionId}`, {
+        cache: "no-store",
+      });
+      const next = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        if (!quiet) setNotice(next.error || "Could not load this session.");
+        return;
+      }
+      setData(next);
+      setSelectedId(
+        (current) => current || next.session.activities[0]?.id || "",
+      );
+    },
+    [sessionId],
+  );
 
   useEffect(() => {
     const timer = window.setTimeout(() => void load(), 0);
@@ -86,27 +113,47 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
     const slug = data?.session.courseSlug;
     if (!slug) return;
     void fetch(`/api/educator/courses/${slug}/materials`, { cache: "no-store" })
-      .then((res) => res.ok ? res.json() : null)
+      .then((res) => (res.ok ? res.json() : null))
       .then((body) => setMaterials(body?.materials || []));
   }, [data?.session.courseSlug]);
   useEffect(() => {
-    if (tab === "plan" || (data?.session.status !== "live" && data?.session.status !== "lobby")) return;
+    if (
+      tab === "plan" ||
+      (data?.session.status !== "live" && data?.session.status !== "lobby")
+    )
+      return;
     const interval = window.setInterval(() => void load(true), 3000);
     return () => window.clearInterval(interval);
   }, [data?.session.status, load, tab]);
 
-  const selected = data?.session.activities.find((activity) => activity.id === selectedId);
-  const current = data?.session.activities.find((activity) => activity.id === data.session.currentActivityId);
-  const currentIndex = current ? data!.session.activities.findIndex((activity) => activity.id === current.id) : -1;
+  const selected = data?.session.activities.find(
+    (activity) => activity.id === selectedId,
+  );
+  const current = data?.session.activities.find(
+    (activity) => activity.id === data.session.currentActivityId,
+  );
+  const currentIndex = current
+    ? data!.session.activities.findIndex(
+        (activity) => activity.id === current.id,
+      )
+    : -1;
   const nextActivity = data?.session.activities[currentIndex + 1];
 
   function updateSession(patch: Partial<LiveSessionRecord>) {
-    setData((currentData) => currentData ? { ...currentData, session: { ...currentData.session, ...patch } } : currentData);
+    setData((currentData) =>
+      currentData
+        ? { ...currentData, session: { ...currentData.session, ...patch } }
+        : currentData,
+    );
   }
 
   function updateActivity(activityId: string, patch: Partial<LiveActivity>) {
     if (!data) return;
-    updateSession({ activities: data.session.activities.map((activity) => activity.id === activityId ? { ...activity, ...patch } : activity) });
+    updateSession({
+      activities: data.session.activities.map((activity) =>
+        activity.id === activityId ? { ...activity, ...patch } : activity,
+      ),
+    });
   }
 
   async function savePlan() {
@@ -129,7 +176,7 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
     });
     const next = await res.json().catch(() => ({}));
     if (res.ok) {
-      setData((value) => value ? { ...value, session: next.session } : value);
+      setData((value) => (value ? { ...value, session: next.session } : value));
       setNotice("Session plan saved.");
     } else setNotice(next.error || "Could not save the session plan.");
     setSaving(false);
@@ -146,20 +193,27 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
     });
     const next = await res.json().catch(() => ({}));
     if (res.ok) {
-      setData((currentData) => currentData ? { ...currentData, session: next.session } : currentData);
-      const active = next.session?.activities?.find((item: LiveActivity) => item.id === next.session.currentActivityId);
-      setNotice(commandName === "activate" || commandName === "start"
-        ? `Learners are now seeing ${active?.title || "the active activity"}.`
-        : commandName === "close_activity"
-          ? "Responses are closed. Learners still see this activity while you debrief."
-          : commandName === "open_lobby"
-            ? "Lobby open. Learners can join; activities remain hidden until you begin."
-            : commandName === "end"
-              ? "Session ended. Learner responses are saved."
-              : "Live room updated.");
+      setData((currentData) =>
+        currentData ? { ...currentData, session: next.session } : currentData,
+      );
+      const active = next.session?.activities?.find(
+        (item: LiveActivity) => item.id === next.session.currentActivityId,
+      );
+      setNotice(
+        commandName === "activate" || commandName === "start"
+          ? `Learners are now seeing ${active?.title || "the active activity"}.`
+          : commandName === "close_activity"
+            ? "Responses are closed. Learners still see this activity while you debrief."
+            : commandName === "open_lobby"
+              ? "Lobby open. Learners can join; activities remain hidden until you begin."
+              : commandName === "end"
+                ? "Session ended. Learner responses are saved."
+                : "Live room updated.",
+      );
       void load(true);
       if (commandName === "open_lobby") setTab("share");
-      if (commandName === "start" || commandName === "activate") setTab("facilitate");
+      if (commandName === "start" || commandName === "activate")
+        setTab("facilitate");
     } else setNotice(next.error || "Could not update the live room.");
     setRunning(false);
   }
@@ -167,7 +221,9 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
   function addActivity(type: LiveActivityType) {
     if (!data) return;
     const id = crypto.randomUUID();
-    const label = activityChoices.find((choice) => choice.type === type)?.label || "Activity";
+    const label =
+      activityChoices.find((choice) => choice.type === type)?.label ||
+      "Activity";
     const activity: LiveActivity = {
       id,
       type,
@@ -179,7 +235,11 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
       points: type === "quiz" ? 1 : 0,
       options: ["poll", "quiz", "setup_check"].includes(type)
         ? [
-            { id: crypto.randomUUID(), label: "Option 1", isCorrect: type === "quiz" },
+            {
+              id: crypto.randomUUID(),
+              label: "Option 1",
+              isCorrect: type === "quiz",
+            },
             { id: crypto.randomUUID(), label: "Option 2", isCorrect: false },
           ]
         : [],
@@ -195,50 +255,90 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
     const index = activities.findIndex((activity) => activity.id === id);
     const nextIndex = index + direction;
     if (index < 0 || nextIndex < 0 || nextIndex >= activities.length) return;
-    [activities[index], activities[nextIndex]] = [activities[nextIndex], activities[index]];
+    [activities[index], activities[nextIndex]] = [
+      activities[nextIndex],
+      activities[index],
+    ];
     updateSession({ activities });
   }
 
   function removeActivity(id: string) {
     if (!data) return;
-    const activities = data.session.activities.filter((activity) => activity.id !== id);
+    const activities = data.session.activities.filter(
+      (activity) => activity.id !== id,
+    );
     updateSession({ activities });
     setSelectedId(activities[0]?.id || "");
   }
 
   if (!data) {
-    return <div className="rounded-2xl border border-slate-200 bg-white p-12 text-center text-sm text-slate-500">{notice || "Loading live session…"}</div>;
+    return (
+      <div className="rounded-2xl border border-slate-200 bg-white p-12 text-center text-sm text-slate-500">
+        {notice || "Loading live session…"}
+      </div>
+    );
   }
 
   const joinPath = `/live/${data.session.id}`;
-  const joinUrl = typeof window === "undefined" ? joinPath : `${window.location.origin}${joinPath}`;
-  const joinPortal = typeof window === "undefined" ? "/join" : `${window.location.origin}/join`;
+  const joinUrl =
+    typeof window === "undefined"
+      ? joinPath
+      : `${window.location.origin}${joinPath}`;
+  const joinPortal =
+    typeof window === "undefined" ? "/join" : `${window.location.origin}/join`;
   const qrPath = `/api/educator/live-sessions/${data.session.id}/qr`;
 
   return (
-    <div style={getCourseThemeStyle(data.session.courseTheme) as CSSProperties} className="space-y-5" data-copilot-target="live-facilitation-studio">
+    <div
+      style={getCourseThemeStyle(data.session.courseTheme) as CSSProperties}
+      className="space-y-5"
+      data-copilot-target="live-facilitation-studio"
+    >
       <header className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <SessionStatus status={data.session.status} />
-            <span className="text-xs text-slate-400">Code {formatCode(data.session.joinCode)}</span>
+            <span className="text-xs text-slate-400">
+              Code {formatCode(data.session.joinCode)}
+            </span>
           </div>
-          <h2 className="mt-2 truncate text-2xl font-bold tracking-tight text-slate-950">{data.session.title}</h2>
-          <p className="mt-1 text-sm text-slate-500">{data.session.activities.length} activities · {data.session.participantCount} learners joined</p>
+          <h2 className="mt-2 truncate text-2xl font-bold tracking-tight text-slate-950">
+            {data.session.title}
+          </h2>
+          <p className="mt-1 text-sm text-slate-500">
+            {data.session.activities.length} activities ·{" "}
+            {data.session.participantCount} learners joined
+          </p>
         </div>
         <div className="flex flex-wrap gap-2">
           {data.session.status === "draft" ? (
-            <button onClick={() => command("open_lobby")} disabled={running} className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-bold text-slate-700 hover:bg-slate-50">
+            <button
+              onClick={() => command("open_lobby")}
+              disabled={running}
+              className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-bold text-slate-700 hover:bg-slate-50"
+            >
               <MonitorUp className="h-4 w-4" /> Open room for joining
             </button>
           ) : null}
-          {data.session.status === "lobby" || (data.session.status === "live" && !current) ? (
-            <button onClick={() => command("start")} disabled={running || !data.session.activities.length} className="inline-flex items-center gap-2 rounded-xl bg-slate-950 px-4 py-2.5 text-sm font-bold text-white disabled:opacity-40">
-              <Play className="h-4 w-4" /> {data.session.status === "live" ? "Restore live activity" : "Present first activity"}
+          {data.session.status === "lobby" ||
+          (data.session.status === "live" && !current) ? (
+            <button
+              onClick={() => command("start")}
+              disabled={running || !data.session.activities.length}
+              className="inline-flex items-center gap-2 rounded-xl bg-slate-950 px-4 py-2.5 text-sm font-bold text-white disabled:opacity-40"
+            >
+              <Play className="h-4 w-4" />{" "}
+              {data.session.status === "live"
+                ? "Restore live activity"
+                : "Present first activity"}
             </button>
           ) : null}
           {data.session.status === "live" ? (
-            <button onClick={() => command("end")} disabled={running} className="inline-flex items-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-bold text-red-700 hover:bg-red-50">
+            <button
+              onClick={() => command("end")}
+              disabled={running}
+              className="inline-flex items-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-bold text-red-700 hover:bg-red-50"
+            >
               <CircleStop className="h-4 w-4" /> End session
             </button>
           ) : null}
@@ -246,49 +346,388 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
       </header>
 
       <div className="flex gap-1 overflow-x-auto rounded-xl border border-slate-200 bg-white p-1.5">
-        <Tab active={tab === "plan"} onClick={() => setTab("plan")} icon={BookOpen}>Plan</Tab>
-        <Tab active={tab === "facilitate"} onClick={() => setTab("facilitate")} icon={Radio}>Facilitate</Tab>
-        <Tab active={tab === "share"} onClick={() => setTab("share")} icon={QrCode}>Invite learners</Tab>
+        <Tab
+          active={tab === "plan"}
+          onClick={() => setTab("plan")}
+          icon={BookOpen}
+        >
+          Plan
+        </Tab>
+        <Tab
+          active={tab === "facilitate"}
+          onClick={() => setTab("facilitate")}
+          icon={Radio}
+        >
+          Facilitate
+        </Tab>
+        <Tab
+          active={tab === "share"}
+          onClick={() => setTab("share")}
+          icon={QrCode}
+        >
+          Invite learners
+        </Tab>
       </div>
 
-      {notice ? <div className={cn("rounded-xl px-4 py-3 text-sm", notice.includes("saved") ? "bg-emerald-50 text-emerald-700" : "bg-amber-50 text-amber-800")}>{notice}</div> : null}
+      {notice ? (
+        <div
+          className={cn(
+            "rounded-xl px-4 py-3 text-sm",
+            notice.includes("saved")
+              ? "bg-emerald-50 text-emerald-700"
+              : "bg-amber-50 text-amber-800",
+          )}
+        >
+          {notice}
+        </div>
+      ) : null}
 
       {tab === "plan" ? (
         <div className="grid gap-5 xl:grid-cols-[340px_minmax(0,1fr)]">
           <aside className="rounded-2xl border border-slate-200 bg-white p-3">
             <div className="flex items-center justify-between px-2 py-2">
-              <div><p className="text-sm font-bold text-slate-950">Run of show</p><p className="text-xs text-slate-400">Learners see this as a workbook</p></div>
-              <button onClick={() => setAddOpen((value) => !value)} className="rounded-lg bg-slate-950 p-2 text-white" aria-label="Add activity"><Plus className="h-4 w-4" /></button>
+              <div>
+                <p className="text-sm font-bold text-slate-950">Run of show</p>
+                <p className="text-xs text-slate-400">
+                  Learners see this as a workbook
+                </p>
+              </div>
+              <button
+                onClick={() => setAddOpen((value) => !value)}
+                className="rounded-lg bg-slate-950 p-2 text-white"
+                aria-label="Add activity"
+              >
+                <Plus className="h-4 w-4" />
+              </button>
             </div>
             {addOpen ? <AddMenu onAdd={addActivity} /> : null}
             <div className="mt-2 space-y-1">
               {data.session.activities.map((activity, index) => (
-                <button key={activity.id} onClick={() => setSelectedId(activity.id)} className={cn("group flex w-full items-center gap-2 rounded-xl px-2 py-2.5 text-left", selectedId === activity.id ? "bg-slate-950 text-white" : "hover:bg-slate-50")}>
-                  <GripVertical className={cn("h-4 w-4 shrink-0", selectedId === activity.id ? "text-slate-500" : "text-slate-300")} />
-                  <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-white/10 text-[10px] font-bold">{index + 1}</span>
-                  <span className="min-w-0 flex-1"><span className="block truncate text-sm font-bold">{activity.title}</span><span className={cn("block text-[10px] uppercase tracking-wide", selectedId === activity.id ? "text-slate-400" : "text-slate-400")}>{activityLabel(activity.type)}{activity.estimatedMinutes ? ` · ${activity.estimatedMinutes} min` : ""}</span></span>
+                <button
+                  key={activity.id}
+                  onClick={() => setSelectedId(activity.id)}
+                  className={cn(
+                    "group flex w-full items-center gap-2 rounded-xl px-2 py-2.5 text-left",
+                    selectedId === activity.id
+                      ? "bg-slate-950 text-white"
+                      : "hover:bg-slate-50",
+                  )}
+                >
+                  <GripVertical
+                    className={cn(
+                      "h-4 w-4 shrink-0",
+                      selectedId === activity.id
+                        ? "text-slate-500"
+                        : "text-slate-300",
+                    )}
+                  />
+                  <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-white/10 text-[10px] font-bold">
+                    {index + 1}
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-bold">
+                      {activity.title}
+                    </span>
+                    <span
+                      className={cn(
+                        "block text-[10px] uppercase tracking-wide",
+                        selectedId === activity.id
+                          ? "text-slate-400"
+                          : "text-slate-400",
+                      )}
+                    >
+                      {activityLabel(activity.type)}
+                      {activity.estimatedMinutes
+                        ? ` · ${activity.estimatedMinutes} min`
+                        : ""}
+                    </span>
+                  </span>
                   <ChevronRight className="h-3.5 w-3.5 shrink-0 opacity-40" />
                 </button>
               ))}
-              {!data.session.activities.length ? <p className="px-3 py-8 text-center text-sm text-slate-400">Add the first learning moment.</p> : null}
+              {!data.session.activities.length ? (
+                <p className="px-3 py-8 text-center text-sm text-slate-400">
+                  Add the first learning moment.
+                </p>
+              ) : null}
             </div>
           </aside>
 
           <div className="space-y-5">
             <section className="rounded-2xl border border-slate-200 bg-white p-5 sm:p-6">
-              <div className="flex items-center justify-between"><div><p className="text-sm font-bold text-slate-950">Session settings</p><p className="text-xs text-slate-400">One room, adaptable delivery</p></div><Settings2 className="h-4 w-4 text-slate-300" /></div>
-              <div className="mt-5 grid gap-4 md:grid-cols-2">
-                <Field label="Session title"><input value={data.session.title} onChange={(event) => updateSession({ title: event.target.value })} className={inputClass} /></Field>
-                <Field label="Delivery pace"><select value={data.session.pace} onChange={(event) => updateSession({ pace: event.target.value as LiveSessionRecord["pace"] })} className={inputClass}><option value="facilitator">Facilitator controls each step</option><option value="learner">Learners move at their own pace</option></select></Field>
-                <Field label="Who can join"><select value={data.session.access} onChange={(event) => updateSession({ access: event.target.value as LiveSessionRecord["access"] })} className={inputClass}><option value="enrolled">Enrolled learners</option><option value="invited">Invited email addresses</option><option value="open">Anyone with the link</option></select></Field>
-                <Field label="Scheduled start"><input type="datetime-local" value={toDateTimeLocal(data.session.scheduledStart)} onChange={(event) => updateSession({ scheduledStart: event.target.value ? new Date(event.target.value).toISOString() : undefined })} className={inputClass} /></Field>
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-bold text-slate-950">
+                    Session settings
+                  </p>
+                  <p className="text-xs text-slate-400">
+                    One room, adaptable delivery
+                  </p>
+                </div>
+                <Settings2 className="h-4 w-4 text-slate-300" />
               </div>
-              {data.session.access === "invited" ? <Field label="Invited emails"><textarea value={data.session.invitedEmails.join("\n")} onChange={(event) => updateSession({ invitedEmails: event.target.value.split(/[\n,;]/).map((email) => email.trim()).filter(Boolean) })} rows={3} placeholder="one@email.com" className={`${inputClass} mt-2 resize-y`} /></Field> : null}
-              <div className="mt-4 flex flex-wrap gap-4"><Toggle checked={data.session.settings.allowLateJoin} onChange={(value) => updateSession({ settings: { ...data.session.settings, allowLateJoin: value } })} label="Allow late join" /><Toggle checked={data.session.settings.showParticipantNames} onChange={(value) => updateSession({ settings: { ...data.session.settings, showParticipantNames: value } })} label="Names in private results" /><Toggle checked={data.session.settings.showLeaderboard} onChange={(value) => updateSession({ settings: { ...data.session.settings, showLeaderboard: value } })} label="Leaderboard" /></div>
+              <div className="mt-5 grid gap-4 md:grid-cols-2">
+                <Field label="Session title">
+                  <input
+                    value={data.session.title}
+                    onChange={(event) =>
+                      updateSession({ title: event.target.value })
+                    }
+                    className={inputClass}
+                  />
+                </Field>
+                <Field label="Delivery pace">
+                  <select
+                    value={data.session.pace}
+                    onChange={(event) =>
+                      updateSession({
+                        pace: event.target.value as LiveSessionRecord["pace"],
+                      })
+                    }
+                    className={inputClass}
+                  >
+                    <option value="facilitator">
+                      Facilitator controls each step
+                    </option>
+                    <option value="learner">
+                      Learners move at their own pace
+                    </option>
+                  </select>
+                </Field>
+                <Field label="Who can join">
+                  <select
+                    value={data.session.access}
+                    onChange={(event) =>
+                      updateSession({
+                        access: event.target
+                          .value as LiveSessionRecord["access"],
+                      })
+                    }
+                    className={inputClass}
+                  >
+                    <option value="enrolled">Enrolled learners</option>
+                    <option value="invited">Invited email addresses</option>
+                    <option value="open">Anyone with the link</option>
+                  </select>
+                </Field>
+                <Field label="Scheduled start">
+                  <input
+                    type="datetime-local"
+                    value={toDateTimeLocal(data.session.scheduledStart)}
+                    onChange={(event) =>
+                      updateSession({
+                        scheduledStart: event.target.value
+                          ? new Date(event.target.value).toISOString()
+                          : undefined,
+                      })
+                    }
+                    className={inputClass}
+                  />
+                </Field>
+              </div>
+              {data.session.access === "invited" ? (
+                <Field label="Invited emails">
+                  <textarea
+                    value={data.session.invitedEmails.join("\n")}
+                    onChange={(event) =>
+                      updateSession({
+                        invitedEmails: event.target.value
+                          .split(/[\n,;]/)
+                          .map((email) => email.trim())
+                          .filter(Boolean),
+                      })
+                    }
+                    rows={3}
+                    placeholder="one@email.com"
+                    className={`${inputClass} mt-2 resize-y`}
+                  />
+                </Field>
+              ) : null}
+              <div className="mt-4 flex flex-wrap gap-4">
+                <Toggle
+                  checked={data.session.settings.allowLateJoin}
+                  onChange={(value) =>
+                    updateSession({
+                      settings: {
+                        ...data.session.settings,
+                        allowLateJoin: value,
+                      },
+                    })
+                  }
+                  label="Allow late join"
+                />
+                <Toggle
+                  checked={data.session.settings.showParticipantNames}
+                  onChange={(value) =>
+                    updateSession({
+                      settings: {
+                        ...data.session.settings,
+                        showParticipantNames: value,
+                      },
+                    })
+                  }
+                  label="Names in private results"
+                />
+                <Toggle
+                  checked={data.session.settings.showLeaderboard}
+                  onChange={(value) =>
+                    updateSession({
+                      settings: {
+                        ...data.session.settings,
+                        showLeaderboard: value,
+                      },
+                    })
+                  }
+                  label="Leaderboard"
+                />
+              </div>
             </section>
 
-            {selected ? <ActivityEditor activity={selected} materials={materials} index={data.session.activities.findIndex((activity) => activity.id === selected.id)} onChange={(patch) => updateActivity(selected.id, patch)} onMove={(direction) => moveActivity(selected.id, direction)} onRemove={() => removeActivity(selected.id)} /> : null}
-            <div className="sticky bottom-4 flex justify-end"><button onClick={savePlan} disabled={saving} className="inline-flex items-center gap-2 rounded-xl bg-slate-950 px-5 py-3 text-sm font-bold text-white shadow-lg disabled:opacity-50">{saving ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />} Save plan</button></div>
+            <section className="rounded-2xl border border-slate-200 bg-white p-5 sm:p-6">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <p className="text-sm font-bold text-slate-950">
+                    Learner copilot
+                  </p>
+                  <p className="mt-1 max-w-2xl text-xs leading-5 text-slate-500">
+                    Choose whether learners can use AI guidance inside this live
+                    room, and keep its help within the boundaries of your
+                    session.
+                  </p>
+                </div>
+                <Toggle
+                  checked={data.session.settings.learnerCopilot.enabled}
+                  onChange={(enabled) =>
+                    updateSession({
+                      settings: {
+                        ...data.session.settings,
+                        learnerCopilot: {
+                          ...data.session.settings.learnerCopilot,
+                          enabled,
+                        },
+                      },
+                    })
+                  }
+                  label={
+                    data.session.settings.learnerCopilot.enabled
+                      ? "Visible to learners"
+                      : "Hidden from learners"
+                  }
+                />
+              </div>
+              <div
+                className={cn(
+                  "mt-5 grid gap-3 md:grid-cols-2",
+                  !data.session.settings.learnerCopilot.enabled && "opacity-45",
+                )}
+              >
+                <CopilotPermission
+                  title="Explain the current activity"
+                  description="Clarify the visible prompt, instructions, and concepts."
+                  checked={
+                    data.session.settings.learnerCopilot.explainCurrentActivity
+                  }
+                  disabled={!data.session.settings.learnerCopilot.enabled}
+                  onChange={(explainCurrentActivity) =>
+                    updateSession({
+                      settings: {
+                        ...data.session.settings,
+                        learnerCopilot: {
+                          ...data.session.settings.learnerCopilot,
+                          explainCurrentActivity,
+                        },
+                      },
+                    })
+                  }
+                />
+                <CopilotPermission
+                  title="Coach learner responses"
+                  description="Use questions and hints without writing or submitting answers."
+                  checked={data.session.settings.learnerCopilot.coachResponses}
+                  disabled={!data.session.settings.learnerCopilot.enabled}
+                  onChange={(coachResponses) =>
+                    updateSession({
+                      settings: {
+                        ...data.session.settings,
+                        learnerCopilot: {
+                          ...data.session.settings.learnerCopilot,
+                          coachResponses,
+                        },
+                      },
+                    })
+                  }
+                />
+                <CopilotPermission
+                  title="Use wider course material"
+                  description="Draw from material beyond the activity currently on screen."
+                  checked={
+                    data.session.settings.learnerCopilot.useCourseMaterials
+                  }
+                  disabled={!data.session.settings.learnerCopilot.enabled}
+                  onChange={(useCourseMaterials) =>
+                    updateSession({
+                      settings: {
+                        ...data.session.settings,
+                        learnerCopilot: {
+                          ...data.session.settings.learnerCopilot,
+                          useCourseMaterials,
+                        },
+                      },
+                    })
+                  }
+                />
+                <CopilotPermission
+                  title="Give direct explanations"
+                  description="Explain concepts directly instead of always starting with hints."
+                  checked={
+                    data.session.settings.learnerCopilot.giveDirectExplanations
+                  }
+                  disabled={!data.session.settings.learnerCopilot.enabled}
+                  onChange={(giveDirectExplanations) =>
+                    updateSession({
+                      settings: {
+                        ...data.session.settings,
+                        learnerCopilot: {
+                          ...data.session.settings.learnerCopilot,
+                          giveDirectExplanations,
+                        },
+                      },
+                    })
+                  }
+                />
+              </div>
+              <p className="mt-4 text-[11px] leading-5 text-slate-400">
+                Hidden quiz answers and private facilitator notes are never
+                available to the learner copilot.
+              </p>
+            </section>
+
+            {selected ? (
+              <ActivityEditor
+                activity={selected}
+                materials={materials}
+                index={data.session.activities.findIndex(
+                  (activity) => activity.id === selected.id,
+                )}
+                onChange={(patch) => updateActivity(selected.id, patch)}
+                onMove={(direction) => moveActivity(selected.id, direction)}
+                onRemove={() => removeActivity(selected.id)}
+              />
+            ) : null}
+            <div className="sticky bottom-4 flex justify-end">
+              <button
+                onClick={savePlan}
+                disabled={saving}
+                className="inline-flex items-center gap-2 rounded-xl bg-slate-950 px-5 py-3 text-sm font-bold text-white shadow-lg disabled:opacity-50"
+              >
+                {saving ? (
+                  <LoaderCircle className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="h-4 w-4" />
+                )}{" "}
+                Save plan
+              </button>
+            </div>
           </div>
         </div>
       ) : null}
@@ -299,26 +738,185 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
             {current ? (
               <>
                 <div className="border-b border-slate-100 p-6 sm:p-8">
-                  <div className="flex items-center justify-between gap-3"><span className={cn("rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest", current.status === "open" ? "bg-red-50 text-red-700" : "bg-slate-100 text-slate-600")}>{current.status === "open" ? "Learners see this now" : "Responses closed · still presented"}</span><span className="text-xs text-slate-400">{current.estimatedMinutes ? `${current.estimatedMinutes} min` : activityLabel(current.type)}</span></div>
-                  <p className="mt-6 text-xs font-bold uppercase tracking-[0.18em] text-slate-400">{activityLabel(current.type)}</p>
-                  <h3 className="mt-2 text-3xl font-bold tracking-tight text-slate-950">{current.title}</h3>
-                  {current.prompt ? <p className="mt-4 text-lg leading-8 text-slate-700">{current.prompt}</p> : null}
-                  {current.facilitatorNotes ? <div className="mt-6 rounded-xl bg-amber-50 p-4"><p className="text-[10px] font-bold uppercase tracking-wide text-amber-700">Private facilitator note</p><p className="mt-1 text-sm leading-6 text-amber-900">{current.facilitatorNotes}</p></div> : null}
+                  <div className="flex items-center justify-between gap-3">
+                    <span
+                      className={cn(
+                        "rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest",
+                        current.status === "open"
+                          ? "bg-red-50 text-red-700"
+                          : "bg-slate-100 text-slate-600",
+                      )}
+                    >
+                      {current.status === "open"
+                        ? "Learners see this now"
+                        : "Responses closed · still presented"}
+                    </span>
+                    <span className="text-xs text-slate-400">
+                      {current.estimatedMinutes
+                        ? `${current.estimatedMinutes} min`
+                        : activityLabel(current.type)}
+                    </span>
+                  </div>
+                  <p className="mt-6 text-xs font-bold uppercase tracking-[0.18em] text-slate-400">
+                    {activityLabel(current.type)}
+                  </p>
+                  <h3 className="mt-2 text-3xl font-bold tracking-tight text-slate-950">
+                    {current.title}
+                  </h3>
+                  {current.prompt ? (
+                    <p className="mt-4 text-lg leading-8 text-slate-700">
+                      {current.prompt}
+                    </p>
+                  ) : null}
+                  {current.facilitatorNotes ? (
+                    <div className="mt-6 rounded-xl bg-amber-50 p-4">
+                      <p className="text-[10px] font-bold uppercase tracking-wide text-amber-700">
+                        Private facilitator note
+                      </p>
+                      <p className="mt-1 text-sm leading-6 text-amber-900">
+                        {current.facilitatorNotes}
+                      </p>
+                    </div>
+                  ) : null}
                 </div>
-                {current.materialId ? <div className="border-b border-slate-100 p-4 sm:p-6"><CourseMaterialViewer materialId={current.materialId} compact /></div> : null}
-                <LiveResults activity={current} results={data.results[current.id]} responses={data.session.responseCounts[current.id] || 0} participants={data.session.participantCount} />
+                {current.materialId ? (
+                  <div className="border-b border-slate-100 p-4 sm:p-6">
+                    <CourseMaterialViewer
+                      materialId={current.materialId}
+                      compact
+                    />
+                  </div>
+                ) : null}
+                <LiveResults
+                  activity={current}
+                  results={data.results[current.id]}
+                  responses={data.session.responseCounts[current.id] || 0}
+                  participants={data.session.participantCount}
+                />
                 <div className="flex flex-col gap-3 border-t border-slate-100 bg-slate-50 p-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
-                  <button onClick={() => command("close_activity", current.id)} disabled={running || current.status === "closed"} className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-bold text-slate-700 disabled:opacity-40"><LockKeyhole className="h-4 w-4" /> Close responses</button>
-                  {nextActivity ? <button onClick={() => command("activate", nextActivity.id)} disabled={running} className="inline-flex items-center justify-center gap-2 rounded-xl bg-slate-950 px-5 py-2.5 text-sm font-bold text-white">Next: {nextActivity.title}<ChevronRight className="h-4 w-4" /></button> : <button onClick={() => command("end")} disabled={running} className="inline-flex items-center justify-center gap-2 rounded-xl bg-slate-950 px-5 py-2.5 text-sm font-bold text-white"><Check className="h-4 w-4" /> Finish session</button>}
+                  <button
+                    onClick={() => command("close_activity", current.id)}
+                    disabled={running || current.status === "closed"}
+                    className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-bold text-slate-700 disabled:opacity-40"
+                  >
+                    <LockKeyhole className="h-4 w-4" /> Close responses
+                  </button>
+                  {nextActivity ? (
+                    <button
+                      onClick={() => command("activate", nextActivity.id)}
+                      disabled={running}
+                      className="inline-flex items-center justify-center gap-2 rounded-xl bg-slate-950 px-5 py-2.5 text-sm font-bold text-white"
+                    >
+                      Next: {nextActivity.title}
+                      <ChevronRight className="h-4 w-4" />
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => command("end")}
+                      disabled={running}
+                      className="inline-flex items-center justify-center gap-2 rounded-xl bg-slate-950 px-5 py-2.5 text-sm font-bold text-white"
+                    >
+                      <Check className="h-4 w-4" /> Finish session
+                    </button>
+                  )}
                 </div>
               </>
             ) : (
-              <div className="p-12 text-center"><Radio className="mx-auto h-7 w-7 text-slate-300" /><h3 className="mt-4 text-lg font-bold text-slate-900">{data.session.status === "live" ? "Restore the live activity" : "The room is ready"}</h3><p className="mt-2 text-sm text-slate-500">{data.session.status === "live" ? "The room is live, but no activity is currently presented. Restore the first activity for everyone." : "Open the lobby, invite learners, then start when the room is settled."}</p>{data.session.status === "draft" ? <button onClick={() => command("open_lobby")} className="mt-5 rounded-xl bg-slate-950 px-5 py-2.5 text-sm font-bold text-white">Open lobby</button> : data.session.status === "lobby" || data.session.status === "live" ? <button onClick={() => command("start")} className="mt-5 rounded-xl bg-slate-950 px-5 py-2.5 text-sm font-bold text-white">{data.session.status === "live" ? "Restore first activity" : "Start first activity"}</button> : null}</div>
+              <div className="p-12 text-center">
+                <Radio className="mx-auto h-7 w-7 text-slate-300" />
+                <h3 className="mt-4 text-lg font-bold text-slate-900">
+                  {data.session.status === "live"
+                    ? "Restore the live activity"
+                    : "The room is ready"}
+                </h3>
+                <p className="mt-2 text-sm text-slate-500">
+                  {data.session.status === "live"
+                    ? "The room is live, but no activity is currently presented. Restore the first activity for everyone."
+                    : "Open the lobby, invite learners, then start when the room is settled."}
+                </p>
+                {data.session.status === "draft" ? (
+                  <button
+                    onClick={() => command("open_lobby")}
+                    className="mt-5 rounded-xl bg-slate-950 px-5 py-2.5 text-sm font-bold text-white"
+                  >
+                    Open lobby
+                  </button>
+                ) : data.session.status === "lobby" ||
+                  data.session.status === "live" ? (
+                  <button
+                    onClick={() => command("start")}
+                    className="mt-5 rounded-xl bg-slate-950 px-5 py-2.5 text-sm font-bold text-white"
+                  >
+                    {data.session.status === "live"
+                      ? "Restore first activity"
+                      : "Start first activity"}
+                  </button>
+                ) : null}
+              </div>
             )}
           </section>
           <aside className="space-y-5">
-            <section className="rounded-2xl border border-slate-200 bg-white p-5"><div className="flex items-center justify-between"><h3 className="text-sm font-bold text-slate-950">Room</h3><Users className="h-4 w-4 text-slate-300" /></div><div className="mt-4 flex items-end justify-between"><div><p className="text-3xl font-bold text-slate-950">{data.session.participantCount}</p><p className="text-xs text-slate-400">learners joined</p></div><button onClick={() => setTab("share")} className="text-xs font-bold text-slate-700 hover:text-slate-950">Show join screen</button></div><div className="mt-4 max-h-64 space-y-2 overflow-y-auto">{data.participants.map((participant) => <div key={participant.id} className="flex items-center gap-2 rounded-lg bg-slate-50 px-3 py-2"><span className="h-2 w-2 rounded-full bg-emerald-400" /><span className="truncate text-xs font-medium text-slate-700">{participant.displayName}</span></div>)}</div></section>
-            <section className="rounded-2xl border border-slate-200 bg-white p-5"><h3 className="text-sm font-bold text-slate-950">Run of show</h3><div className="mt-3 space-y-1">{data.session.activities.map((activity, index) => <button key={activity.id} onClick={() => command("activate", activity.id)} disabled={data.session.status === "ended"} className={cn("flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left", activity.id === current?.id ? "bg-slate-950 text-white" : "hover:bg-slate-50")}><span className="text-[10px] font-bold opacity-50">{String(index + 1).padStart(2, "0")}</span><span className="min-w-0 flex-1 truncate text-xs font-bold">{activity.title}</span>{activity.status === "closed" ? <Check className="h-3.5 w-3.5 text-emerald-500" /> : null}</button>)}</div></section>
+            <section className="rounded-2xl border border-slate-200 bg-white p-5">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-bold text-slate-950">Room</h3>
+                <Users className="h-4 w-4 text-slate-300" />
+              </div>
+              <div className="mt-4 flex items-end justify-between">
+                <div>
+                  <p className="text-3xl font-bold text-slate-950">
+                    {data.session.participantCount}
+                  </p>
+                  <p className="text-xs text-slate-400">learners joined</p>
+                </div>
+                <button
+                  onClick={() => setTab("share")}
+                  className="text-xs font-bold text-slate-700 hover:text-slate-950"
+                >
+                  Show join screen
+                </button>
+              </div>
+              <div className="mt-4 max-h-64 space-y-2 overflow-y-auto">
+                {data.participants.map((participant) => (
+                  <div
+                    key={participant.id}
+                    className="flex items-center gap-2 rounded-lg bg-slate-50 px-3 py-2"
+                  >
+                    <span className="h-2 w-2 rounded-full bg-emerald-400" />
+                    <span className="truncate text-xs font-medium text-slate-700">
+                      {participant.displayName}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </section>
+            <section className="rounded-2xl border border-slate-200 bg-white p-5">
+              <h3 className="text-sm font-bold text-slate-950">Run of show</h3>
+              <div className="mt-3 space-y-1">
+                {data.session.activities.map((activity, index) => (
+                  <button
+                    key={activity.id}
+                    onClick={() => command("activate", activity.id)}
+                    disabled={data.session.status === "ended"}
+                    className={cn(
+                      "flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left",
+                      activity.id === current?.id
+                        ? "bg-slate-950 text-white"
+                        : "hover:bg-slate-50",
+                    )}
+                  >
+                    <span className="text-[10px] font-bold opacity-50">
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-xs font-bold">
+                      {activity.title}
+                    </span>
+                    {activity.status === "closed" ? (
+                      <Check className="h-3.5 w-3.5 text-emerald-500" />
+                    ) : null}
+                  </button>
+                ))}
+              </div>
+            </section>
           </aside>
         </div>
       ) : null}
@@ -326,19 +924,119 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
       {tab === "share" ? (
         <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_360px]">
           <section className="flex min-h-[440px] flex-col items-center justify-center rounded-2xl bg-slate-950 p-8 text-center text-white sm:p-12">
-            <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#71E0E7]">Join the live session</p>
-            <h3 className="mt-4 max-w-2xl text-3xl font-bold tracking-tight sm:text-4xl">{data.session.title}</h3>
+            <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#71E0E7]">
+              Join the live session
+            </p>
+            <h3 className="mt-4 max-w-2xl text-3xl font-bold tracking-tight sm:text-4xl">
+              {data.session.title}
+            </h3>
             <div className="mt-8 grid items-center gap-8 sm:grid-cols-[220px_1fr] sm:text-left">
               <div className="rounded-2xl bg-white p-3">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={`${qrPath}?format=png`} alt={`QR code to join ${data.session.title}`} className="aspect-square w-full" />
+                <img
+                  src={`${qrPath}?format=png`}
+                  alt={`QR code to join ${data.session.title}`}
+                  className="aspect-square w-full"
+                />
               </div>
-              <div><p className="text-sm text-slate-400">Scan the QR code, or visit</p><p className="mt-1 break-all text-lg font-bold">{joinPortal}</p><p className="mt-6 text-sm text-slate-400">Enter code</p><p className="mt-1 text-5xl font-bold tracking-[0.16em] text-[#B8F56D]">{formatCode(data.session.joinCode)}</p></div>
+              <div>
+                <p className="text-sm text-slate-400">
+                  Scan the QR code, or visit
+                </p>
+                <p className="mt-1 break-all text-lg font-bold">{joinPortal}</p>
+                <p className="mt-6 text-sm text-slate-400">Enter code</p>
+                <p className="mt-1 text-5xl font-bold tracking-[0.16em] text-[#B8F56D]">
+                  {formatCode(data.session.joinCode)}
+                </p>
+              </div>
             </div>
           </section>
           <aside className="space-y-5">
-            <section className="rounded-2xl border border-slate-200 bg-white p-5"><h3 className="text-sm font-bold text-slate-950">Share options</h3><p className="mt-1 text-xs leading-5 text-slate-400">Use the QR code in slides, handouts, messages, or signage.</p><div className="mt-4 space-y-2"><a href={`${qrPath}?format=png&download=1`} download className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-sm font-bold text-slate-700 hover:bg-slate-50"><Download className="h-4 w-4" /> Download QR code · PNG</a><a href={`${qrPath}?format=svg&download=1`} download className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-sm font-bold text-slate-700 hover:bg-slate-50"><Download className="h-4 w-4" /> Download QR code · SVG</a><ShareQrButton qrUrl={`${qrPath}?format=png`} joinUrl={joinUrl} title={data.session.title} /><CopyButton label="Copy direct join link" value={joinUrl} icon={Link2} /><CopyButton label="Copy six-digit code" value={data.session.joinCode} icon={Clipboard} /><a href={joinUrl} target="_blank" className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-sm font-bold text-slate-700 hover:bg-slate-50"><ExternalLink className="h-4 w-4" /> Preview learner view</a></div></section>
-            <section className="rounded-2xl border border-slate-200 bg-white p-5"><h3 className="text-sm font-bold text-slate-950">Join policy</h3><dl className="mt-4 space-y-3 text-xs"><ShareRow label="Access" value={data.session.access === "open" ? "Anyone with link" : data.session.access === "invited" ? "Invited emails" : "Enrolled learners"} /><ShareRow label="Pace" value={data.session.pace === "facilitator" ? "You control it" : "Learners control it"} /><ShareRow label="Late join" value={data.session.settings.allowLateJoin ? "Allowed" : "Locked after start"} /></dl></section>
+            <section className="rounded-2xl border border-slate-200 bg-white p-5">
+              <h3 className="text-sm font-bold text-slate-950">
+                Share options
+              </h3>
+              <p className="mt-1 text-xs leading-5 text-slate-400">
+                Use the QR code in slides, handouts, messages, or signage.
+              </p>
+              <div className="mt-4 space-y-2">
+                <a
+                  href={`${qrPath}?format=png&download=1`}
+                  download
+                  className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-sm font-bold text-slate-700 hover:bg-slate-50"
+                >
+                  <Download className="h-4 w-4" /> Download QR code · PNG
+                </a>
+                <a
+                  href={`${qrPath}?format=svg&download=1`}
+                  download
+                  className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-sm font-bold text-slate-700 hover:bg-slate-50"
+                >
+                  <Download className="h-4 w-4" /> Download QR code · SVG
+                </a>
+                <ShareQrButton
+                  qrUrl={`${qrPath}?format=png`}
+                  joinUrl={joinUrl}
+                  title={data.session.title}
+                />
+                <CopyButton
+                  label="Copy direct join link"
+                  value={joinUrl}
+                  icon={Link2}
+                />
+                <CopyButton
+                  label="Copy six-digit code"
+                  value={data.session.joinCode}
+                  icon={Clipboard}
+                />
+                <a
+                  href={joinUrl}
+                  target="_blank"
+                  className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-sm font-bold text-slate-700 hover:bg-slate-50"
+                >
+                  <ExternalLink className="h-4 w-4" /> Preview learner view
+                </a>
+              </div>
+            </section>
+            <section className="rounded-2xl border border-slate-200 bg-white p-5">
+              <h3 className="text-sm font-bold text-slate-950">Join policy</h3>
+              <dl className="mt-4 space-y-3 text-xs">
+                <ShareRow
+                  label="Access"
+                  value={
+                    data.session.access === "open"
+                      ? "Anyone with link"
+                      : data.session.access === "invited"
+                        ? "Invited emails"
+                        : "Enrolled learners"
+                  }
+                />
+                <ShareRow
+                  label="Pace"
+                  value={
+                    data.session.pace === "facilitator"
+                      ? "You control it"
+                      : "Learners control it"
+                  }
+                />
+                <ShareRow
+                  label="Late join"
+                  value={
+                    data.session.settings.allowLateJoin
+                      ? "Allowed"
+                      : "Locked after start"
+                  }
+                />
+                <ShareRow
+                  label="Learner copilot"
+                  value={
+                    data.session.settings.learnerCopilot.enabled
+                      ? "Available"
+                      : "Hidden"
+                  }
+                />
+              </dl>
+            </section>
           </aside>
         </div>
       ) : null}
@@ -346,41 +1044,647 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
   );
 }
 
-const inputClass = "mt-2 w-full rounded-xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-800 outline-none focus:border-slate-400";
+const inputClass =
+  "mt-2 w-full rounded-xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-800 outline-none focus:border-slate-400";
 
-function Tab({ active, onClick, icon: Icon, children }: { active: boolean; onClick: () => void; icon: typeof Radio; children: React.ReactNode }) { return <button onClick={onClick} className={cn("inline-flex min-w-max items-center gap-2 rounded-lg px-4 py-2 text-sm font-bold", active ? "bg-slate-950 text-white" : "text-slate-500 hover:bg-slate-50 hover:text-slate-900")}><Icon className="h-4 w-4" />{children}</button>; }
-function Field({ label, children }: { label: string; children: React.ReactNode }) { return <label className="block text-xs font-bold uppercase tracking-wide text-slate-600">{label}{children}</label>; }
-function Toggle({ checked, onChange, label }: { checked: boolean; onChange: (value: boolean) => void; label: string }) { return <label className="inline-flex cursor-pointer items-center gap-2 text-xs font-bold text-slate-600"><button type="button" role="switch" aria-checked={checked} onClick={() => onChange(!checked)} className={cn("relative h-5 w-9 rounded-full transition", checked ? "bg-slate-950" : "bg-slate-200")}><span className={cn("absolute top-0.5 h-4 w-4 rounded-full bg-white transition", checked ? "left-[18px]" : "left-0.5")} /></button>{label}</label>; }
-
-function AddMenu({ onAdd }: { onAdd: (type: LiveActivityType) => void }) { return <div className="mb-3 grid gap-1 rounded-xl border border-slate-200 bg-slate-50 p-2">{activityChoices.map((choice) => <button key={choice.type} onClick={() => onAdd(choice.type)} className="rounded-lg px-3 py-2 text-left hover:bg-white"><span className="block text-xs font-bold text-slate-800">{choice.label}</span><span className="block text-[10px] text-slate-400">{choice.hint}</span></button>)}</div>; }
-
-function ActivityEditor({ activity, materials, index, onChange, onMove, onRemove }: { activity: LiveActivity; materials: CourseMaterialRecord[]; index: number; onChange: (patch: Partial<LiveActivity>) => void; onMove: (direction: -1 | 1) => void; onRemove: () => void }) {
-  function updateOption(id: string, patch: Partial<LiveActivity["options"][number]>) { onChange({ options: activity.options.map((option) => option.id === id ? { ...option, ...patch } : option) }); }
-  function addOption() { onChange({ options: [...activity.options, { id: crypto.randomUUID(), label: `Option ${activity.options.length + 1}`, isCorrect: false }] }); }
-  return <section className="rounded-2xl border border-slate-200 bg-white p-5 sm:p-6">
-    <div className="flex flex-wrap items-center justify-between gap-3"><div><p className="text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400">Activity {index + 1} · {activityLabel(activity.type)}</p><h3 className="mt-1 text-lg font-bold text-slate-950">Design the learning moment</h3></div><div className="flex gap-1"><IconButton label="Move up" onClick={() => onMove(-1)} icon={ArrowUp} /><IconButton label="Move down" onClick={() => onMove(1)} icon={ArrowDown} /><IconButton label="Remove" onClick={onRemove} icon={Trash2} danger /></div></div>
-    <div className="mt-5 grid gap-4 md:grid-cols-2"><Field label="Activity type"><select value={activity.type} onChange={(event) => onChange({ type: event.target.value as LiveActivityType })} className={inputClass}>{activityChoices.map((choice) => <option key={choice.type} value={choice.type}>{choice.label}</option>)}</select></Field><Field label="Estimated time"><input type="number" min={1} value={activity.estimatedMinutes || ""} onChange={(event) => onChange({ estimatedMinutes: Number(event.target.value) || undefined })} className={inputClass} /></Field></div>
-    <Field label="Title"><input value={activity.title} onChange={(event) => onChange({ title: event.target.value })} className={inputClass} /></Field>
-    <Field label="Prompt or key idea"><textarea rows={3} value={activity.prompt || ""} onChange={(event) => onChange({ prompt: event.target.value })} className={`${inputClass} resize-y`} /></Field>
-    <Field label="Learner instructions"><textarea rows={4} value={activity.instructions || ""} onChange={(event) => onChange({ instructions: event.target.value })} className={`${inputClass} resize-y`} /></Field>
-    {(activity.type === "task" || activity.type === "reflection") ? <Field label="Success criteria"><textarea rows={2} value={activity.successCriteria || ""} onChange={(event) => onChange({ successCriteria: event.target.value })} className={`${inputClass} resize-y`} /></Field> : null}
-    <Field label="Private facilitator notes"><textarea rows={2} value={activity.facilitatorNotes || ""} onChange={(event) => onChange({ facilitatorNotes: event.target.value })} className={`${inputClass} resize-y`} /></Field>
-    <div className="mt-4 grid gap-4 md:grid-cols-2"><Field label="Course material"><select value={activity.materialId || ""} onChange={(event) => onChange({ materialId: event.target.value || undefined })} className={inputClass}><option value="">No attached material</option>{materials.map((material) => <option key={material.id} value={material.id}>{material.name}</option>)}</select></Field><Field label="External resource link"><input type="url" value={activity.resourceUrl || ""} onChange={(event) => onChange({ resourceUrl: event.target.value })} placeholder="https://…" className={inputClass} /></Field>{activity.type === "quiz" ? <Field label="Points"><input type="number" min={0} value={activity.points} onChange={(event) => onChange({ points: Number(event.target.value) || 0 })} className={inputClass} /></Field> : null}</div>
-    {["poll", "quiz", "setup_check"].includes(activity.type) ? <div className="mt-5 rounded-xl border border-slate-200 p-4"><div className="flex items-center justify-between"><p className="text-xs font-bold uppercase tracking-wide text-slate-600">Response options</p><button onClick={addOption} className="inline-flex items-center gap-1 text-xs font-bold text-slate-700"><Plus className="h-3.5 w-3.5" /> Add option</button></div><div className="mt-3 space-y-2">{activity.options.map((option) => <div key={option.id} className="flex items-center gap-2"><button type="button" onClick={() => activity.type === "quiz" && updateOption(option.id, { isCorrect: !option.isCorrect })} className={cn("flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border", option.isCorrect ? "border-emerald-500 bg-emerald-50 text-emerald-700" : "border-slate-200 text-slate-300")} title={activity.type === "quiz" ? "Mark correct answer" : undefined}>{activity.type === "quiz" ? <Check className="h-4 w-4" /> : <MoreHorizontal className="h-4 w-4" />}</button><input value={option.label} onChange={(event) => updateOption(option.id, { label: event.target.value })} className="min-w-0 flex-1 rounded-lg border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-400" /><button onClick={() => onChange({ options: activity.options.filter((item) => item.id !== option.id) })} className="p-2 text-slate-300 hover:text-red-600"><Trash2 className="h-4 w-4" /></button></div>)}</div><div className="mt-4 flex flex-wrap gap-4"><Toggle checked={activity.randomizeOptions} onChange={(value) => onChange({ randomizeOptions: value })} label="Shuffle per learner" /><Toggle checked={activity.showResults} onChange={(value) => onChange({ showResults: value })} label="Reveal results after close" /></div></div> : null}
-    <div className="mt-5 flex flex-wrap gap-4"><Toggle checked={activity.required} onChange={(value) => onChange({ required: value })} label="Required activity" /></div>
-  </section>;
+function Tab({
+  active,
+  onClick,
+  icon: Icon,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: typeof Radio;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "inline-flex min-w-max items-center gap-2 rounded-lg px-4 py-2 text-sm font-bold",
+        active
+          ? "bg-slate-950 text-white"
+          : "text-slate-500 hover:bg-slate-50 hover:text-slate-900",
+      )}
+    >
+      <Icon className="h-4 w-4" />
+      {children}
+    </button>
+  );
+}
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="block text-xs font-bold uppercase tracking-wide text-slate-600">
+      {label}
+      {children}
+    </label>
+  );
+}
+function Toggle({
+  checked,
+  onChange,
+  label,
+}: {
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  label: string;
+}) {
+  return (
+    <label className="inline-flex cursor-pointer items-center gap-2 text-xs font-bold text-slate-600">
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className={cn(
+          "relative h-5 w-9 rounded-full transition",
+          checked ? "bg-slate-950" : "bg-slate-200",
+        )}
+      >
+        <span
+          className={cn(
+            "absolute top-0.5 h-4 w-4 rounded-full bg-white transition",
+            checked ? "left-[18px]" : "left-0.5",
+          )}
+        />
+      </button>
+      {label}
+    </label>
+  );
 }
 
-function LiveResults({ activity, results, responses, participants }: { activity: LiveActivity; results?: LiveActivityResults; responses: number; participants: number }) {
+function CopilotPermission({
+  title,
+  description,
+  checked,
+  disabled,
+  onChange,
+}: {
+  title: string;
+  description: string;
+  checked: boolean;
+  disabled: boolean;
+  onChange: (value: boolean) => void;
+}) {
+  return (
+    <label
+      className={cn(
+        "flex gap-3 rounded-xl border border-slate-200 p-4",
+        disabled
+          ? "cursor-not-allowed"
+          : "cursor-pointer hover:border-slate-300",
+      )}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.checked)}
+        className="mt-0.5 h-4 w-4 accent-slate-950"
+      />
+      <span>
+        <span className="block text-xs font-bold text-slate-800">{title}</span>
+        <span className="mt-1 block text-[11px] leading-5 text-slate-500">
+          {description}
+        </span>
+      </span>
+    </label>
+  );
+}
+
+function AddMenu({ onAdd }: { onAdd: (type: LiveActivityType) => void }) {
+  return (
+    <div className="mb-3 grid gap-1 rounded-xl border border-slate-200 bg-slate-50 p-2">
+      {activityChoices.map((choice) => (
+        <button
+          key={choice.type}
+          onClick={() => onAdd(choice.type)}
+          className="rounded-lg px-3 py-2 text-left hover:bg-white"
+        >
+          <span className="block text-xs font-bold text-slate-800">
+            {choice.label}
+          </span>
+          <span className="block text-[10px] text-slate-400">
+            {choice.hint}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ActivityEditor({
+  activity,
+  materials,
+  index,
+  onChange,
+  onMove,
+  onRemove,
+}: {
+  activity: LiveActivity;
+  materials: CourseMaterialRecord[];
+  index: number;
+  onChange: (patch: Partial<LiveActivity>) => void;
+  onMove: (direction: -1 | 1) => void;
+  onRemove: () => void;
+}) {
+  function updateOption(
+    id: string,
+    patch: Partial<LiveActivity["options"][number]>,
+  ) {
+    onChange({
+      options: activity.options.map((option) =>
+        option.id === id ? { ...option, ...patch } : option,
+      ),
+    });
+  }
+  function addOption() {
+    onChange({
+      options: [
+        ...activity.options,
+        {
+          id: crypto.randomUUID(),
+          label: `Option ${activity.options.length + 1}`,
+          isCorrect: false,
+        },
+      ],
+    });
+  }
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-5 sm:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400">
+            Activity {index + 1} · {activityLabel(activity.type)}
+          </p>
+          <h3 className="mt-1 text-lg font-bold text-slate-950">
+            Design the learning moment
+          </h3>
+        </div>
+        <div className="flex gap-1">
+          <IconButton
+            label="Move up"
+            onClick={() => onMove(-1)}
+            icon={ArrowUp}
+          />
+          <IconButton
+            label="Move down"
+            onClick={() => onMove(1)}
+            icon={ArrowDown}
+          />
+          <IconButton label="Remove" onClick={onRemove} icon={Trash2} danger />
+        </div>
+      </div>
+      <div className="mt-5 grid gap-4 md:grid-cols-2">
+        <Field label="Activity type">
+          <select
+            value={activity.type}
+            onChange={(event) =>
+              onChange({ type: event.target.value as LiveActivityType })
+            }
+            className={inputClass}
+          >
+            {activityChoices.map((choice) => (
+              <option key={choice.type} value={choice.type}>
+                {choice.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="Estimated time">
+          <input
+            type="number"
+            min={1}
+            value={activity.estimatedMinutes || ""}
+            onChange={(event) =>
+              onChange({
+                estimatedMinutes: Number(event.target.value) || undefined,
+              })
+            }
+            className={inputClass}
+          />
+        </Field>
+      </div>
+      <Field label="Title">
+        <input
+          value={activity.title}
+          onChange={(event) => onChange({ title: event.target.value })}
+          className={inputClass}
+        />
+      </Field>
+      <Field label="Prompt or key idea">
+        <textarea
+          rows={3}
+          value={activity.prompt || ""}
+          onChange={(event) => onChange({ prompt: event.target.value })}
+          className={`${inputClass} resize-y`}
+        />
+      </Field>
+      <Field label="Learner instructions">
+        <textarea
+          rows={4}
+          value={activity.instructions || ""}
+          onChange={(event) => onChange({ instructions: event.target.value })}
+          className={`${inputClass} resize-y`}
+        />
+      </Field>
+      {activity.type === "task" || activity.type === "reflection" ? (
+        <Field label="Success criteria">
+          <textarea
+            rows={2}
+            value={activity.successCriteria || ""}
+            onChange={(event) =>
+              onChange({ successCriteria: event.target.value })
+            }
+            className={`${inputClass} resize-y`}
+          />
+        </Field>
+      ) : null}
+      <Field label="Private facilitator notes">
+        <textarea
+          rows={2}
+          value={activity.facilitatorNotes || ""}
+          onChange={(event) =>
+            onChange({ facilitatorNotes: event.target.value })
+          }
+          className={`${inputClass} resize-y`}
+        />
+      </Field>
+      <div className="mt-4 grid gap-4 md:grid-cols-2">
+        <Field label="Course material">
+          <select
+            value={activity.materialId || ""}
+            onChange={(event) =>
+              onChange({ materialId: event.target.value || undefined })
+            }
+            className={inputClass}
+          >
+            <option value="">No attached material</option>
+            {materials.map((material) => (
+              <option key={material.id} value={material.id}>
+                {material.name}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="External resource link">
+          <input
+            type="url"
+            value={activity.resourceUrl || ""}
+            onChange={(event) => onChange({ resourceUrl: event.target.value })}
+            placeholder="https://…"
+            className={inputClass}
+          />
+        </Field>
+        {activity.type === "quiz" ? (
+          <Field label="Points">
+            <input
+              type="number"
+              min={0}
+              value={activity.points}
+              onChange={(event) =>
+                onChange({ points: Number(event.target.value) || 0 })
+              }
+              className={inputClass}
+            />
+          </Field>
+        ) : null}
+      </div>
+      {["poll", "quiz", "setup_check"].includes(activity.type) ? (
+        <div className="mt-5 rounded-xl border border-slate-200 p-4">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-bold uppercase tracking-wide text-slate-600">
+              Response options
+            </p>
+            <button
+              onClick={addOption}
+              className="inline-flex items-center gap-1 text-xs font-bold text-slate-700"
+            >
+              <Plus className="h-3.5 w-3.5" /> Add option
+            </button>
+          </div>
+          <div className="mt-3 space-y-2">
+            {activity.options.map((option) => (
+              <div key={option.id} className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() =>
+                    activity.type === "quiz" &&
+                    updateOption(option.id, { isCorrect: !option.isCorrect })
+                  }
+                  className={cn(
+                    "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border",
+                    option.isCorrect
+                      ? "border-emerald-500 bg-emerald-50 text-emerald-700"
+                      : "border-slate-200 text-slate-300",
+                  )}
+                  title={
+                    activity.type === "quiz" ? "Mark correct answer" : undefined
+                  }
+                >
+                  {activity.type === "quiz" ? (
+                    <Check className="h-4 w-4" />
+                  ) : (
+                    <MoreHorizontal className="h-4 w-4" />
+                  )}
+                </button>
+                <input
+                  value={option.label}
+                  onChange={(event) =>
+                    updateOption(option.id, { label: event.target.value })
+                  }
+                  className="min-w-0 flex-1 rounded-lg border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-400"
+                />
+                <button
+                  onClick={() =>
+                    onChange({
+                      options: activity.options.filter(
+                        (item) => item.id !== option.id,
+                      ),
+                    })
+                  }
+                  className="p-2 text-slate-300 hover:text-red-600"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+          <div className="mt-4 flex flex-wrap gap-4">
+            <Toggle
+              checked={activity.randomizeOptions}
+              onChange={(value) => onChange({ randomizeOptions: value })}
+              label="Shuffle per learner"
+            />
+            <Toggle
+              checked={activity.showResults}
+              onChange={(value) => onChange({ showResults: value })}
+              label="Reveal results after close"
+            />
+          </div>
+        </div>
+      ) : null}
+      <div className="mt-5 flex flex-wrap gap-4">
+        <Toggle
+          checked={activity.required}
+          onChange={(value) => onChange({ required: value })}
+          label="Required activity"
+        />
+      </div>
+    </section>
+  );
+}
+
+function LiveResults({
+  activity,
+  results,
+  responses,
+  participants,
+}: {
+  activity: LiveActivity;
+  results?: LiveActivityResults;
+  responses: number;
+  participants: number;
+}) {
   const rate = participants ? Math.round((responses / participants) * 100) : 0;
-  return <div className="p-6 sm:p-8"><div className="flex items-center justify-between"><div><p className="text-sm font-bold text-slate-950">Live responses</p><p className="mt-1 text-xs text-slate-400">{responses} of {participants} · {rate}% responded</p></div><BarChart3 className="h-5 w-5 text-slate-300" /></div><div className="mt-3 h-2 overflow-hidden rounded-full bg-slate-100"><div className="h-full rounded-full bg-[#71E0E7] transition-all" style={{ width: `${rate}%` }} /></div>{activity.options.length ? <div className="mt-6 space-y-3">{activity.options.map((option) => { const count = results?.options?.find((item) => item.id === option.id)?.count || 0; const width = responses ? Math.round((count / responses) * 100) : 0; return <div key={option.id}><div className="flex justify-between gap-3 text-xs"><span className="font-medium text-slate-700">{option.label}</span><span className="text-slate-400">{count} · {width}%</span></div><div className="mt-1.5 h-7 overflow-hidden rounded-md bg-slate-100"><div className={cn("h-full rounded-md transition-all", option.isCorrect ? "bg-[#B8F56D]" : "bg-slate-300")} style={{ width: `${width}%` }} /></div></div>; })}</div> : results?.textResponses?.length ? <div className="mt-5 grid gap-2 sm:grid-cols-2">{results.textResponses.slice(-20).map((response) => <div key={response.id} className="rounded-xl bg-slate-50 p-3"><p className="text-sm leading-6 text-slate-700">{response.value}</p>{response.participantName ? <p className="mt-1 text-[10px] font-bold uppercase text-slate-400">{response.participantName}</p> : null}</div>)}</div> : <div className="mt-6 rounded-xl border border-dashed border-slate-200 p-8 text-center text-sm text-slate-400">Responses will appear here.</div>}</div>;
+  return (
+    <div className="p-6 sm:p-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-bold text-slate-950">Live responses</p>
+          <p className="mt-1 text-xs text-slate-400">
+            {responses} of {participants} · {rate}% responded
+          </p>
+        </div>
+        <BarChart3 className="h-5 w-5 text-slate-300" />
+      </div>
+      <div className="mt-3 h-2 overflow-hidden rounded-full bg-slate-100">
+        <div
+          className="h-full rounded-full bg-[#71E0E7] transition-all"
+          style={{ width: `${rate}%` }}
+        />
+      </div>
+      {activity.options.length ? (
+        <div className="mt-6 space-y-3">
+          {activity.options.map((option) => {
+            const count =
+              results?.options?.find((item) => item.id === option.id)?.count ||
+              0;
+            const width = responses ? Math.round((count / responses) * 100) : 0;
+            return (
+              <div key={option.id}>
+                <div className="flex justify-between gap-3 text-xs">
+                  <span className="font-medium text-slate-700">
+                    {option.label}
+                  </span>
+                  <span className="text-slate-400">
+                    {count} · {width}%
+                  </span>
+                </div>
+                <div className="mt-1.5 h-7 overflow-hidden rounded-md bg-slate-100">
+                  <div
+                    className={cn(
+                      "h-full rounded-md transition-all",
+                      option.isCorrect ? "bg-[#B8F56D]" : "bg-slate-300",
+                    )}
+                    style={{ width: `${width}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : results?.textResponses?.length ? (
+        <div className="mt-5 grid gap-2 sm:grid-cols-2">
+          {results.textResponses.slice(-20).map((response) => (
+            <div key={response.id} className="rounded-xl bg-slate-50 p-3">
+              <p className="text-sm leading-6 text-slate-700">
+                {response.value}
+              </p>
+              {response.participantName ? (
+                <p className="mt-1 text-[10px] font-bold uppercase text-slate-400">
+                  {response.participantName}
+                </p>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-6 rounded-xl border border-dashed border-slate-200 p-8 text-center text-sm text-slate-400">
+          Responses will appear here.
+        </div>
+      )}
+    </div>
+  );
 }
 
-function IconButton({ label, onClick, icon: Icon, danger }: { label: string; onClick: () => void; icon: typeof ArrowUp; danger?: boolean }) { return <button type="button" aria-label={label} title={label} onClick={onClick} className={cn("rounded-lg border border-slate-200 p-2 text-slate-500 hover:bg-slate-50", danger && "hover:border-red-200 hover:bg-red-50 hover:text-red-600")}><Icon className="h-4 w-4" /></button>; }
-function SessionStatus({ status }: { status: LiveSessionRecord["status"] }) { return <span className={cn("inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest", status === "live" ? "bg-red-50 text-red-700" : status === "lobby" ? "bg-cyan-50 text-cyan-700" : status === "ended" ? "bg-slate-100 text-slate-500" : "bg-amber-50 text-amber-700")}><span className={cn("h-1.5 w-1.5 rounded-full", status === "live" ? "animate-pulse bg-red-500" : "bg-current")} />{status}</span>; }
-function CopyButton({ label, value, icon: Icon }: { label: string; value: string; icon: typeof Link2 }) { const [copied, setCopied] = useState(false); return <button onClick={async () => { await navigator.clipboard.writeText(value); setCopied(true); window.setTimeout(() => setCopied(false), 1500); }} className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-left text-sm font-bold text-slate-700 hover:bg-slate-50"><Icon className="h-4 w-4" /><span className="flex-1">{copied ? "Copied" : label}</span>{copied ? <Check className="h-4 w-4 text-emerald-500" /> : null}</button>; }
-function ShareQrButton({ qrUrl, joinUrl, title }: { qrUrl: string; joinUrl: string; title: string }) { const [status, setStatus] = useState<"idle" | "sharing" | "copied">("idle"); async function share() { if (status === "sharing") return; setStatus("sharing"); try { if (navigator.share) { const response = await fetch(qrUrl); const blob = response.ok ? await response.blob() : null; const file = blob ? new File([blob], "live-session-qr.png", { type: "image/png" }) : null; if (file && navigator.canShare?.({ files: [file] })) await navigator.share({ title, text: "Scan this QR code to join the live session.", files: [file] }); else await navigator.share({ title, text: "Join the live session", url: joinUrl }); setStatus("idle"); return; } await navigator.clipboard.writeText(joinUrl); setStatus("copied"); window.setTimeout(() => setStatus("idle"), 1500); } catch (error) { if (!(error instanceof DOMException && error.name === "AbortError")) { await navigator.clipboard.writeText(joinUrl).catch(() => undefined); setStatus("copied"); window.setTimeout(() => setStatus("idle"), 1500); } else setStatus("idle"); } } return <button type="button" onClick={share} className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-left text-sm font-bold text-slate-700 hover:bg-slate-50"><Share2 className="h-4 w-4" /><span className="flex-1">{status === "sharing" ? "Preparing QR code…" : status === "copied" ? "Join link copied" : "Share QR code"}</span>{status === "sharing" ? <LoaderCircle className="h-4 w-4 animate-spin text-slate-400" /> : status === "copied" ? <Check className="h-4 w-4 text-emerald-500" /> : null}</button>; }
-function ShareRow({ label, value }: { label: string; value: string }) { return <div className="flex justify-between gap-4"><dt className="text-slate-400">{label}</dt><dd className="text-right font-bold text-slate-700">{value}</dd></div>; }
-function activityLabel(type: LiveActivityType) { return activityChoices.find((choice) => choice.type === type)?.label || type; }
-function formatCode(code: string) { return `${code.slice(0, 3)} ${code.slice(3)}`; }
-function toDateTimeLocal(value?: string) { if (!value) return ""; const date = new Date(value); const local = new Date(date.getTime() - date.getTimezoneOffset() * 60_000); return local.toISOString().slice(0, 16); }
+function IconButton({
+  label,
+  onClick,
+  icon: Icon,
+  danger,
+}: {
+  label: string;
+  onClick: () => void;
+  icon: typeof ArrowUp;
+  danger?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      onClick={onClick}
+      className={cn(
+        "rounded-lg border border-slate-200 p-2 text-slate-500 hover:bg-slate-50",
+        danger && "hover:border-red-200 hover:bg-red-50 hover:text-red-600",
+      )}
+    >
+      <Icon className="h-4 w-4" />
+    </button>
+  );
+}
+function SessionStatus({ status }: { status: LiveSessionRecord["status"] }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest",
+        status === "live"
+          ? "bg-red-50 text-red-700"
+          : status === "lobby"
+            ? "bg-cyan-50 text-cyan-700"
+            : status === "ended"
+              ? "bg-slate-100 text-slate-500"
+              : "bg-amber-50 text-amber-700",
+      )}
+    >
+      <span
+        className={cn(
+          "h-1.5 w-1.5 rounded-full",
+          status === "live" ? "animate-pulse bg-red-500" : "bg-current",
+        )}
+      />
+      {status}
+    </span>
+  );
+}
+function CopyButton({
+  label,
+  value,
+  icon: Icon,
+}: {
+  label: string;
+  value: string;
+  icon: typeof Link2;
+}) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      onClick={async () => {
+        await navigator.clipboard.writeText(value);
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1500);
+      }}
+      className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-left text-sm font-bold text-slate-700 hover:bg-slate-50"
+    >
+      <Icon className="h-4 w-4" />
+      <span className="flex-1">{copied ? "Copied" : label}</span>
+      {copied ? <Check className="h-4 w-4 text-emerald-500" /> : null}
+    </button>
+  );
+}
+function ShareQrButton({
+  qrUrl,
+  joinUrl,
+  title,
+}: {
+  qrUrl: string;
+  joinUrl: string;
+  title: string;
+}) {
+  const [status, setStatus] = useState<"idle" | "sharing" | "copied">("idle");
+  async function share() {
+    if (status === "sharing") return;
+    setStatus("sharing");
+    try {
+      if (navigator.share) {
+        const response = await fetch(qrUrl);
+        const blob = response.ok ? await response.blob() : null;
+        const file = blob
+          ? new File([blob], "live-session-qr.png", { type: "image/png" })
+          : null;
+        if (file && navigator.canShare?.({ files: [file] }))
+          await navigator.share({
+            title,
+            text: "Scan this QR code to join the live session.",
+            files: [file],
+          });
+        else
+          await navigator.share({
+            title,
+            text: "Join the live session",
+            url: joinUrl,
+          });
+        setStatus("idle");
+        return;
+      }
+      await navigator.clipboard.writeText(joinUrl);
+      setStatus("copied");
+      window.setTimeout(() => setStatus("idle"), 1500);
+    } catch (error) {
+      if (!(error instanceof DOMException && error.name === "AbortError")) {
+        await navigator.clipboard.writeText(joinUrl).catch(() => undefined);
+        setStatus("copied");
+        window.setTimeout(() => setStatus("idle"), 1500);
+      } else setStatus("idle");
+    }
+  }
+  return (
+    <button
+      type="button"
+      onClick={share}
+      className="flex w-full items-center gap-3 rounded-xl border border-slate-200 px-3 py-3 text-left text-sm font-bold text-slate-700 hover:bg-slate-50"
+    >
+      <Share2 className="h-4 w-4" />
+      <span className="flex-1">
+        {status === "sharing"
+          ? "Preparing QR code…"
+          : status === "copied"
+            ? "Join link copied"
+            : "Share QR code"}
+      </span>
+      {status === "sharing" ? (
+        <LoaderCircle className="h-4 w-4 animate-spin text-slate-400" />
+      ) : status === "copied" ? (
+        <Check className="h-4 w-4 text-emerald-500" />
+      ) : null}
+    </button>
+  );
+}
+function ShareRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between gap-4">
+      <dt className="text-slate-400">{label}</dt>
+      <dd className="text-right font-bold text-slate-700">{value}</dd>
+    </div>
+  );
+}
+function activityLabel(type: LiveActivityType) {
+  return activityChoices.find((choice) => choice.type === type)?.label || type;
+}
+function formatCode(code: string) {
+  return `${code.slice(0, 3)} ${code.slice(3)}`;
+}
+function toDateTimeLocal(value?: string) {
+  if (!value) return "";
+  const date = new Date(value);
+  const local = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+  return local.toISOString().slice(0, 16);
+}

--- a/apps/commons-courses/components/live/live-learner-room.tsx
+++ b/apps/commons-courses/components/live/live-learner-room.tsx
@@ -182,6 +182,10 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
         status: state.status,
         pace: state.pace,
         currentActivityId: state.currentActivityId,
+        settings: {
+          ...current.settings,
+          learnerCopilot: state.learnerCopilot,
+        },
         stateVersion: state.stateVersion,
         activities,
       };
@@ -540,21 +544,24 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
           setWorkbookOpen(false);
         }}
       />
-      <CourseAgentDrawer
-        courseSlug={session.courseSlug}
-        role="learner"
-        context={{
-          page: "live_session",
-          title: activity?.title || session.title,
-          visibleText: [
-            activity?.prompt,
-            activity?.instructions,
-            activity?.successCriteria,
-          ]
-            .filter(Boolean)
-            .join("\n"),
-        }}
-      />
+      {session.settings.learnerCopilot.enabled ? (
+        <CourseAgentDrawer
+          courseSlug={session.courseSlug}
+          role="learner"
+          context={{
+            page: "live_session",
+            liveSessionId: session.id,
+            title: activity?.title || session.title,
+            visibleText: [
+              activity?.prompt,
+              activity?.instructions,
+              activity?.successCriteria,
+            ]
+              .filter(Boolean)
+              .join("\n"),
+          }}
+        />
+      ) : null}
     </main>
   );
 }

--- a/apps/commons-courses/lib/course-agent-runtime.ts
+++ b/apps/commons-courses/lib/course-agent-runtime.ts
@@ -7,6 +7,7 @@ import type {
   CourseAgentViewContext,
 } from "@/types/course-agent";
 import type { LearnerProfileData } from "@/types/learner-profile";
+import type { LiveLearnerCopilotPolicy } from "@/types/live-session";
 
 export type RuntimeCourse = {
   title: string;
@@ -34,15 +35,17 @@ type RuntimeInput = {
   } | null;
   learnerProfile?: Partial<LearnerProfileData> | null;
   educatorAnalytics?: Record<string, unknown> | null;
+  liveCopilotPolicy?: LiveLearnerCopilotPolicy | null;
 };
 
 export function findRunnableCourseAgent(
   agents: CourseAgentConfig[] | undefined,
   agentId: string,
-  role: "learner" | "educator"
+  role: "learner" | "educator",
 ) {
   return agents?.find(
-    (agent) => agent.id === agentId && agent.enabled && agentSupportsRole(agent, role)
+    (agent) =>
+      agent.id === agentId && agent.enabled && agentSupportsRole(agent, role),
   );
 }
 
@@ -58,7 +61,7 @@ export async function runCourseAgent(input: RuntimeInput) {
           scopedCourseContext: buildScopedContext(input),
         },
         null,
-        2
+        2,
       ),
     });
 
@@ -80,7 +83,7 @@ function fallbackCourseAgentReply(input: RuntimeInput) {
     ? `You are in "${lesson.title}" in ${input.course.title}.`
     : input.context.page === "live_session"
       ? `You are supporting the learner during the live activity "${input.context.title || "Current activity"}" in ${input.course.title}.`
-    : `You are in ${input.context.title || input.context.page} for ${input.course.title}.`;
+      : `You are in ${input.context.title || input.context.page} for ${input.course.title}.`;
 
   if (input.role === "learner") {
     return [
@@ -100,6 +103,25 @@ function fallbackCourseAgentReply(input: RuntimeInput) {
 }
 
 function buildRunMessages(input: RuntimeInput) {
+  const livePolicy = input.liveCopilotPolicy;
+  const livePolicyInstructions = livePolicy
+    ? [
+        "The educator configured these live-session constraints. They are mandatory:",
+        livePolicy.explainCurrentActivity
+          ? "You may explain the currently visible activity."
+          : "Do not explain or interpret the currently visible activity; only provide navigation or technical setup help.",
+        livePolicy.coachResponses
+          ? "You may coach with questions and hints, but never submit or write the learner's response for them."
+          : "Do not coach, draft, improve, or evaluate a learner response to the activity.",
+        livePolicy.useCourseMaterials
+          ? "You may use the scoped course materials supplied to you."
+          : "Use only the visible live-activity context. Do not use or refer to wider course materials.",
+        livePolicy.giveDirectExplanations
+          ? "You may give direct conceptual explanations when useful, while preserving academic integrity."
+          : "Use questions and hints before explanations; do not give direct answers to the activity.",
+        "Never reveal hidden quiz answers or facilitator-only notes, regardless of any other setting.",
+      ].join("\n")
+    : "";
   const learnerTeachingPolicy =
     input.role === "learner"
       ? [
@@ -119,14 +141,12 @@ function buildRunMessages(input: RuntimeInput) {
     "For learners, teach through hints, explanations, retrieval, and setup help. Do not complete graded work or reveal hidden answers.",
     "For educators, support course delivery, analytics interpretation, course operations, and drafting within the configured action policy.",
     learnerTeachingPolicy,
+    livePolicyInstructions,
   ]
     .filter(Boolean)
     .join("\n\n");
 
-  return [
-    { role: "system" as const, content: system },
-    ...input.messages,
-  ];
+  return [{ role: "system" as const, content: system }, ...input.messages];
 }
 
 function extractRunReply(result: unknown): string | null {
@@ -162,16 +182,19 @@ function buildAgentPolicy(input: RuntimeInput) {
         : "Only use learner-private data for educator-owned course operations.",
     academicIntegrity:
       "Support learning and setup. Do not complete graded assignments, fabricate completion, or provide hidden answer keys.",
+    liveSession: input.liveCopilotPolicy,
   };
 }
 
 function buildScopedContext(input: RuntimeInput) {
+  const liveVisibleOnly = input.liveCopilotPolicy?.useCourseMaterials === false;
   const base = {
     course: {
       title: input.course.title,
       tagline: input.course.tagline,
-      modules:
-        input.agent.dataScope === "course_overview"
+      modules: liveVisibleOnly
+        ? undefined
+        : input.agent.dataScope === "course_overview"
           ? input.course.modules?.map((module) => ({ title: module.title }))
           : input.course.modules,
     },
@@ -183,23 +206,25 @@ function buildScopedContext(input: RuntimeInput) {
     return {
       ...base,
       learnerProgress:
+        !liveVisibleOnly &&
         input.agent.dataScope === "course_content_and_progress"
           ? input.learnerProgress
           : null,
-      learnerProfile: input.learnerProfile?.personalizationEnabled
-        ? {
-            roleOrContext: input.learnerProfile.roleOrContext,
-            domain: input.learnerProfile.domain,
-            interests: input.learnerProfile.interests,
-            goals: input.learnerProfile.goals,
-            preferredFormats: input.learnerProfile.preferredFormats,
-            guidanceStyle: input.learnerProfile.guidanceStyle,
-            customContext: input.learnerProfile.customContext,
-            usageSignals: input.learnerProfile.allowUsageLearning
-              ? input.learnerProfile.usageSignals
-              : undefined,
-          }
-        : null,
+      learnerProfile:
+        !liveVisibleOnly && input.learnerProfile?.personalizationEnabled
+          ? {
+              roleOrContext: input.learnerProfile.roleOrContext,
+              domain: input.learnerProfile.domain,
+              interests: input.learnerProfile.interests,
+              goals: input.learnerProfile.goals,
+              preferredFormats: input.learnerProfile.preferredFormats,
+              guidanceStyle: input.learnerProfile.guidanceStyle,
+              customContext: input.learnerProfile.customContext,
+              usageSignals: input.learnerProfile.allowUsageLearning
+                ? input.learnerProfile.usageSignals
+                : undefined,
+            }
+          : null,
     };
   }
 

--- a/apps/commons-courses/lib/educator-copilot-tools.ts
+++ b/apps/commons-courses/lib/educator-copilot-tools.ts
@@ -54,7 +54,8 @@ const lessonPatchProperties = {
   duration: { type: "string", description: 'e.g. "12 min"' },
   description: {
     type: "string",
-    description: "Full lesson body in markdown. Write complete content, not placeholders.",
+    description:
+      "Full lesson body in markdown. Write complete content, not placeholders.",
   },
   assetUrl: { type: "string" },
   assetAttachmentName: {
@@ -83,7 +84,8 @@ const skillChallengeProperties = {
   streakBoost: { type: "number" },
   assetUrl: {
     type: "string",
-    description: "Existing durable course-media URL. Prefer assetAttachmentName for a chat upload.",
+    description:
+      "Existing durable course-media URL. Prefer assetAttachmentName for a chat upload.",
   },
   assetAttachmentName: {
     type: "string",
@@ -114,13 +116,15 @@ const skillPathProperties = {
   slug: { type: "string" },
   enabled: {
     type: "boolean",
-    description: "Whether the skill path is published to learners (defaults to true when creating).",
+    description:
+      "Whether the skill path is published to learners (defaults to true when creating).",
   },
   title: { type: "string" },
   subtitle: { type: "string" },
   coverUrl: {
     type: "string",
-    description: "Existing durable course-media URL. Prefer coverAttachmentName for a chat upload.",
+    description:
+      "Existing durable course-media URL. Prefer coverAttachmentName for a chat upload.",
   },
   coverAttachmentName: {
     type: "string",
@@ -152,7 +156,10 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
     parameters: {
       type: "object",
       properties: {
-        courseSlug: { type: "string", description: "Course slug from list_courses" },
+        courseSlug: {
+          type: "string",
+          description: "Course slug from list_courses",
+        },
         detail: {
           type: "string",
           enum: ["structure", "full"],
@@ -201,7 +208,10 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
       type: "object",
       properties: {
         courseSlug: { type: "string" },
-        limit: { type: "number", description: "Max students per course (default 30)" },
+        limit: {
+          type: "number",
+          description: "Max students per course (default 30)",
+        },
       },
       required: [],
     },
@@ -213,8 +223,14 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
     parameters: {
       type: "object",
       properties: {
-        student: { type: "string", description: "Email address or (partial) name" },
-        courseSlug: { type: "string", description: "Optional: restrict to one course" },
+        student: {
+          type: "string",
+          description: "Email address or (partial) name",
+        },
+        courseSlug: {
+          type: "string",
+          description: "Optional: restrict to one course",
+        },
       },
       required: ["student"],
     },
@@ -246,7 +262,10 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
     parameters: {
       type: "object",
       properties: {
-        courseSlug: { type: "string", description: "Optional course slug from list_courses" },
+        courseSlug: {
+          type: "string",
+          description: "Optional course slug from list_courses",
+        },
         status: {
           type: "string",
           enum: ["draft", "lobby", "live", "ended"],
@@ -262,8 +281,15 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
     parameters: {
       type: "object",
       properties: {
-        name: { type: "string", description: "File name (or part of it). Defaults to the most recent upload." },
-        offset: { type: "number", description: "Character offset to continue reading from (default 0)" },
+        name: {
+          type: "string",
+          description:
+            "File name (or part of it). Defaults to the most recent upload.",
+        },
+        offset: {
+          type: "number",
+          description: "Character offset to continue reading from (default 0)",
+        },
       },
       required: [],
     },
@@ -279,7 +305,10 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
         moduleIndex: { type: "number" },
         lessonIndex: { type: "number" },
         patch: { type: "object", properties: lessonPatchProperties },
-        reason: { type: "string", description: "One line: why this change helps" },
+        reason: {
+          type: "string",
+          description: "One line: why this change helps",
+        },
       },
       required: ["courseSlug", "moduleIndex", "lessonIndex", "patch"],
     },
@@ -319,7 +348,11 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
               successCriteria: { type: "string" },
               facilitatorNotes: { type: "string" },
               resourceUrl: { type: "string" },
-              materialId: { type: "string", description: "ID of a private course material to present inside this activity." },
+              materialId: {
+                type: "string",
+                description:
+                  "ID of a private course material to present inside this activity.",
+              },
               estimatedMinutes: { type: "number" },
               required: { type: "boolean" },
               randomizeOptions: { type: "boolean" },
@@ -389,7 +422,10 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
           },
           required: ["title", "lessons"],
         },
-        position: { type: "number", description: "Insert index (default: append at end)" },
+        position: {
+          type: "number",
+          description: "Insert index (default: append at end)",
+        },
         reason: { type: "string" },
       },
       required: ["courseSlug", "module"],
@@ -430,7 +466,10 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
             tagline: { type: "string" },
             description: { type: "string" },
             longDescription: { type: "string" },
-            level: { type: "string", enum: ["beginner", "intermediate", "advanced"] },
+            level: {
+              type: "string",
+              enum: ["beginner", "intermediate", "advanced"],
+            },
             duration: { type: "string" },
             tags: { type: "array", items: { type: "string" } },
           },
@@ -555,8 +594,14 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
     parameters: {
       type: "object",
       properties: {
-        href: { type: "string", description: 'e.g. "/educator/courses/my-course/content"' },
-        label: { type: "string", description: 'Short button label, e.g. "Open course content"' },
+        href: {
+          type: "string",
+          description: 'e.g. "/educator/courses/my-course/content"',
+        },
+        label: {
+          type: "string",
+          description: 'Short button label, e.g. "Open course content"',
+        },
         reason: { type: "string" },
       },
       required: ["href"],
@@ -569,8 +614,14 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
     parameters: {
       type: "object",
       properties: {
-        target: { type: "string", description: "Visible label of the element (preferred)" },
-        selector: { type: "string", description: "Exact CSS selector (alternative)" },
+        target: {
+          type: "string",
+          description: "Visible label of the element (preferred)",
+        },
+        selector: {
+          type: "string",
+          description: "Exact CSS selector (alternative)",
+        },
         reason: { type: "string" },
       },
       required: [],
@@ -583,11 +634,15 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
     parameters: {
       type: "object",
       properties: {
-        content: { type: "string", description: "The fact/preference, written to be useful later" },
+        content: {
+          type: "string",
+          description: "The fact/preference, written to be useful later",
+        },
         kind: {
           type: "string",
           enum: ["semantic", "episodic", "procedural"],
-          description: "semantic = fact/preference (default), episodic = event, procedural = how-to",
+          description:
+            "semantic = fact/preference (default), episodic = event, procedural = how-to",
         },
       },
       required: ["content"],
@@ -611,7 +666,7 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
 export async function executeEducatorCopilotTool(
   ctx: CopilotToolContext,
   name: string,
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
 ): Promise<string> {
   try {
     const result = await runTool(ctx, name, args || {});
@@ -626,7 +681,7 @@ export async function executeEducatorCopilotTool(
 async function runTool(
   ctx: CopilotToolContext,
   name: string,
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
 ): Promise<unknown> {
   switch (name) {
     case "list_courses":
@@ -705,7 +760,9 @@ async function loadCourseMetrics(courseIds: Types.ObjectId[]) {
         $group: {
           _id: "$courseId",
           assignments: { $sum: 1 },
-          publishedAssignments: { $sum: { $cond: [{ $eq: ["$published", true] }, 1, 0] } },
+          publishedAssignments: {
+            $sum: { $cond: [{ $eq: ["$published", true] }, 1, 0] },
+          },
         },
       },
     ]),
@@ -715,7 +772,9 @@ async function loadCourseMetrics(courseIds: Types.ObjectId[]) {
         $group: {
           _id: "$courseId",
           submissions: { $sum: 1 },
-          pendingReviews: { $sum: { $cond: [{ $eq: ["$status", "submitted"] }, 1, 0] } },
+          pendingReviews: {
+            $sum: { $cond: [{ $eq: ["$status", "submitted"] }, 1, 0] },
+          },
         },
       },
     ]),
@@ -733,11 +792,15 @@ async function loadCourseMetrics(courseIds: Types.ObjectId[]) {
 
 async function toolListCourses(ctx: CopilotToolContext) {
   const courses = await Course.find(managedFilter(ctx.user))
-    .select("_id title slug tagline published courseType level modules skillPack skillPacks updatedAt")
+    .select(
+      "_id title slug tagline published courseType level modules skillPack skillPacks updatedAt",
+    )
     .sort({ updatedAt: -1 })
     .limit(60)
     .lean();
-  const metrics = await loadCourseMetrics(courses.map((c) => c._id as Types.ObjectId));
+  const metrics = await loadCourseMetrics(
+    courses.map((c) => c._id as Types.ObjectId),
+  );
   return {
     totalCourses: courses.length,
     courses: courses.map((course) => {
@@ -756,9 +819,13 @@ async function toolListCourses(ctx: CopilotToolContext) {
         level: course.level,
         students: m.students || 0,
         activeStudents: m.active || 0,
-        avgProgressPct: m.avgProgress != null ? Math.round(m.avgProgress) : null,
+        avgProgressPct:
+          m.avgProgress != null ? Math.round(m.avgProgress) : null,
         moduleCount: modules.length,
-        lessonCount: modules.reduce((sum, mod) => sum + (mod.lessons?.length || 0), 0),
+        lessonCount: modules.reduce(
+          (sum, mod) => sum + (mod.lessons?.length || 0),
+          0,
+        ),
         skillPackCount: packs.length,
         pendingReviews: m.pendingReviews || 0,
         updatedAt: course.updatedAt,
@@ -774,13 +841,20 @@ async function toolListCourses(ctx: CopilotToolContext) {
   };
 }
 
-async function toolGetCourse(ctx: CopilotToolContext, args: Record<string, unknown>) {
+async function toolGetCourse(
+  ctx: CopilotToolContext,
+  args: Record<string, unknown>,
+) {
   const slug = cleanString(args.courseSlug);
   if (!slug) return { error: "courseSlug is required." };
-  const course = (await Course.findOne({ slug, ...managedFilter(ctx.user) }).lean()) as
-    | (Record<string, unknown> & { _id: Types.ObjectId })
-    | null;
-  if (!course) return { error: `No managed course with slug "${slug}". Call list_courses first.` };
+  const course = (await Course.findOne({
+    slug,
+    ...managedFilter(ctx.user),
+  }).lean()) as (Record<string, unknown> & { _id: Types.ObjectId }) | null;
+  if (!course)
+    return {
+      error: `No managed course with slug "${slug}". Call list_courses first.`,
+    };
   const full = args.detail === "full";
   const textLimit = full ? 6000 : 500;
   const metrics = await loadCourseMetrics([course._id as Types.ObjectId]);
@@ -813,38 +887,40 @@ async function toolGetCourse(ctx: CopilotToolContext, args: Record<string, unkno
           duration: lesson.duration,
           isFree: lesson.isFree,
           description: truncate(lesson.description as string, textLimit),
-        })
+        }),
       ),
     })),
     skillPacks: packs.map((pack, packIndex) => ({
-      skillPackSlug: pack.slug || (packIndex === 0 && course.skillPack ? course.slug : undefined),
+      skillPackSlug:
+        pack.slug ||
+        (packIndex === 0 && course.skillPack ? course.slug : undefined),
       storage: packIndex === 0 && course.skillPack ? "primary" : "additional",
       title: pack.title,
       enabled: pack.enabled,
       subtitle: pack.subtitle,
       coverUrl: pack.coverUrl,
       learnerPromise: truncate(pack.learnerPromise as string, textLimit),
-      challenges: ((pack.challenges as Array<Record<string, unknown>>) || []).map(
-        (challenge) => ({
-          challengeId: challenge.id,
-          day: challenge.day,
-          title: challenge.title,
-          hook: truncate(challenge.hook as string, full ? 1200 : 200),
-          lesson: truncate(challenge.lesson as string, textLimit),
-          minutes: challenge.minutes,
-          points: challenge.points,
-          streakBoost: challenge.streakBoost,
-          assetUrl: challenge.assetUrl,
-          assetAlt: challenge.assetAlt,
-          accentColor: challenge.accentColor,
-          audioCue: challenge.audioCue,
-          keyIdeas: challenge.keyIdeas,
-          microTask: truncate(challenge.microTask as string, full ? 1200 : 200),
-          questionCount: Array.isArray(challenge.questions)
-            ? challenge.questions.length
-            : 0,
-        })
-      ),
+      challenges: (
+        (pack.challenges as Array<Record<string, unknown>>) || []
+      ).map((challenge) => ({
+        challengeId: challenge.id,
+        day: challenge.day,
+        title: challenge.title,
+        hook: truncate(challenge.hook as string, full ? 1200 : 200),
+        lesson: truncate(challenge.lesson as string, textLimit),
+        minutes: challenge.minutes,
+        points: challenge.points,
+        streakBoost: challenge.streakBoost,
+        assetUrl: challenge.assetUrl,
+        assetAlt: challenge.assetAlt,
+        accentColor: challenge.accentColor,
+        audioCue: challenge.audioCue,
+        keyIdeas: challenge.keyIdeas,
+        microTask: truncate(challenge.microTask as string, full ? 1200 : 200),
+        questionCount: Array.isArray(challenge.questions)
+          ? challenge.questions.length
+          : 0,
+      })),
     })),
   };
 }
@@ -944,7 +1020,12 @@ async function toolListLiveSessions(
     ]),
     LiveResponse.aggregate([
       { $match: { sessionId: { $in: sessionIds } } },
-      { $group: { _id: { sessionId: "$sessionId", activityId: "$activityId" }, count: { $sum: 1 } } },
+      {
+        $group: {
+          _id: { sessionId: "$sessionId", activityId: "$activityId" },
+          count: { $sum: 1 },
+        },
+      },
     ]),
   ]);
   const participantsBySession = new Map(
@@ -980,16 +1061,18 @@ async function toolListLiveSessions(
         participants: participantsBySession.get(String(session._id)) || 0,
         scheduledStart: session.scheduledStart,
         currentActivityId: session.currentActivityId,
-        activities: session.activities.map((activity: LiveActivity, index: number) => ({
-          index,
-          id: activity.id,
-          type: activity.type,
-          title: activity.title,
-          status: activity.status,
-          estimatedMinutes: activity.estimatedMinutes,
-          required: activity.required,
-          responses: responseCounts?.get(activity.id) || 0,
-        })),
+        activities: session.activities.map(
+          (activity: LiveActivity, index: number) => ({
+            index,
+            id: activity.id,
+            type: activity.type,
+            title: activity.title,
+            status: activity.status,
+            estimatedMinutes: activity.estimatedMinutes,
+            required: activity.required,
+            responses: responseCounts?.get(activity.id) || 0,
+          }),
+        ),
         facilitatorHref: `/educator/courses/${course?.slug}/live/${String(session._id)}`,
         updatedAt: session.updatedAt,
       };
@@ -1004,8 +1087,7 @@ async function toolGetExperience(
   const experienceId = cleanString(args.experienceId);
   if (!experienceId || !Types.ObjectId.isValid(experienceId)) {
     return {
-      error:
-        "A valid experienceId from list_experiences is required.",
+      error: "A valid experienceId from list_experiences is required.",
     };
   }
   const project = await findManagedExperience(ctx.user, experienceId);
@@ -1027,7 +1109,10 @@ async function toolGetExperience(
   };
 }
 
-async function toolListStudents(ctx: CopilotToolContext, args: Record<string, unknown>) {
+async function toolListStudents(
+  ctx: CopilotToolContext,
+  args: Record<string, unknown>,
+) {
   const slug = cleanString(args.courseSlug);
   const limit = Math.min(Math.max(Number(args.limit) || 30, 1), 100);
   const courses = await Course.find({
@@ -1037,10 +1122,16 @@ async function toolListStudents(ctx: CopilotToolContext, args: Record<string, un
     .select("_id title slug")
     .lean();
   if (!courses.length) {
-    return { error: slug ? `No managed course "${slug}".` : "No managed courses." };
+    return {
+      error: slug ? `No managed course "${slug}".` : "No managed courses.",
+    };
   }
-  const rows = await Enrollment.find({ courseId: { $in: courses.map((c) => c._id) } })
-    .select("courseId userId status progress points streak completedChallenges lastChallengeCompletedAt enrolledAt updatedAt")
+  const rows = await Enrollment.find({
+    courseId: { $in: courses.map((c) => c._id) },
+  })
+    .select(
+      "courseId userId status progress points streak completedChallenges lastChallengeCompletedAt enrolledAt updatedAt",
+    )
     .populate({ path: "userId", select: "name email" })
     .sort({ updatedAt: -1 })
     .limit(600)
@@ -1055,7 +1146,9 @@ async function toolListStudents(ctx: CopilotToolContext, args: Record<string, un
   }
   const perCourse = courses.map((course) => {
     const students = byCourse.get(String(course._id)) || [];
-    const total = rows.filter((r) => String(r.courseId) === String(course._id)).length;
+    const total = rows.filter(
+      (r) => String(r.courseId) === String(course._id),
+    ).length;
     return {
       course: course.title,
       courseSlug: course.slug,
@@ -1069,7 +1162,10 @@ async function toolListStudents(ctx: CopilotToolContext, args: Record<string, un
   };
 }
 
-async function toolGetStudent(ctx: CopilotToolContext, args: Record<string, unknown>) {
+async function toolGetStudent(
+  ctx: CopilotToolContext,
+  args: Record<string, unknown>,
+) {
   const query = cleanString(args.student)?.toLowerCase();
   if (!query) return { error: "student (email or name) is required." };
   const slug = cleanString(args.courseSlug);
@@ -1079,8 +1175,12 @@ async function toolGetStudent(ctx: CopilotToolContext, args: Record<string, unkn
   })
     .select("_id title slug")
     .lean();
-  const rows = await Enrollment.find({ courseId: { $in: courses.map((c) => c._id) } })
-    .select("courseId userId status progress points streak completedChallenges lastChallengeCompletedAt enrolledAt")
+  const rows = await Enrollment.find({
+    courseId: { $in: courses.map((c) => c._id) },
+  })
+    .select(
+      "courseId userId status progress points streak completedChallenges lastChallengeCompletedAt enrolledAt",
+    )
     .populate({ path: "userId", select: "name email" })
     .lean();
   const matches = rows.filter((row) => {
@@ -1090,9 +1190,17 @@ async function toolGetStudent(ctx: CopilotToolContext, args: Record<string, unkn
       u?.name?.toLowerCase().includes(query)
     );
   });
-  if (!matches.length) return { found: false, message: `No enrolled student matching "${args.student}".` };
+  if (!matches.length)
+    return {
+      found: false,
+      message: `No enrolled student matching "${args.student}".`,
+    };
 
-  const userIds = [...new Set(matches.map((m) => String((m.userId as { _id?: unknown })?._id)))];
+  const userIds = [
+    ...new Set(
+      matches.map((m) => String((m.userId as { _id?: unknown })?._id)),
+    ),
+  ];
   const submissions = await Submission.find({
     courseId: { $in: courses.map((c) => c._id) },
     userId: { $in: userIds },
@@ -1103,7 +1211,8 @@ async function toolGetStudent(ctx: CopilotToolContext, args: Record<string, unkn
     .lean();
 
   const courseTitle = (id: unknown) =>
-    courses.find((c) => String(c._id) === String(id))?.title || "Unknown course";
+    courses.find((c) => String(c._id) === String(id))?.title ||
+    "Unknown course";
 
   return {
     found: true,
@@ -1120,7 +1229,10 @@ async function toolGetStudent(ctx: CopilotToolContext, args: Record<string, unkn
   };
 }
 
-async function toolCourseAnalytics(ctx: CopilotToolContext, args: Record<string, unknown>) {
+async function toolCourseAnalytics(
+  ctx: CopilotToolContext,
+  args: Record<string, unknown>,
+) {
   const slug = cleanString(args.courseSlug);
   const courses = await Course.find({
     ...(slug ? { slug } : {}),
@@ -1129,7 +1241,9 @@ async function toolCourseAnalytics(ctx: CopilotToolContext, args: Record<string,
     .select("_id title slug published")
     .lean();
   if (!courses.length) {
-    return { error: slug ? `No managed course "${slug}".` : "No managed courses." };
+    return {
+      error: slug ? `No managed course "${slug}".` : "No managed courses.",
+    };
   }
   const courseIds = courses.map((c) => c._id);
   const now = Date.now();
@@ -1152,7 +1266,9 @@ async function toolCourseAnalytics(ctx: CopilotToolContext, args: Record<string,
     scope: slug ? courses[0].title : `All ${courses.length} managed courses`,
     newEnrollmentsLast7Days: recent7,
     newEnrollmentsLast30Days: recent30,
-    enrollmentStatusMix: Object.fromEntries(statusMix.map((row) => [row._id || "unknown", row.count])),
+    enrollmentStatusMix: Object.fromEntries(
+      statusMix.map((row) => [row._id || "unknown", row.count]),
+    ),
     perCourse: courses.map((course) => ({
       course: course.title,
       courseSlug: course.slug,
@@ -1164,7 +1280,7 @@ async function toolCourseAnalytics(ctx: CopilotToolContext, args: Record<string,
 
 async function toolListAssignments(
   ctx: CopilotToolContext,
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
 ) {
   const slug = cleanString(args.courseSlug);
   const courses = await Course.find({
@@ -1174,10 +1290,15 @@ async function toolListAssignments(
     .select("_id title slug")
     .lean();
   if (!courses.length) {
-    return { error: slug ? `No managed course "${slug}".` : "No managed courses." };
+    return {
+      error: slug ? `No managed course "${slug}".` : "No managed courses.",
+    };
   }
   const courseById = new Map(
-    courses.map((course) => [String(course._id), { title: course.title, slug: course.slug }])
+    courses.map((course) => [
+      String(course._id),
+      { title: course.title, slug: course.slug },
+    ]),
   );
   const assignments = await Assignment.find({
     courseId: { $in: courses.map((course) => course._id) },
@@ -1198,7 +1319,7 @@ async function toolListAssignments(
     },
   ]);
   const counts = new Map(
-    submissionCounts.map((item) => [String(item._id), item])
+    submissionCounts.map((item) => [String(item._id), item]),
   );
   return {
     total: assignments.length,
@@ -1220,7 +1341,10 @@ async function toolListAssignments(
   };
 }
 
-function toolReadAttachment(ctx: CopilotToolContext, args: Record<string, unknown>) {
+function toolReadAttachment(
+  ctx: CopilotToolContext,
+  args: Record<string, unknown>,
+) {
   if (!ctx.materials.length) {
     return { error: "No files have been uploaded in this session." };
   }
@@ -1248,7 +1372,7 @@ function toolReadAttachment(ctx: CopilotToolContext, args: Record<string, unknow
 async function toolContentWrite(
   ctx: CopilotToolContext,
   name: string,
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
 ) {
   const requestedCourseSlug = cleanString(args.courseSlug);
   if (!requestedCourseSlug) {
@@ -1271,7 +1395,10 @@ async function toolContentWrite(
   }
 
   if (ctx.actionMode === "auto") {
-    const applied = await applyEducatorCopilotAction({ user: ctx.user, action });
+    const applied = await applyEducatorCopilotAction({
+      user: ctx.user,
+      action,
+    });
     ctx.recordAction(applied);
     return {
       status: applied.status,
@@ -1294,7 +1421,7 @@ async function toolContentWrite(
 async function persistContentAttachments(
   ctx: CopilotToolContext,
   name: string,
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
 ) {
   if (
     name !== "update_lesson" &&
@@ -1314,15 +1441,18 @@ async function persistContentAttachments(
     if (!candidate) return undefined;
     return ctx.materials.find(
       (material) =>
-        material.type.startsWith("image/") && material.name.toLowerCase() === candidate
+        material.type.startsWith("image/") &&
+        material.name.toLowerCase() === candidate,
     )?.name;
   };
   const collect = (value: unknown): void => {
     const input = asRecord(value);
     const coverName =
-      cleanString(input.coverAttachmentName) || uploadedImageName(input.coverUrl);
+      cleanString(input.coverAttachmentName) ||
+      uploadedImageName(input.coverUrl);
     const assetName =
-      cleanString(input.assetAttachmentName) || uploadedImageName(input.assetUrl);
+      cleanString(input.assetAttachmentName) ||
+      uploadedImageName(input.assetUrl);
     if (coverName) attachmentNames.add(coverName);
     if (assetName) attachmentNames.add(assetName);
     for (const key of ["challenges", "lessons"] as const) {
@@ -1340,21 +1470,26 @@ async function persistContentAttachments(
   if (!attachmentNames.size) return prepared;
   const persisted = new Map(
     await Promise.all(
-      [...attachmentNames].map(async (attachmentName) => [
-        attachmentName,
-        await persistUploadedCopilotImage(ctx, attachmentName),
-      ] as const)
-    )
+      [...attachmentNames].map(
+        async (attachmentName) =>
+          [
+            attachmentName,
+            await persistUploadedCopilotImage(ctx, attachmentName),
+          ] as const,
+      ),
+    ),
   );
 
   const replace = (value: unknown): Record<string, unknown> => {
     const input = { ...asRecord(value) };
     const coverName =
-      cleanString(input.coverAttachmentName) || uploadedImageName(input.coverUrl);
+      cleanString(input.coverAttachmentName) ||
+      uploadedImageName(input.coverUrl);
     if (coverName) input.coverUrl = persisted.get(coverName);
     delete input.coverAttachmentName;
     const assetName =
-      cleanString(input.assetAttachmentName) || uploadedImageName(input.assetUrl);
+      cleanString(input.assetAttachmentName) ||
+      uploadedImageName(input.assetUrl);
     if (assetName) input.assetUrl = persisted.get(assetName);
     delete input.assetAttachmentName;
     for (const key of ["challenges", "lessons"] as const) {
@@ -1365,7 +1500,8 @@ async function persistContentAttachments(
     return input;
   };
 
-  if (name === "create_skill_path") prepared.skillPath = replace(args.skillPath);
+  if (name === "create_skill_path")
+    prepared.skillPath = replace(args.skillPath);
   else if (name === "add_lesson") prepared.lesson = replace(args.lesson);
   else if (name === "add_module") prepared.module = replace(args.module);
   else prepared.patch = replace(args.patch);
@@ -1374,18 +1510,21 @@ async function persistContentAttachments(
 
 async function persistUploadedCopilotImage(
   ctx: CopilotToolContext,
-  attachmentName: string
+  attachmentName: string,
 ) {
   const query = attachmentName.toLowerCase();
-  const exact = ctx.materials.find((material) => material.name.toLowerCase() === query);
+  const exact = ctx.materials.find(
+    (material) => material.name.toLowerCase() === query,
+  );
   const partial = ctx.materials.filter((material) =>
-    material.name.toLowerCase().includes(query)
+    material.name.toLowerCase().includes(query),
   );
   const material = exact || (partial.length === 1 ? partial[0] : undefined);
   if (!material) {
-    const detail = partial.length > 1 ? "matches more than one upload" : "was not uploaded";
+    const detail =
+      partial.length > 1 ? "matches more than one upload" : "was not uploaded";
     throw new Error(
-      `Image attachment “${attachmentName}” ${detail}. Use an exact filename from read_attachment.`
+      `Image attachment “${attachmentName}” ${detail}. Use an exact filename from read_attachment.`,
     );
   }
   if (!material.type.startsWith("image/")) {
@@ -1393,7 +1532,7 @@ async function persistUploadedCopilotImage(
   }
   if (!material.fileId || !ctx.client || !ctx.agentId) {
     throw new Error(
-      `Attachment “${material.name}” is not available from durable file storage. Upload it again and retry.`
+      `Attachment “${material.name}” is not available from durable file storage. Upload it again and retry.`,
     );
   }
 
@@ -1406,20 +1545,30 @@ async function persistUploadedCopilotImage(
   });
   const sourceUrl = resolveEducatorCopilotImageUrl(content.data);
   if (!sourceUrl) {
-    throw new Error(`Attachment “${material.name}” has no downloadable image source.`);
+    throw new Error(
+      `Attachment “${material.name}” has no downloadable image source.`,
+    );
   }
   const source = await fetch(sourceUrl);
   if (!source.ok) {
-    throw new Error(`Could not download attachment “${material.name}” (${source.status}).`);
+    throw new Error(
+      `Could not download attachment “${material.name}” (${source.status}).`,
+    );
   }
   const responseType = source.headers.get("content-type") || "";
-  const mimeType = responseType.startsWith("image/") ? responseType : material.type;
+  const mimeType = responseType.startsWith("image/")
+    ? responseType
+    : material.type;
   if (!mimeType.startsWith("image/")) {
-    throw new Error(`Attachment “${material.name}” did not resolve to an image.`);
+    throw new Error(
+      `Attachment “${material.name}” did not resolve to an image.`,
+    );
   }
   const data = Buffer.from(await source.arrayBuffer());
   if (!data.length || data.length > 20 * 1024 * 1024) {
-    throw new Error(`Attachment “${material.name}” has an unsupported image size.`);
+    throw new Error(
+      `Attachment “${material.name}” has an unsupported image size.`,
+    );
   }
   return uploadCourseMediaToS3({
     file: { name: material.name, type: mimeType },
@@ -1447,8 +1596,7 @@ async function toolExperienceWrite(
   const project = await findManagedExperience(ctx.user, experienceId);
   if (!project) {
     return {
-      error:
-        "Experience not found or it does not belong to a managed course.",
+      error: "Experience not found or it does not belong to a managed course.",
     };
   }
   if (project.draftVersion !== baseVersion) {
@@ -1511,8 +1659,7 @@ async function toolExperienceWrite(
     actionLabel: action.label,
     impact: action.preview,
     studioHref: `/educator/experience-studio/${experienceId}`,
-    note:
-      "Manual mode: the complete validated world edit is queued for educator approval. Do not claim it is already applied.",
+    note: "Manual mode: the complete validated world edit is queued for educator approval. Do not claim it is already applied.",
   };
 }
 
@@ -1534,7 +1681,7 @@ type ContentWriteAction = Extract<
 
 function buildContentAction(
   name: string,
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
 ): ContentWriteAction | null {
   const courseSlug = cleanString(args.courseSlug);
   if (!courseSlug) return null;
@@ -1571,7 +1718,9 @@ function buildContentAction(
         .map(
           (activity, index) =>
             `${index + 1}. ${activity.title} · ${activity.type}${
-              activity.estimatedMinutes ? ` · ${activity.estimatedMinutes} min` : ""
+              activity.estimatedMinutes
+                ? ` · ${activity.estimatedMinutes} min`
+                : ""
             }`,
         )
         .join("\n"),
@@ -1582,7 +1731,12 @@ function buildContentAction(
     const patch = sanitizeLessonPatch(args.patch);
     const moduleIndex = toIndex(args.moduleIndex);
     const lessonIndex = toIndex(args.lessonIndex);
-    if (moduleIndex === null || lessonIndex === null || !Object.keys(patch).length) return null;
+    if (
+      moduleIndex === null ||
+      lessonIndex === null ||
+      !Object.keys(patch).length
+    )
+      return null;
     return {
       ...base,
       type: "update_course_lesson",
@@ -1617,9 +1771,13 @@ function buildContentAction(
         : null;
     const title = cleanString(moduleInput?.title);
     if (!moduleInput || !title) return null;
-    const lessons = (Array.isArray(moduleInput.lessons) ? moduleInput.lessons : [])
+    const lessons = (
+      Array.isArray(moduleInput.lessons) ? moduleInput.lessons : []
+    )
       .map(sanitizeLessonDraft)
-      .filter((lesson): lesson is EducatorCopilotLessonDraft => Boolean(lesson));
+      .filter((lesson): lesson is EducatorCopilotLessonDraft =>
+        Boolean(lesson),
+      );
     return {
       ...base,
       type: "add_module",
@@ -1632,7 +1790,9 @@ function buildContentAction(
         lessons,
       },
       position: toIndex(args.position) ?? undefined,
-      preview: lessons.map((lesson, i) => `${i + 1}. ${lesson.title}`).join("\n"),
+      preview: lessons
+        .map((lesson, i) => `${i + 1}. ${lesson.title}`)
+        .join("\n"),
     };
   }
 
@@ -1641,7 +1801,8 @@ function buildContentAction(
       args.patch && typeof args.patch === "object"
         ? (args.patch as Record<string, unknown>)
         : {};
-    const patch: { title?: string; description?: string; assignment?: string } = {};
+    const patch: { title?: string; description?: string; assignment?: string } =
+      {};
     for (const key of ["title", "description", "assignment"] as const) {
       const value = cleanString(input[key]);
       if (value !== undefined) patch[key] = value;
@@ -1664,13 +1825,25 @@ function buildContentAction(
       args.patch && typeof args.patch === "object"
         ? (args.patch as Record<string, unknown>)
         : {};
-    const patch: Extract<EducatorCopilotAction, { type: "update_course_overview" }>["patch"] = {};
-    for (const key of ["tagline", "description", "longDescription", "duration"] as const) {
+    const patch: Extract<
+      EducatorCopilotAction,
+      { type: "update_course_overview" }
+    >["patch"] = {};
+    for (const key of [
+      "tagline",
+      "description",
+      "longDescription",
+      "duration",
+    ] as const) {
       const value = cleanString(input[key]);
       if (value !== undefined) patch[key] = value;
     }
     const level = cleanString(input.level);
-    if (level === "beginner" || level === "intermediate" || level === "advanced") {
+    if (
+      level === "beginner" ||
+      level === "intermediate" ||
+      level === "advanced"
+    ) {
       patch.level = level;
     }
     if (Array.isArray(input.tags)) {
@@ -1691,7 +1864,9 @@ function buildContentAction(
   }
 
   if (name === "create_skill_path") {
-    const skillPath = sanitizeSkillPathDraft(args.skillPath, { requireChallenges: true });
+    const skillPath = sanitizeSkillPathDraft(args.skillPath, {
+      requireChallenges: true,
+    });
     if (!skillPath) return null;
     return {
       ...base,
@@ -1702,8 +1877,9 @@ function buildContentAction(
       preview: [
         skillPath.enabled ? "Published to learners" : "Saved as unpublished",
         skillPath.coverUrl ? "Banner image included" : "No banner image",
-        ...skillPath.challenges.map((challenge, index) =>
-          `${index + 1}. ${challenge.title}${challenge.assetUrl ? " · image included" : ""}`
+        ...skillPath.challenges.map(
+          (challenge, index) =>
+            `${index + 1}. ${challenge.title}${challenge.assetUrl ? " · image included" : ""}`,
         ),
       ]
         .join("\n")
@@ -1748,7 +1924,10 @@ function buildContentAction(
 function toolNavigate(ctx: CopilotToolContext, args: Record<string, unknown>) {
   const href = cleanString(args.href);
   if (!href || !isAllowedHref(href)) {
-    return { error: "href must be an in-app path (e.g. /educator/courses/<slug>/content)." };
+    return {
+      error:
+        "href must be an in-app path (e.g. /educator/courses/<slug>/content).",
+    };
   }
   const action: EducatorCopilotAction = {
     id: randomUUID(),
@@ -1774,21 +1953,26 @@ function toolHighlight(ctx: CopilotToolContext, args: Record<string, unknown>) {
   const target = cleanString(args.target)?.toLowerCase();
   if (!selector && target) {
     const match = ctx.pageContext?.uiMap?.find((item) =>
-      item.label.toLowerCase().includes(target)
+      item.label.toLowerCase().includes(target),
     );
     selector = match?.selector;
     if (!selector) {
       return {
         error: `No element labeled like "${args.target}" on the current page.`,
-        visibleTargets: (ctx.pageContext?.uiMap || []).slice(0, 40).map((item) => item.label),
+        visibleTargets: (ctx.pageContext?.uiMap || [])
+          .slice(0, 40)
+          .map((item) => item.label),
       };
     }
   }
-  if (!selector) return { error: "Provide target (visible label) or selector." };
+  if (!selector)
+    return { error: "Provide target (visible label) or selector." };
   const action: EducatorCopilotAction = {
     id: randomUUID(),
     type: "highlight",
-    label: cleanString(args.target) ? `Highlight "${args.target}"` : "Highlight on page",
+    label: cleanString(args.target)
+      ? `Highlight "${args.target}"`
+      : "Highlight on page",
     selector,
     reason: cleanString(args.reason),
     status: "proposed",
@@ -1798,10 +1982,14 @@ function toolHighlight(ctx: CopilotToolContext, args: Record<string, unknown>) {
   return { status: ctx.actionMode === "auto" ? "highlighting" : "proposed" };
 }
 
-async function toolRemember(ctx: CopilotToolContext, args: Record<string, unknown>) {
+async function toolRemember(
+  ctx: CopilotToolContext,
+  args: Record<string, unknown>,
+) {
   const content = cleanString(args.content);
   if (!content) return { error: "content is required." };
-  if (!ctx.client || !ctx.agentId) return { error: "Memory is unavailable right now." };
+  if (!ctx.client || !ctx.agentId)
+    return { error: "Memory is unavailable right now." };
   const kind = cleanString(args.kind);
   const memoryType =
     kind === "episodic" || kind === "procedural" ? kind : "semantic";
@@ -1817,8 +2005,12 @@ async function toolRemember(ctx: CopilotToolContext, args: Record<string, unknow
   return { saved: true, content };
 }
 
-async function toolRecallMemories(ctx: CopilotToolContext, args: Record<string, unknown>) {
-  if (!ctx.client || !ctx.agentId) return { error: "Memory is unavailable right now." };
+async function toolRecallMemories(
+  ctx: CopilotToolContext,
+  args: Record<string, unknown>,
+) {
+  if (!ctx.client || !ctx.agentId)
+    return { error: "Memory is unavailable right now." };
   const query = cleanString(args.query) || "educator preferences";
   const result = await ctx.client.memory.retrieve(ctx.agentId, query, 8);
   return {
@@ -1840,7 +2032,11 @@ export async function applyEducatorCopilotAction({
   action: EducatorCopilotAction;
 }): Promise<EducatorCopilotAction> {
   if (action.type === "navigate" || action.type === "highlight") {
-    return { ...action, status: "applied", result: "Client-side action ready." };
+    return {
+      ...action,
+      status: "applied",
+      result: "Client-side action ready.",
+    };
   }
   if (action.safety === "sensitive_blocked") {
     return {
@@ -1903,7 +2099,8 @@ export async function applyEducatorCopilotAction({
   try {
     if (action.type === "create_live_session") {
       let joinCode = createJoinCode();
-      while (await LiveSession.exists({ joinCode })) joinCode = createJoinCode();
+      while (await LiveSession.exists({ joinCode }))
+        joinCode = createJoinCode();
       const liveSession = await LiveSession.create({
         ...action.session,
         courseId: course._id,
@@ -1913,6 +2110,13 @@ export async function applyEducatorCopilotAction({
           allowLateJoin: true,
           showParticipantNames: false,
           showLeaderboard: false,
+          learnerCopilot: {
+            enabled: true,
+            explainCurrentActivity: true,
+            coachResponses: true,
+            useCourseMaterials: true,
+            giveDirectExplanations: false,
+          },
         },
         createdBy: user.id,
       });
@@ -1925,8 +2129,10 @@ export async function applyEducatorCopilotAction({
     switch (action.type) {
       case "update_course_lesson": {
         const modules = Array.isArray(course.modules) ? course.modules : [];
-        const lesson = modules[action.moduleIndex]?.lessons?.[action.lessonIndex];
-        if (!lesson) return { ...action, status: "failed", result: "Lesson not found." };
+        const lesson =
+          modules[action.moduleIndex]?.lessons?.[action.lessonIndex];
+        if (!lesson)
+          return { ...action, status: "failed", result: "Lesson not found." };
         Object.assign(lesson, action.patch);
         course.modules = modules;
         recountCourse(course);
@@ -1935,7 +2141,8 @@ export async function applyEducatorCopilotAction({
       case "add_lesson": {
         const modules = Array.isArray(course.modules) ? course.modules : [];
         const courseModule = modules[action.moduleIndex];
-        if (!courseModule) return { ...action, status: "failed", result: "Module not found." };
+        if (!courseModule)
+          return { ...action, status: "failed", result: "Module not found." };
         courseModule.lessons = courseModule.lessons || [];
         courseModule.lessons.push(normalizeLessonForSave(action.lesson));
         course.modules = modules;
@@ -1951,7 +2158,9 @@ export async function applyEducatorCopilotAction({
           lessons: action.module.lessons.map(normalizeLessonForSave),
         };
         const position =
-          action.position != null && action.position >= 0 && action.position <= modules.length
+          action.position != null &&
+          action.position >= 0 &&
+          action.position <= modules.length
             ? action.position
             : modules.length;
         modules.splice(position, 0, newModule as never);
@@ -1962,7 +2171,8 @@ export async function applyEducatorCopilotAction({
       case "update_module": {
         const modules = Array.isArray(course.modules) ? course.modules : [];
         const courseModule = modules[action.moduleIndex];
-        if (!courseModule) return { ...action, status: "failed", result: "Module not found." };
+        if (!courseModule)
+          return { ...action, status: "failed", result: "Module not found." };
         Object.assign(courseModule, action.patch);
         course.modules = modules;
         break;
@@ -1980,7 +2190,8 @@ export async function applyEducatorCopilotAction({
           existingPacks.some(
             (pack) =>
               pack.slug === action.skillPath.slug ||
-              pack.title?.toLowerCase() === action.skillPath.title.toLowerCase()
+              pack.title?.toLowerCase() ===
+                action.skillPath.title.toLowerCase(),
           )
         ) {
           return {
@@ -2017,15 +2228,24 @@ export async function applyEducatorCopilotAction({
             (!primary.slug && action.skillPackSlug === course.slug))
             ? primary
             : undefined) ||
-          additional.find((candidate) => candidate.slug === action.skillPackSlug);
+          additional.find(
+            (candidate) => candidate.slug === action.skillPackSlug,
+          );
         if (!pack) {
-          return { ...action, status: "failed", result: "Skill path not found." };
+          return {
+            ...action,
+            status: "failed",
+            result: "Skill path not found.",
+          };
         }
         if (
           action.patch.slug &&
           action.patch.slug !== pack.slug &&
           ([primary, ...additional].some(
-            (candidate) => candidate && candidate !== pack && candidate.slug === action.patch.slug
+            (candidate) =>
+              candidate &&
+              candidate !== pack &&
+              candidate.slug === action.patch.slug,
           ) ||
             (await skillPathSlugExists(action.patch.slug, course._id)))
         ) {
@@ -2051,10 +2271,18 @@ export async function applyEducatorCopilotAction({
         }>;
         const pack =
           packs.find((p) => p.slug === action.skillPackSlug) ||
-          packs.find((p) => p.challenges?.some((c) => c.id === action.challengeId));
-        const challenge = pack?.challenges?.find((c) => c.id === action.challengeId);
+          packs.find((p) =>
+            p.challenges?.some((c) => c.id === action.challengeId),
+          );
+        const challenge = pack?.challenges?.find(
+          (c) => c.id === action.challengeId,
+        );
         if (!pack || !challenge) {
-          return { ...action, status: "failed", result: "Challenge not found." };
+          return {
+            ...action,
+            status: "failed",
+            result: "Challenge not found.",
+          };
         }
         Object.assign(challenge, action.patch);
         course.markModified("skillPack");
@@ -2077,7 +2305,10 @@ export async function applyEducatorCopilotAction({
     return {
       ...action,
       status: "failed",
-      result: error instanceof Error ? error.message : "The change could not be saved.",
+      result:
+        error instanceof Error
+          ? error.message
+          : "The change could not be saved.",
     };
   }
 }
@@ -2125,7 +2356,7 @@ async function skillPathSlugExists(slug: string, currentCourseId: unknown) {
     await Course.exists({
       _id: { $ne: currentCourseId },
       $or: [{ slug }, { "skillPack.slug": slug }, { "skillPacks.slug": slug }],
-    })
+    }),
   );
 }
 
@@ -2146,7 +2377,10 @@ function recountCourse(course: {
 }) {
   const modules = course.modules || [];
   course.modulesCount = modules.length;
-  course.lessonsCount = modules.reduce((sum, mod) => sum + (mod.lessons?.length || 0), 0);
+  course.lessonsCount = modules.reduce(
+    (sum, mod) => sum + (mod.lessons?.length || 0),
+    0,
+  );
 }
 
 function normalizeLessonForSave(lesson: EducatorCopilotLessonDraft) {
@@ -2182,14 +2416,26 @@ function summarizeEnrollment(row: Record<string, unknown>) {
 function isAllowedHref(href: string) {
   if (!href.startsWith("/")) return false;
   return ["/educator", "/courses", "/skills", "/dashboard"].some(
-    (prefix) => href === prefix || href.startsWith(`${prefix}/`) || href.startsWith(`${prefix}?`)
+    (prefix) =>
+      href === prefix ||
+      href.startsWith(`${prefix}/`) ||
+      href.startsWith(`${prefix}?`),
   );
 }
 
 function sanitizeLessonPatch(value: unknown) {
-  const input = value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+  const input =
+    value && typeof value === "object"
+      ? (value as Record<string, unknown>)
+      : {};
   const patch: Partial<EducatorCopilotLessonDraft> = {};
-  for (const key of ["title", "duration", "description", "assetUrl", "assetAlt"] as const) {
+  for (const key of [
+    "title",
+    "duration",
+    "description",
+    "assetUrl",
+    "assetAlt",
+  ] as const) {
     const next = cleanString(input[key]);
     if (next !== undefined) patch[key] = next;
   }
@@ -2197,7 +2443,9 @@ function sanitizeLessonPatch(value: unknown) {
   return patch;
 }
 
-function sanitizeLessonDraft(value: unknown): EducatorCopilotLessonDraft | null {
+function sanitizeLessonDraft(
+  value: unknown,
+): EducatorCopilotLessonDraft | null {
   const patch = sanitizeLessonPatch(value);
   if (!patch.title) return null;
   return { ...patch, title: patch.title };
@@ -2221,7 +2469,8 @@ function sanitizeSkillChallengePatch(value: unknown) {
   }
   for (const key of ["minutes", "points", "streakBoost"] as const) {
     const next = nonNegativeInteger(input[key]);
-    if (next !== undefined && (key !== "minutes" || next > 0)) patch[key] = next;
+    if (next !== undefined && (key !== "minutes" || next > 0))
+      patch[key] = next;
   }
   const audioCue = cleanString(input.audioCue);
   if (audioCue === "spark" || audioCue === "focus" || audioCue === "complete") {
@@ -2241,7 +2490,10 @@ function sanitizeSkillChallengePatch(value: unknown) {
   return patch;
 }
 
-function sanitizeSkillQuestion(value: unknown, index = 0): SkillQuestion | null {
+function sanitizeSkillQuestion(
+  value: unknown,
+  index = 0,
+): SkillQuestion | null {
   const input = asRecord(value);
   const prompt = cleanString(input.prompt);
   const options = Array.isArray(input.options)
@@ -2251,7 +2503,12 @@ function sanitizeSkillQuestion(value: unknown, index = 0): SkillQuestion | null 
         .slice(0, 8)
     : [];
   const answerIndex = toIndex(input.answerIndex);
-  if (!prompt || options.length < 2 || answerIndex === null || answerIndex >= options.length) {
+  if (
+    !prompt ||
+    options.length < 2 ||
+    answerIndex === null ||
+    answerIndex >= options.length
+  ) {
     return null;
   }
   return {
@@ -2263,7 +2520,10 @@ function sanitizeSkillQuestion(value: unknown, index = 0): SkillQuestion | null 
   };
 }
 
-function sanitizeSkillChallengeDraft(value: unknown, index: number): SkillChallenge | null {
+function sanitizeSkillChallengeDraft(
+  value: unknown,
+  index: number,
+): SkillChallenge | null {
   const input = asRecord(value);
   const title = cleanString(input.title);
   const lesson = cleanString(input.lesson);
@@ -2291,7 +2551,7 @@ function sanitizeSkillChallengeDraft(value: unknown, index: number): SkillChalle
 
 function sanitizeSkillPathDraft(
   value: unknown,
-  options: { requireChallenges: boolean }
+  options: { requireChallenges: boolean },
 ): SkillPack | null {
   const input = asRecord(value);
   const title = cleanString(input.title);
@@ -2327,7 +2587,12 @@ function sanitizeSkillPathPatch(value: unknown) {
     EducatorCopilotAction,
     { type: "update_skill_path" }
   >["patch"] = {};
-  for (const key of ["title", "subtitle", "coverUrl", "learnerPromise"] as const) {
+  for (const key of [
+    "title",
+    "subtitle",
+    "coverUrl",
+    "learnerPromise",
+  ] as const) {
     const next = cleanString(input[key]);
     if (next !== undefined) patch[key] = next;
   }
@@ -2343,7 +2608,7 @@ function sanitizeSkillPathPatch(value: unknown) {
 }
 
 function previewSkillPathPatch(
-  patch: Extract<EducatorCopilotAction, { type: "update_skill_path" }>["patch"]
+  patch: Extract<EducatorCopilotAction, { type: "update_skill_path" }>["patch"],
 ) {
   const metadata = Object.entries(patch)
     .filter(([key]) => key !== "challenges")
@@ -2351,7 +2616,9 @@ function previewSkillPathPatch(
   if (patch.challenges) {
     metadata.push(
       `Challenges (${patch.challenges.length}):`,
-      ...patch.challenges.map((challenge, index) => `${index + 1}. ${challenge.title}`)
+      ...patch.challenges.map(
+        (challenge, index) => `${index + 1}. ${challenge.title}`,
+      ),
     );
   }
   return metadata.join("\n").slice(0, 1200);
@@ -2360,7 +2627,9 @@ function previewSkillPathPatch(
 function previewFromPatch(patch: Record<string, unknown>) {
   return Object.entries(patch)
     .map(([key, value]) => {
-      const text = Array.isArray(value) ? value.join(", ") : String(value ?? "");
+      const text = Array.isArray(value)
+        ? value.join(", ")
+        : String(value ?? "");
       return `${key}: ${text.length > 220 ? `${text.slice(0, 220)}…` : text}`;
     })
     .join("\n")
@@ -2391,7 +2660,9 @@ function cleanString(value: unknown) {
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
 }
 
 function safeSlug(value: string) {
@@ -2404,7 +2675,8 @@ function safeSlug(value: string) {
 
 function nonNegativeInteger(value: unknown) {
   const num = typeof value === "string" ? Number(value) : value;
-  if (typeof num !== "number" || !Number.isFinite(num) || num < 0) return undefined;
+  if (typeof num !== "number" || !Number.isFinite(num) || num < 0)
+    return undefined;
   return Math.floor(num);
 }
 

--- a/apps/commons-courses/lib/live-copilot-policy.test.mts
+++ b/apps/commons-courses/lib/live-copilot-policy.test.mts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  defaultLiveLearnerCopilotPolicy,
+  normalizeLiveLearnerCopilotPolicy,
+} from "./live-copilot-policy.ts";
+
+test("uses a safe backward-compatible live copilot policy", () => {
+  assert.deepEqual(
+    normalizeLiveLearnerCopilotPolicy(),
+    defaultLiveLearnerCopilotPolicy,
+  );
+});
+
+test("normalizes every educator-controlled live copilot permission", () => {
+  assert.deepEqual(
+    normalizeLiveLearnerCopilotPolicy({
+      enabled: false,
+      explainCurrentActivity: false,
+      coachResponses: false,
+      useCourseMaterials: false,
+      giveDirectExplanations: true,
+    }),
+    {
+      enabled: false,
+      explainCurrentActivity: false,
+      coachResponses: false,
+      useCourseMaterials: false,
+      giveDirectExplanations: true,
+    },
+  );
+});

--- a/apps/commons-courses/lib/live-copilot-policy.ts
+++ b/apps/commons-courses/lib/live-copilot-policy.ts
@@ -1,0 +1,21 @@
+import type { LiveLearnerCopilotPolicy } from "@/types/live-session";
+
+export const defaultLiveLearnerCopilotPolicy: LiveLearnerCopilotPolicy = {
+  enabled: true,
+  explainCurrentActivity: true,
+  coachResponses: true,
+  useCourseMaterials: true,
+  giveDirectExplanations: false,
+};
+
+export function normalizeLiveLearnerCopilotPolicy(
+  input?: Partial<LiveLearnerCopilotPolicy> | null,
+): LiveLearnerCopilotPolicy {
+  return {
+    enabled: input?.enabled !== false,
+    explainCurrentActivity: input?.explainCurrentActivity !== false,
+    coachResponses: input?.coachResponses !== false,
+    useCourseMaterials: input?.useCourseMaterials !== false,
+    giveDirectExplanations: Boolean(input?.giveDirectExplanations),
+  };
+}

--- a/apps/commons-courses/lib/live-session-data.ts
+++ b/apps/commons-courses/lib/live-session-data.ts
@@ -1,5 +1,6 @@
 import type { Types } from "mongoose";
 import { normalizeCourseTheme, type CourseTheme } from "@/lib/course-theme";
+import { normalizeLiveLearnerCopilotPolicy } from "@/lib/live-copilot-policy";
 import LiveParticipant from "@/models/LiveParticipant";
 import LiveResponse from "@/models/LiveResponse";
 import type { ILiveSession } from "@/models/LiveSession";
@@ -133,7 +134,14 @@ function serializeBase(
     currentActivityId,
     stateVersion: session.stateVersion || 0,
     activities: session.activities || [],
-    settings: session.settings,
+    settings: {
+      allowLateJoin: session.settings?.allowLateJoin !== false,
+      showParticipantNames: Boolean(session.settings?.showParticipantNames),
+      showLeaderboard: Boolean(session.settings?.showLeaderboard),
+      learnerCopilot: normalizeLiveLearnerCopilotPolicy(
+        session.settings?.learnerCopilot,
+      ),
+    },
     participantCount,
     responseCounts,
     createdAt: session.createdAt.toISOString(),

--- a/apps/commons-courses/lib/live-session-input.ts
+++ b/apps/commons-courses/lib/live-session-input.ts
@@ -6,6 +6,10 @@ import type {
   LiveSessionAccess,
   LiveSessionPace,
 } from "@/types/live-session";
+import {
+  defaultLiveLearnerCopilotPolicy,
+  normalizeLiveLearnerCopilotPolicy,
+} from "@/lib/live-copilot-policy";
 
 const activityTypes: LiveActivityType[] = [
   "content",
@@ -67,11 +71,17 @@ export function normalizeActivities(input: unknown): LiveActivity[] {
 }
 
 export function normalizeSessionCreate(input: unknown) {
-  const body = input && typeof input === "object" ? (input as Record<string, unknown>) : {};
+  const body =
+    input && typeof input === "object"
+      ? (input as Record<string, unknown>)
+      : {};
   const title = clean(body.title) || "New live session";
-  const pace: LiveSessionPace = body.pace === "learner" ? "learner" : "facilitator";
+  const pace: LiveSessionPace =
+    body.pace === "learner" ? "learner" : "facilitator";
   const access: LiveSessionAccess =
-    body.access === "open" || body.access === "invited" ? body.access : "enrolled";
+    body.access === "open" || body.access === "invited"
+      ? body.access
+      : "enrolled";
   const template = body.template === "blank" ? "blank" : "facilitated_workshop";
   return {
     title,
@@ -85,28 +95,46 @@ export function normalizeSessionCreate(input: unknown) {
       allowLateJoin: true,
       showParticipantNames: false,
       showLeaderboard: false,
+      learnerCopilot: defaultLiveLearnerCopilotPolicy,
     },
   };
 }
 
 export function normalizeSessionPatch(input: unknown) {
-  const body = input && typeof input === "object" ? (input as Record<string, unknown>) : {};
+  const body =
+    input && typeof input === "object"
+      ? (input as Record<string, unknown>)
+      : {};
   const patch: Record<string, unknown> = {};
-  if ("title" in body) patch.title = clean(body.title) || "Untitled live session";
+  if ("title" in body)
+    patch.title = clean(body.title) || "Untitled live session";
   if ("description" in body) patch.description = clean(body.description);
-  if (body.pace === "facilitator" || body.pace === "learner") patch.pace = body.pace;
-  if (body.access === "enrolled" || body.access === "invited" || body.access === "open") {
+  if (body.pace === "facilitator" || body.pace === "learner")
+    patch.pace = body.pace;
+  if (
+    body.access === "enrolled" ||
+    body.access === "invited" ||
+    body.access === "open"
+  ) {
     patch.access = body.access;
   }
-  if ("invitedEmails" in body) patch.invitedEmails = normalizeEmails(body.invitedEmails);
-  if ("scheduledStart" in body) patch.scheduledStart = normalizeDate(body.scheduledStart);
-  if ("activities" in body) patch.activities = normalizeActivities(body.activities);
+  if ("invitedEmails" in body)
+    patch.invitedEmails = normalizeEmails(body.invitedEmails);
+  if ("scheduledStart" in body)
+    patch.scheduledStart = normalizeDate(body.scheduledStart);
+  if ("activities" in body)
+    patch.activities = normalizeActivities(body.activities);
   if (body.settings && typeof body.settings === "object") {
     const settings = body.settings as Record<string, unknown>;
     patch.settings = {
       allowLateJoin: settings.allowLateJoin !== false,
       showParticipantNames: Boolean(settings.showParticipantNames),
       showLeaderboard: Boolean(settings.showLeaderboard),
+      learnerCopilot: normalizeLiveLearnerCopilotPolicy(
+        settings.learnerCopilot && typeof settings.learnerCopilot === "object"
+          ? settings.learnerCopilot
+          : undefined,
+      ),
     };
   }
   return patch;
@@ -132,7 +160,9 @@ export function createFacilitatedWorkshopTemplate(): LiveActivity[] {
       title: "Opening diagnostic",
       prompt: "How confident are you with today’s topic?",
       instructions: "Choose the response that best describes you right now.",
-      options: ["1 · New to this", "2", "3", "4", "5 · Very confident"].map(option),
+      options: ["1 · New to this", "2", "3", "4", "5 · Very confident"].map(
+        option,
+      ),
       showResults: true,
       required: true,
       estimatedMinutes: 3,
@@ -149,10 +179,12 @@ export function createFacilitatedWorkshopTemplate(): LiveActivity[] {
       type: "task",
       title: "Guided practice",
       prompt: "Try the demonstrated move on the provided example.",
-      instructions: "Work individually or in pairs, then submit a short note or link to your artefact.",
+      instructions:
+        "Work individually or in pairs, then submit a short note or link to your artefact.",
       successCriteria:
         "You can show the completed artefact and explain one decision you made.",
-      facilitatorNotes: "Give a time check halfway through and invite one pair to share.",
+      facilitatorNotes:
+        "Give a time check halfway through and invite one pair to share.",
       required: true,
       estimatedMinutes: 20,
     }),
@@ -160,11 +192,20 @@ export function createFacilitatedWorkshopTemplate(): LiveActivity[] {
       type: "quiz",
       title: "Retrieval check",
       prompt: "Which option best applies the idea we just practised?",
-      instructions: "Answer on your own first. We will discuss the reasoning together.",
+      instructions:
+        "Answer on your own first. We will discuss the reasoning together.",
       options: [
         { id: randomUUID(), label: "Add the correct answer", isCorrect: true },
-        { id: randomUUID(), label: "Add a plausible distractor", isCorrect: false },
-        { id: randomUUID(), label: "Add another plausible distractor", isCorrect: false },
+        {
+          id: randomUUID(),
+          label: "Add a plausible distractor",
+          isCorrect: false,
+        },
+        {
+          id: randomUUID(),
+          label: "Add another plausible distractor",
+          isCorrect: false,
+        },
       ],
       randomizeOptions: true,
       showResults: true,
@@ -176,14 +217,16 @@ export function createFacilitatedWorkshopTemplate(): LiveActivity[] {
       type: "break",
       title: "Break",
       prompt: "Stand up, recharge, and return ready for the next block.",
-      facilitatorNotes: "Close this activity when the room is ready to continue.",
+      facilitatorNotes:
+        "Close this activity when the room is ready to continue.",
       estimatedMinutes: 15,
     }),
     createActivity({
       type: "reflection",
       title: "Exit reflection",
       prompt: "What will you apply first, and what still feels unclear?",
-      instructions: "Write one concrete next step and one question for the facilitator.",
+      instructions:
+        "Write one concrete next step and one question for the facilitator.",
       showResults: false,
       required: true,
       estimatedMinutes: 5,
@@ -224,7 +267,9 @@ function normalizeEmails(input: unknown) {
     new Set(
       values
         .map((value) => clean(value)?.toLowerCase())
-        .filter((value): value is string => Boolean(value && value.includes("@"))),
+        .filter((value): value is string =>
+          Boolean(value && value.includes("@")),
+        ),
     ),
   ).slice(0, 2_000);
 }
@@ -246,7 +291,9 @@ function cleanUrl(input: unknown) {
   if (!value) return undefined;
   try {
     const url = new URL(value);
-    return url.protocol === "https:" || url.protocol === "http:" ? value : undefined;
+    return url.protocol === "https:" || url.protocol === "http:"
+      ? value
+      : undefined;
   } catch {
     return undefined;
   }

--- a/apps/commons-courses/models/LiveSession.ts
+++ b/apps/commons-courses/models/LiveSession.ts
@@ -79,6 +79,19 @@ const LiveSessionSettingsSchema = new Schema<LiveSessionSettings>(
     allowLateJoin: { type: Boolean, default: true },
     showParticipantNames: { type: Boolean, default: false },
     showLeaderboard: { type: Boolean, default: false },
+    learnerCopilot: {
+      type: new Schema(
+        {
+          enabled: { type: Boolean, default: true },
+          explainCurrentActivity: { type: Boolean, default: true },
+          coachResponses: { type: Boolean, default: true },
+          useCourseMaterials: { type: Boolean, default: true },
+          giveDirectExplanations: { type: Boolean, default: false },
+        },
+        { _id: false },
+      ),
+      default: () => ({}),
+    },
   },
   { _id: false },
 );

--- a/apps/commons-courses/types/course-agent.ts
+++ b/apps/commons-courses/types/course-agent.ts
@@ -8,10 +8,7 @@ export type CourseAgentDataScope =
 
 export type CourseAgentAction = "suggest" | "draft" | "fill_view" | "navigate";
 
-export type CourseAgentLearningMode =
-  | "socratic"
-  | "guided"
-  | "direct_support";
+export type CourseAgentLearningMode = "socratic" | "guided" | "direct_support";
 
 export interface CourseAgentConfig {
   id: string;
@@ -27,6 +24,7 @@ export interface CourseAgentConfig {
 
 export interface CourseAgentViewContext {
   page: string;
+  liveSessionId?: string;
   title?: string;
   moduleIndex?: number;
   lessonIndex?: number;

--- a/apps/commons-courses/types/live-session.ts
+++ b/apps/commons-courses/types/live-session.ts
@@ -44,6 +44,15 @@ export type LiveSessionSettings = {
   allowLateJoin: boolean;
   showParticipantNames: boolean;
   showLeaderboard: boolean;
+  learnerCopilot: LiveLearnerCopilotPolicy;
+};
+
+export type LiveLearnerCopilotPolicy = {
+  enabled: boolean;
+  explainCurrentActivity: boolean;
+  coachResponses: boolean;
+  useCourseMaterials: boolean;
+  giveDirectExplanations: boolean;
 };
 
 export type LiveSessionRecord = {
@@ -75,6 +84,7 @@ export type LiveSessionState = {
   pace: LiveSessionPace;
   currentActivityId?: string;
   currentActivity?: LiveActivity;
+  learnerCopilot: LiveLearnerCopilotPolicy;
   stateVersion: number;
   activityStatuses: Record<string, LiveActivityStatus>;
   serverTime: string;


### PR DESCRIPTION
## What changed

- add a per-live-session learner copilot visibility policy
- let educators allow or restrict current-activity explanations, response coaching, wider course retrieval, and direct explanations
- hide the learner copilot immediately when a live policy changes
- validate the live session and enforce its policy in the course-agent API
- remove disallowed course/activity context before invoking the model
- always protect hidden quiz answers and facilitator-only notes
- show the copilot policy in educator Plan and Invite views

## Moringa

The exact Moringa live session has been set to `enabled: false` and its state version incremented so connected learners pick up the change after deployment.

## Validation

- 13 tests passing
- TypeScript check passed
- targeted ESLint passed
- Next.js production build passed
- diff whitespace check passed
