### PR TITLE
Add private learner lab workspaces

### DIFF
--- a/apps/commons-courses/app/api/courses/[slug]/materials/route.ts
+++ b/apps/commons-courses/app/api/courses/[slug]/materials/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { serializeCourseMaterial } from "@/lib/course-material-data";
+import { serializeLabWorkspace } from "@/lib/lab-workspace-data";
 import { connectDB } from "@/lib/db";
 import Course from "@/models/Course";
 import CourseMaterial from "@/models/CourseMaterial";
 import Enrollment from "@/models/Enrollment";
+import LabWorkspace from "@/models/LabWorkspace";
 
 export async function GET(
   _req: NextRequest,
@@ -19,5 +21,6 @@ export async function GET(
   const enrolled = await Enrollment.exists({ userId: currentUser.user.id, courseId: course._id, status: { $ne: "cancelled" } });
   if (!enrolled) return NextResponse.json({ error: "Enroll in this course to view its materials." }, { status: 403 });
   const materials = await CourseMaterial.find({ courseId: course._id, visibility: "course" }).sort({ createdAt: -1 });
-  return NextResponse.json({ materials: materials.map(serializeCourseMaterial) });
+  const workspaces = await LabWorkspace.find({ courseId: course._id, visibility: "course" }).sort({ createdAt: -1 });
+  return NextResponse.json({ materials: materials.map(serializeCourseMaterial), workspaces: workspaces.map((workspace) => serializeLabWorkspace(workspace)) });
 }

--- a/apps/commons-courses/app/api/educator/courses/[slug]/lab-workspaces/route.ts
+++ b/apps/commons-courses/app/api/educator/courses/[slug]/lab-workspaces/route.ts
@@ -1,0 +1,135 @@
+import { NextRequest, NextResponse } from "next/server";
+import { parseLabArchive } from "@/lib/lab-archive";
+import { serializeLabWorkspace } from "@/lib/lab-workspace-data";
+import { deleteLabFiles, uploadLabFile } from "@/lib/lab-workspace-storage";
+import { requireEducatorCourse } from "@/lib/educator-auth";
+import LabWorkspace from "@/models/LabWorkspace";
+
+const maxArchiveSize = 50 * 1024 * 1024;
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const result = await requireEducatorCourse(slug);
+  if (result.error) return result.error;
+  const workspaces = await LabWorkspace.find({
+    courseId: result.course._id,
+  }).sort({
+    createdAt: -1,
+  });
+  return NextResponse.json({
+    workspaces: workspaces.map((workspace) =>
+      serializeLabWorkspace(workspace, { educator: true }),
+    ),
+  });
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const result = await requireEducatorCourse(slug);
+  if (result.error) return result.error;
+  const form = await request.formData();
+  const archive = form.get("archive");
+  if (
+    !(archive instanceof File) ||
+    !archive.name.toLowerCase().endsWith(".zip")
+  ) {
+    return NextResponse.json(
+      { error: "Choose a ZIP lab pack." },
+      { status: 400 },
+    );
+  }
+  if (archive.size > maxArchiveSize) {
+    return NextResponse.json(
+      { error: "Lab packs must be smaller than 50 MB." },
+      { status: 400 },
+    );
+  }
+  const title = String(form.get("title") || "")
+    .trim()
+    .slice(0, 140);
+  if (!title)
+    return NextResponse.json(
+      { error: "Give this lab a title." },
+      { status: 400 },
+    );
+
+  const sourceBytes = Buffer.from(await archive.arrayBuffer());
+  let parsed: Awaited<ReturnType<typeof parseLabArchive>>;
+  try {
+    parsed = await parseLabArchive(sourceBytes);
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "The ZIP file could not be read.",
+      },
+      { status: 400 },
+    );
+  }
+  const uploadedIds: unknown[] = [];
+  try {
+    const sourcePackGridFsId = await uploadLabFile(
+      sourceBytes,
+      archive.name,
+      "application/zip",
+    );
+    uploadedIds.push(sourcePackGridFsId);
+    const learnerPackName = archive.name.replace(/\.zip$/i, "-learner.zip");
+    const learnerPackGridFsId = await uploadLabFile(
+      parsed.learnerPack,
+      learnerPackName,
+      "application/zip",
+    );
+    uploadedIds.push(learnerPackGridFsId);
+    const files = [];
+    for (const file of parsed.files) {
+      const gridFsId = await uploadLabFile(
+        file.bytes,
+        file.name,
+        file.mimeType,
+      );
+      uploadedIds.push(gridFsId);
+      files.push({ ...file, bytes: undefined, gridFsId });
+    }
+    const workspace = await LabWorkspace.create({
+      courseId: result.course._id,
+      courseSlug: result.course.slug,
+      ownerUserId: result.session.userId,
+      title,
+      description:
+        String(form.get("description") || "")
+          .trim()
+          .slice(0, 1200) || undefined,
+      instructions:
+        String(form.get("instructions") || "")
+          .trim()
+          .slice(0, 5000) || undefined,
+      visibility: form.get("visibility") === "live" ? "live" : "course",
+      sourceFileName: archive.name,
+      sourcePackGridFsId,
+      sourcePackSize: sourceBytes.length,
+      learnerPackGridFsId,
+      learnerPackSize: parsed.learnerPack.length,
+      files,
+    });
+    return NextResponse.json(
+      { workspace: serializeLabWorkspace(workspace, { educator: true }) },
+      { status: 201 },
+    );
+  } catch (error) {
+    await deleteLabFiles(uploadedIds);
+    console.error("Lab workspace upload failed", error);
+    return NextResponse.json(
+      { error: "The lab files could not be stored. Try again." },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/commons-courses/app/api/educator/lab-workspaces/[id]/route.ts
+++ b/apps/commons-courses/app/api/educator/lab-workspaces/[id]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Types } from "mongoose";
+import { authorizeLabWorkspace } from "@/lib/lab-workspace-access";
+import { serializeLabWorkspace } from "@/lib/lab-workspace-data";
+import { deleteLabFiles } from "@/lib/lab-workspace-storage";
+import type { ILabWorkspaceFile } from "@/models/LabWorkspace";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const result = await authorizeLabWorkspace(id);
+  if (result.error) return result.error;
+  if (!result.manages)
+    return NextResponse.json({ error: "Forbidden." }, { status: 403 });
+  const body = await request.json();
+  if (typeof body.title === "string" && body.title.trim()) {
+    result.workspace.title = body.title.trim().slice(0, 140);
+  }
+  if (typeof body.description === "string") {
+    result.workspace.description =
+      body.description.trim().slice(0, 1200) || undefined;
+  }
+  if (typeof body.instructions === "string") {
+    result.workspace.instructions =
+      body.instructions.trim().slice(0, 5000) || undefined;
+  }
+  if (body.visibility === "course" || body.visibility === "live") {
+    result.workspace.visibility = body.visibility;
+  }
+  await result.workspace.save();
+  return NextResponse.json({
+    workspace: serializeLabWorkspace(result.workspace, { educator: true }),
+  });
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  if (!Types.ObjectId.isValid(id)) {
+    return NextResponse.json(
+      { error: "Lab workspace not found." },
+      { status: 404 },
+    );
+  }
+  const result = await authorizeLabWorkspace(id);
+  if (result.error) return result.error;
+  if (!result.manages)
+    return NextResponse.json({ error: "Forbidden." }, { status: 403 });
+  const storageIds = [
+    result.workspace.sourcePackGridFsId,
+    result.workspace.learnerPackGridFsId,
+    ...result.workspace.files.map((file: ILabWorkspaceFile) => file.gridFsId),
+  ];
+  await result.workspace.deleteOne();
+  await deleteLabFiles(storageIds);
+  return NextResponse.json({ ok: true });
+}

--- a/apps/commons-courses/app/api/lab-workspaces/[id]/download/route.ts
+++ b/apps/commons-courses/app/api/lab-workspaces/[id]/download/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { authorizeLabWorkspace } from "@/lib/lab-workspace-access";
+import { streamResponse } from "@/lib/lab-workspace-storage";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const result = await authorizeLabWorkspace(id);
+  if (result.error) return result.error;
+  const facilitator =
+    request.nextUrl.searchParams.get("audience") === "facilitator";
+  if (facilitator && !result.manages) {
+    return NextResponse.json(
+      { error: "Facilitator access required." },
+      { status: 403 },
+    );
+  }
+  const filename = facilitator
+    ? result.workspace.sourceFileName
+    : result.workspace.sourceFileName.replace(/\.zip$/i, "-learner.zip");
+  return streamResponse(
+    facilitator
+      ? result.workspace.sourcePackGridFsId
+      : result.workspace.learnerPackGridFsId,
+    {
+      filename,
+      mimeType: "application/zip",
+      size: facilitator
+        ? result.workspace.sourcePackSize
+        : result.workspace.learnerPackSize,
+      download: true,
+    },
+  );
+}

--- a/apps/commons-courses/app/api/lab-workspaces/[id]/files/[fileId]/route.ts
+++ b/apps/commons-courses/app/api/lab-workspaces/[id]/files/[fileId]/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { authorizeLabWorkspace } from "@/lib/lab-workspace-access";
+import { streamResponse } from "@/lib/lab-workspace-storage";
+import type { ILabWorkspaceFile } from "@/models/LabWorkspace";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; fileId: string }> },
+) {
+  const { id, fileId } = await params;
+  const result = await authorizeLabWorkspace(id);
+  if (result.error) return result.error;
+  const file = result.workspace.files.find(
+    (item: ILabWorkspaceFile) => item.id === fileId,
+  );
+  if (!file || (file.audience === "facilitator" && !result.manages)) {
+    return NextResponse.json({ error: "Lab file not found." }, { status: 404 });
+  }
+  return streamResponse(file.gridFsId, {
+    filename: file.name,
+    mimeType: file.mimeType,
+    size: file.size,
+    download: request.nextUrl.searchParams.get("download") === "1",
+  });
+}

--- a/apps/commons-courses/app/api/lab-workspaces/[id]/route.ts
+++ b/apps/commons-courses/app/api/lab-workspaces/[id]/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { authorizeLabWorkspace } from "@/lib/lab-workspace-access";
+import { serializeLabWorkspace } from "@/lib/lab-workspace-data";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const result = await authorizeLabWorkspace(id);
+  if (result.error) return result.error;
+  return NextResponse.json(
+    {
+      workspace: serializeLabWorkspace(result.workspace, {
+        educator: result.manages,
+      }),
+    },
+    { headers: { "Cache-Control": "private, no-store" } },
+  );
+}

--- a/apps/commons-courses/app/courses/[slug]/learn/page.tsx
+++ b/apps/commons-courses/app/courses/[slug]/learn/page.tsx
@@ -8,6 +8,7 @@ import { AssignmentSubmissions } from "@/components/courses/assignment-submissio
 import { AnalyticsTracker, useAnalytics } from "@/components/analytics/analytics-tracker";
 import { CourseAgentDrawer } from "@/components/course-agents/course-agent-drawer";
 import { LearningStudio } from "@/components/learning/learning-studio";
+import { LearnerLabWorkspace } from "@/components/labs/learner-lab-workspace";
 import { RichTextRenderer } from "@/components/rich-text-renderer";
 import {
   CheckCircle,
@@ -33,6 +34,7 @@ interface LessonData {
   description?: string;
   assetUrl?: string;
   assetAlt?: string;
+  labWorkspaceId?: string;
   isFree: boolean;
 }
 
@@ -581,6 +583,10 @@ export default function LearnPage({ params }: Props) {
                   <RichTextRenderer value={currentLesson.description} />
                 </div>
               )}
+
+              {currentLesson?.labWorkspaceId ? (
+                <LearnerLabWorkspace workspaceId={currentLesson.labWorkspaceId} />
+              ) : null}
 
               {/* Module assignment (show on last lesson of each module) */}
               {lessonIdx === currentModule?.lessons.length - 1 &&

--- a/apps/commons-courses/app/educator/courses/[slug]/materials/page.tsx
+++ b/apps/commons-courses/app/educator/courses/[slug]/materials/page.tsx
@@ -1,10 +1,11 @@
 import { redirect } from "next/navigation";
 import { CourseMaterialLibrary } from "@/components/educator/course-material-library";
+import { LabWorkspaceLibrary } from "@/components/educator/lab-workspace-library";
 import { requireEducatorCourse } from "@/lib/educator-auth";
 
 export default async function MaterialsPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   const result = await requireEducatorCourse(slug);
   if (result.error) redirect("/educator");
-  return <CourseMaterialLibrary slug={slug} />;
+  return <div className="space-y-12"><CourseMaterialLibrary slug={slug} /><LabWorkspaceLibrary slug={slug} /></div>;
 }

--- a/apps/commons-courses/components/courses/course-materials-library.tsx
+++ b/apps/commons-courses/components/courses/course-materials-library.tsx
@@ -1,19 +1,22 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { FileText, Presentation } from "lucide-react";
+import { Archive, FileText, Presentation } from "lucide-react";
 import { CourseMaterialViewer } from "@/components/course-material-viewer";
+import { LearnerLabWorkspace } from "@/components/labs/learner-lab-workspace";
 import type { CourseMaterialRecord } from "@/types/course-material";
+import type { LabWorkspaceRecord } from "@/types/lab-workspace";
 
 export function CourseMaterialsLibrary({ slug }: { slug: string }) {
   const [materials, setMaterials] = useState<CourseMaterialRecord[]>([]);
-  const [selected, setSelected] = useState("");
+  const [workspaces, setWorkspaces] = useState<LabWorkspaceRecord[]>([]);
+  const [selected, setSelected] = useState<{ kind: "material" | "lab"; id: string } | null>(null);
   const [notice, setNotice] = useState("Loading materials…");
   useEffect(() => {
     fetch(`/api/courses/${slug}/materials`, { cache: "no-store" })
       .then(async (res) => ({ ok: res.ok, body: await res.json().catch(() => ({})) }))
-      .then(({ ok, body }) => { if (ok) { setMaterials(body.materials || []); setNotice(""); } else setNotice(body.error || "Could not load materials."); })
+      .then(({ ok, body }) => { if (ok) { setMaterials(body.materials || []); setWorkspaces(body.workspaces || []); setNotice(""); } else setNotice(body.error || "Could not load materials."); })
       .catch(() => setNotice("Could not load materials."));
   }, [slug]);
-  return <div className="grid gap-5 lg:grid-cols-[300px_minmax(0,1fr)]"><aside className="rounded-2xl border border-slate-200 bg-white p-3"><p className="px-3 py-2 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400">Course materials</p>{materials.map((item) => <button key={item.id} onClick={() => setSelected(item.id)} className={`flex w-full items-center gap-3 rounded-xl p-3 text-left ${selected === item.id ? "bg-slate-950 text-white" : "hover:bg-slate-50"}`}>{item.kind === "pdf" ? <FileText className="h-4 w-4 shrink-0" /> : <Presentation className="h-4 w-4 shrink-0" />}<span className="min-w-0 flex-1 truncate text-sm font-bold">{item.name}</span></button>)}{notice ? <p className="p-6 text-center text-sm text-slate-400">{notice}</p> : !materials.length ? <p className="p-6 text-center text-sm text-slate-400">Your educator has not shared any materials yet.</p> : null}</aside><section>{selected ? <CourseMaterialViewer materialId={selected} /> : <div className="flex min-h-[460px] items-center justify-center rounded-2xl border border-dashed border-slate-200 bg-white text-sm text-slate-400">Select a material to open it.</div>}</section></div>;
+  return <div className="grid gap-5 lg:grid-cols-[300px_minmax(0,1fr)]"><aside className="rounded-2xl border border-slate-200 bg-white p-3"><p className="px-3 py-2 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400">Course materials</p>{materials.map((item) => <button key={item.id} onClick={() => setSelected({ kind: "material", id: item.id })} className={`flex w-full items-center gap-3 rounded-xl p-3 text-left ${selected?.kind === "material" && selected.id === item.id ? "bg-slate-950 text-white" : "hover:bg-slate-50"}`}>{item.kind === "pdf" ? <FileText className="h-4 w-4 shrink-0" /> : <Presentation className="h-4 w-4 shrink-0" />}<span className="min-w-0 flex-1 truncate text-sm font-bold">{item.name}</span></button>)}{workspaces.length ? <p className="mt-3 border-t border-slate-100 px-3 pb-2 pt-4 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400">Lab workspaces</p> : null}{workspaces.map((item) => <button key={item.id} onClick={() => setSelected({ kind: "lab", id: item.id })} className={`flex w-full items-center gap-3 rounded-xl p-3 text-left ${selected?.kind === "lab" && selected.id === item.id ? "bg-slate-950 text-white" : "hover:bg-slate-50"}`}><Archive className="h-4 w-4 shrink-0" /><span className="min-w-0 flex-1 truncate text-sm font-bold">{item.title}</span></button>)}{notice ? <p className="p-6 text-center text-sm text-slate-400">{notice}</p> : !materials.length && !workspaces.length ? <p className="p-6 text-center text-sm text-slate-400">Your educator has not shared any materials yet.</p> : null}</aside><section>{selected?.kind === "material" ? <CourseMaterialViewer materialId={selected.id} /> : selected?.kind === "lab" ? <LearnerLabWorkspace workspaceId={selected.id} compact /> : <div className="flex min-h-[460px] items-center justify-center rounded-2xl border border-dashed border-slate-200 bg-white text-sm text-slate-400">Select a material or lab to open it.</div>}</section></div>;
 }

--- a/apps/commons-courses/components/educator/course-editor.tsx
+++ b/apps/commons-courses/components/educator/course-editor.tsx
@@ -23,6 +23,7 @@ import type {
   SkillPack,
   SkillQuestion,
 } from "@/types/skills";
+import type { LabWorkspaceRecord } from "@/types/lab-workspace";
 
 type Lesson = {
   title: string;
@@ -30,6 +31,7 @@ type Lesson = {
   description?: string;
   assetUrl?: string;
   assetAlt?: string;
+  labWorkspaceId?: string;
   isFree?: boolean;
 };
 
@@ -197,6 +199,7 @@ export function CourseEditor({
   const [selectedSkillPath, setSelectedSkillPath] = useState("primary");
   const [error, setError] = useState("");
   const [draftSavedAt, setDraftSavedAt] = useState<Date | null>(null);
+  const [labWorkspaces, setLabWorkspaces] = useState<LabWorkspaceRecord[]>([]);
   const isFullEditor = section === "all";
   const show = (name: CourseEditorSection) => isFullEditor || section === name;
   const sectionLabel = getSectionLabel(section);
@@ -219,6 +222,13 @@ export function CourseEditor({
       })
       .catch(() => setError("Could not load course."));
   }, [section, slug]);
+
+  useEffect(() => {
+    if (!slug) return;
+    void fetch(`/api/educator/courses/${slug}/lab-workspaces`, { cache: "no-store" })
+      .then((response) => (response.ok ? response.json() : null))
+      .then((body) => setLabWorkspaces(body?.workspaces || []));
+  }, [slug]);
 
   useEffect(() => {
     if (!hasUnsavedChanges || !slug || section === "collaborators") return;
@@ -875,6 +885,17 @@ export function CourseEditor({
                     onChange={(event) => updateLesson(course, setCourse, moduleIndex, lessonIndex, { ...lesson, assetAlt: event.target.value })}
                     className="rounded-lg border border-slate-200 px-3 py-2 text-sm md:col-span-2"
                   />
+                  <label className="text-xs font-bold text-slate-600 md:col-span-4">
+                    Lab workspace
+                    <select
+                      value={lesson.labWorkspaceId || ""}
+                      onChange={(event) => updateLesson(course, setCourse, moduleIndex, lessonIndex, { ...lesson, labWorkspaceId: event.target.value || undefined })}
+                      className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-normal text-slate-700"
+                    >
+                      <option value="">No attached lab</option>
+                      {labWorkspaces.map((workspace) => <option key={workspace.id} value={workspace.id}>{workspace.title}</option>)}
+                    </select>
+                  </label>
                 </div>
               ))}
               <button type="button" onClick={() => {

--- a/apps/commons-courses/components/educator/lab-workspace-library.tsx
+++ b/apps/commons-courses/components/educator/lab-workspace-library.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Archive, Download, LoaderCircle, Trash2, Upload } from "lucide-react";
+import { LearnerLabWorkspace } from "@/components/labs/learner-lab-workspace";
+import type { LabWorkspaceRecord } from "@/types/lab-workspace";
+
+export function LabWorkspaceLibrary({ slug }: { slug: string }) {
+  const [workspaces, setWorkspaces] = useState<LabWorkspaceRecord[]>([]);
+  const [selected, setSelected] = useState("");
+  const [uploading, setUploading] = useState(false);
+  const [notice, setNotice] = useState("");
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [instructions, setInstructions] = useState("");
+  const [visibility, setVisibility] = useState<"course" | "live">("course");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const load = useCallback(async () => {
+    const response = await fetch(
+      `/api/educator/courses/${slug}/lab-workspaces`,
+      { cache: "no-store" },
+    );
+    const body = await response.json().catch(() => ({}));
+    if (response.ok) setWorkspaces(body.workspaces || []);
+    else setNotice(body.error || "Could not load labs.");
+  }, [slug]);
+  useEffect(() => {
+    const timer = window.setTimeout(() => void load(), 0);
+    return () => window.clearTimeout(timer);
+  }, [load]);
+
+  async function upload(file?: File) {
+    if (!file || !title.trim()) {
+      setNotice("Add a title and choose a ZIP lab pack.");
+      return;
+    }
+    setUploading(true);
+    setNotice("");
+    const form = new FormData();
+    form.append("archive", file);
+    form.append("title", title);
+    form.append("description", description);
+    form.append("instructions", instructions);
+    form.append("visibility", visibility);
+    const response = await fetch(
+      `/api/educator/courses/${slug}/lab-workspaces`,
+      { method: "POST", body: form },
+    );
+    const body = await response.json().catch(() => ({}));
+    if (response.ok) {
+      setWorkspaces((current) => [body.workspace, ...current]);
+      setSelected(body.workspace.id);
+      setTitle("");
+      setDescription("");
+      setInstructions("");
+      setNotice(
+        `Lab ready: ${body.workspace.learnerFileCount} learner files; ${body.workspace.facilitatorFileCount} facilitator-only files protected.`,
+      );
+    } else setNotice(body.error || "Could not create the lab workspace.");
+    setUploading(false);
+    if (inputRef.current) inputRef.current.value = "";
+  }
+  async function remove(id: string) {
+    if (!window.confirm("Delete this lab workspace and its stored files?"))
+      return;
+    const response = await fetch(`/api/educator/lab-workspaces/${id}`, {
+      method: "DELETE",
+    });
+    if (!response.ok) return;
+    setWorkspaces((current) => current.filter((item) => item.id !== id));
+    if (selected === id) setSelected("");
+  }
+
+  return (
+    <div className="space-y-5">
+      <header>
+        <p className="text-xs font-bold uppercase tracking-[0.2em] text-slate-400">
+          Learner practice
+        </p>
+        <h2 className="mt-2 text-2xl font-bold tracking-tight text-slate-950">
+          Lab workspaces
+        </h2>
+        <p className="mt-1 text-sm text-slate-500">
+          Upload a structured ZIP once. Learners receive a safe workspace and
+          learner-only download pack; facilitator files stay private.
+        </p>
+      </header>
+      <section className="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 lg:grid-cols-2">
+        <input
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          placeholder="Lab title"
+          className="rounded-xl border border-slate-200 px-3 py-2.5 text-sm"
+        />
+        <select
+          value={visibility}
+          onChange={(event) =>
+            setVisibility(event.target.value as "course" | "live")
+          }
+          className="rounded-xl border border-slate-200 px-3 py-2.5 text-sm font-bold"
+        >
+          <option value="course">All enrolled learners</option>
+          <option value="live">Live attendees only</option>
+        </select>
+        <input
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          placeholder="Short learner-facing description"
+          className="rounded-xl border border-slate-200 px-3 py-2.5 text-sm lg:col-span-2"
+        />
+        <textarea
+          value={instructions}
+          onChange={(event) => setInstructions(event.target.value)}
+          placeholder="Lab brief and setup instructions"
+          rows={3}
+          className="rounded-xl border border-slate-200 px-3 py-2.5 text-sm lg:col-span-2"
+        />
+        <label className="inline-flex cursor-pointer items-center justify-center gap-2 rounded-xl bg-slate-950 px-4 py-3 text-sm font-bold text-white lg:col-span-2">
+          <input
+            ref={inputRef}
+            type="file"
+            accept=".zip,application/zip"
+            className="sr-only"
+            disabled={uploading}
+            onChange={(event) => void upload(event.target.files?.[0])}
+          />
+          {uploading ? (
+            <LoaderCircle className="h-4 w-4 animate-spin" />
+          ) : (
+            <Upload className="h-4 w-4" />
+          )}
+          Choose ZIP and create workspace
+        </label>
+      </section>
+      {notice ? (
+        <div className="rounded-xl bg-slate-100 px-4 py-3 text-sm text-slate-700">
+          {notice}
+        </div>
+      ) : null}
+      <div className="grid gap-5 xl:grid-cols-[340px_minmax(0,1fr)]">
+        <section className="rounded-2xl border border-slate-200 bg-white p-3">
+          {workspaces.map((item) => (
+            <div
+              key={item.id}
+              className={`group mb-1 flex items-center rounded-xl ${selected === item.id ? "bg-slate-950 text-white" : "hover:bg-slate-50"}`}
+            >
+              <button
+                onClick={() => setSelected(item.id)}
+                className="flex min-w-0 flex-1 items-center gap-3 p-3 text-left"
+              >
+                <Archive className="h-4 w-4 shrink-0" />
+                <span className="min-w-0">
+                  <span className="block truncate text-sm font-bold">
+                    {item.title}
+                  </span>
+                  <span className="text-[10px] uppercase tracking-wide text-slate-400">
+                    {item.learnerFileCount} learner files ·{" "}
+                    {item.facilitatorFileCount} private
+                  </span>
+                </span>
+              </button>
+              <a
+                href={item.facilitatorPackDownloadUrl}
+                title="Download full facilitator pack"
+                className="p-2 opacity-0 group-hover:opacity-100"
+              >
+                <Download className="h-4 w-4" />
+              </a>
+              <button
+                onClick={() => void remove(item.id)}
+                title="Delete lab"
+                className="mr-2 p-2 text-slate-400 opacity-0 hover:text-red-500 group-hover:opacity-100"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </div>
+          ))}
+          {!workspaces.length ? (
+            <div className="p-10 text-center text-sm text-slate-400">
+              No lab workspaces yet.
+            </div>
+          ) : null}
+        </section>
+        <section>
+          {selected ? (
+            <LearnerLabWorkspace workspaceId={selected} compact />
+          ) : (
+            <div className="flex min-h-80 items-center justify-center rounded-2xl border border-dashed border-slate-200 bg-white p-10 text-sm text-slate-400">
+              Select a lab to preview the learner workspace.
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/commons-courses/components/educator/live-facilitator-studio.tsx
+++ b/apps/commons-courses/components/educator/live-facilitator-studio.tsx
@@ -38,7 +38,9 @@ import type {
   LiveSessionRecord,
 } from "@/types/live-session";
 import type { CourseMaterialRecord } from "@/types/course-material";
+import type { LabWorkspaceRecord } from "@/types/lab-workspace";
 import { CourseMaterialViewer } from "@/components/course-material-viewer";
+import { LearnerLabWorkspace } from "@/components/labs/learner-lab-workspace";
 
 type StudioData = {
   session: LiveSessionRecord;
@@ -85,6 +87,7 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
   const [notice, setNotice] = useState("");
   const [addOpen, setAddOpen] = useState(false);
   const [materials, setMaterials] = useState<CourseMaterialRecord[]>([]);
+  const [labWorkspaces, setLabWorkspaces] = useState<LabWorkspaceRecord[]>([]);
 
   const load = useCallback(
     async (quiet = false) => {
@@ -115,6 +118,9 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
     void fetch(`/api/educator/courses/${slug}/materials`, { cache: "no-store" })
       .then((res) => (res.ok ? res.json() : null))
       .then((body) => setMaterials(body?.materials || []));
+    void fetch(`/api/educator/courses/${slug}/lab-workspaces`, { cache: "no-store" })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((body) => setLabWorkspaces(body?.workspaces || []));
   }, [data?.session.courseSlug]);
   useEffect(() => {
     if (
@@ -706,6 +712,7 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
               <ActivityEditor
                 activity={selected}
                 materials={materials}
+                labWorkspaces={labWorkspaces}
                 index={data.session.activities.findIndex(
                   (activity) => activity.id === selected.id,
                 )}
@@ -785,6 +792,11 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
                       materialId={current.materialId}
                       compact
                     />
+                  </div>
+                ) : null}
+                {current.labWorkspaceId ? (
+                  <div className="border-b border-slate-100 p-4 sm:p-6">
+                    <LearnerLabWorkspace workspaceId={current.labWorkspaceId} compact />
                   </div>
                 ) : null}
                 <LiveResults
@@ -1183,6 +1195,7 @@ function AddMenu({ onAdd }: { onAdd: (type: LiveActivityType) => void }) {
 function ActivityEditor({
   activity,
   materials,
+  labWorkspaces,
   index,
   onChange,
   onMove,
@@ -1190,6 +1203,7 @@ function ActivityEditor({
 }: {
   activity: LiveActivity;
   materials: CourseMaterialRecord[];
+  labWorkspaces: LabWorkspaceRecord[];
   index: number;
   onChange: (patch: Partial<LiveActivity>) => void;
   onMove: (direction: -1 | 1) => void;
@@ -1330,6 +1344,22 @@ function ActivityEditor({
             {materials.map((material) => (
               <option key={material.id} value={material.id}>
                 {material.name}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="Lab workspace">
+          <select
+            value={activity.labWorkspaceId || ""}
+            onChange={(event) =>
+              onChange({ labWorkspaceId: event.target.value || undefined })
+            }
+            className={inputClass}
+          >
+            <option value="">No attached lab</option>
+            {labWorkspaces.map((workspace) => (
+              <option key={workspace.id} value={workspace.id}>
+                {workspace.title}
               </option>
             ))}
           </select>

--- a/apps/commons-courses/components/labs/learner-lab-workspace.tsx
+++ b/apps/commons-courses/components/labs/learner-lab-workspace.tsx
@@ -1,0 +1,382 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Archive,
+  ChevronDown,
+  Download,
+  File,
+  FileText,
+  FolderOpen,
+  LoaderCircle,
+  RotateCcw,
+  Save,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type {
+  LabWorkspaceFileRecord,
+  LabWorkspaceRecord,
+} from "@/types/lab-workspace";
+
+export function LearnerLabWorkspace({
+  workspaceId,
+  compact = false,
+}: {
+  workspaceId: string;
+  compact?: boolean;
+}) {
+  const [workspace, setWorkspace] = useState<LabWorkspaceRecord | null>(null);
+  const [selectedId, setSelectedId] = useState("");
+  const [workingCopy, setWorkingCopy] = useState("");
+  const [error, setError] = useState("");
+  const [filesOpen, setFilesOpen] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    void fetch(`/api/lab-workspaces/${workspaceId}`, { cache: "no-store" })
+      .then(async (response) => {
+        const body = await response.json().catch(() => ({}));
+        if (!response.ok)
+          throw new Error(body.error || "Could not open this lab.");
+        if (!active) return;
+        setWorkspace(body.workspace);
+        const first = body.workspace.files[0];
+        setSelectedId(first?.id || "");
+        setWorkingCopy(
+          first
+            ? (window.localStorage.getItem(storageKey(workspaceId, first.id)) ??
+                first.preview ??
+                "")
+            : "",
+        );
+      })
+      .catch((reason) => active && setError(reason.message));
+    return () => {
+      active = false;
+    };
+  }, [workspaceId]);
+
+  const selected = workspace?.files.find((file) => file.id === selectedId);
+  const folders = useMemo(
+    () => groupFiles(workspace?.files || []),
+    [workspace],
+  );
+
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-red-200 bg-red-50 p-5 text-sm text-red-700">
+        {error}
+      </div>
+    );
+  }
+  if (!workspace) {
+    return (
+      <div className="flex min-h-52 items-center justify-center rounded-2xl border border-slate-200 bg-white text-sm text-slate-400">
+        <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+        Preparing your lab workspace…
+      </div>
+    );
+  }
+
+  function saveWorkingCopy() {
+    if (!selected) return;
+    window.localStorage.setItem(
+      storageKey(workspaceId, selected.id),
+      workingCopy,
+    );
+  }
+  function downloadWorkingCopy() {
+    if (!selected) return;
+    saveWorkingCopy();
+    const link = document.createElement("a");
+    link.href = URL.createObjectURL(
+      new Blob([workingCopy], { type: selected.mimeType }),
+    );
+    link.download = selected.name;
+    link.click();
+    URL.revokeObjectURL(link.href);
+  }
+
+  return (
+    <section
+      className={cn(
+        "overflow-hidden rounded-2xl border border-slate-200 bg-white",
+        compact ? "my-2" : "my-8",
+      )}
+    >
+      <header className="border-b border-slate-200 p-5 sm:flex sm:items-start sm:justify-between sm:gap-6 sm:p-6">
+        <div>
+          <div className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400">
+            <Archive className="h-3.5 w-3.5" />
+            Lab workspace
+          </div>
+          <h2 className="mt-2 text-xl font-bold tracking-tight text-slate-950">
+            {workspace.title}
+          </h2>
+          {workspace.description ? (
+            <p className="mt-1 max-w-3xl text-sm leading-6 text-slate-500">
+              {workspace.description}
+            </p>
+          ) : null}
+        </div>
+        <a
+          href={workspace.learnerPackDownloadUrl}
+          className="mt-4 inline-flex shrink-0 items-center gap-2 rounded-xl bg-slate-950 px-4 py-2.5 text-sm font-bold text-white sm:mt-0"
+        >
+          <Download className="h-4 w-4" />
+          Download learner pack
+        </a>
+      </header>
+      {workspace.instructions ? (
+        <div className="border-b border-slate-200 bg-amber-50/60 px-5 py-4 text-sm leading-6 text-slate-700 sm:px-6">
+          <span className="font-bold">Lab brief. </span>
+          {workspace.instructions}
+        </div>
+      ) : null}
+      <button
+        type="button"
+        onClick={() => setFilesOpen((value) => !value)}
+        className="flex w-full items-center justify-between border-b border-slate-200 px-5 py-3 text-left text-sm font-bold text-slate-700 lg:hidden"
+      >
+        <span className="flex items-center gap-2">
+          <FolderOpen className="h-4 w-4" />
+          {selected?.path || `${workspace.learnerFileCount} files`}
+        </span>
+        <ChevronDown
+          className={cn("h-4 w-4 transition", filesOpen && "rotate-180")}
+        />
+      </button>
+      <div className="grid min-h-[440px] lg:grid-cols-[280px_minmax(0,1fr)]">
+        <LabFileList
+          folders={folders}
+          selectedId={selectedId}
+          onSelect={(id) => {
+            const file = workspace.files.find((item) => item.id === id);
+            setSelectedId(id);
+            setWorkingCopy(
+              file
+                ? (window.localStorage.getItem(storageKey(workspaceId, id)) ??
+                    file.preview ??
+                    "")
+                : "",
+            );
+            setFilesOpen(false);
+          }}
+          className={cn(
+            "border-b border-slate-200 lg:block lg:border-b-0 lg:border-r",
+            filesOpen ? "block" : "hidden",
+          )}
+        />
+        <div className="min-w-0 p-4 sm:p-6">
+          {selected ? (
+            <>
+              <div className="flex flex-col gap-3 border-b border-slate-100 pb-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="min-w-0">
+                  <h3 className="truncate text-sm font-bold text-slate-900">
+                    {selected.name}
+                  </h3>
+                  <p className="mt-1 text-xs text-slate-400">
+                    {selected.purpose || selected.path} ·{" "}
+                    {formatSize(selected.size)}
+                  </p>
+                </div>
+                <a
+                  href={selected.downloadUrl}
+                  className="inline-flex shrink-0 items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-xs font-bold text-slate-700"
+                >
+                  <Download className="h-3.5 w-3.5" />
+                  Download original
+                </a>
+              </div>
+              <FileWorkspace
+                file={selected}
+                value={workingCopy}
+                onChange={setWorkingCopy}
+                onSave={saveWorkingCopy}
+                onDownload={downloadWorkingCopy}
+                onReset={() => {
+                  setWorkingCopy(selected.preview || "");
+                  window.localStorage.removeItem(
+                    storageKey(workspaceId, selected.id),
+                  );
+                }}
+              />
+            </>
+          ) : (
+            <div className="flex min-h-80 items-center justify-center text-sm text-slate-400">
+              Choose a file to begin.
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function LabFileList({
+  folders,
+  selectedId,
+  onSelect,
+  className,
+}: {
+  folders: Array<{ name: string; files: LabWorkspaceFileRecord[] }>;
+  selectedId: string;
+  onSelect: (id: string) => void;
+  className?: string;
+}) {
+  return (
+    <nav
+      className={cn(
+        "max-h-[440px] overflow-y-auto bg-slate-50/70 p-3",
+        className,
+      )}
+    >
+      {folders.map((folder) => (
+        <div key={folder.name} className="mb-4">
+          <p className="px-2 py-1 text-[10px] font-bold uppercase tracking-widest text-slate-400">
+            {folder.name}
+          </p>
+          <div className="mt-1 space-y-1">
+            {folder.files.map((file) => (
+              <button
+                type="button"
+                key={file.id}
+                onClick={() => onSelect(file.id)}
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-xs",
+                  selectedId === file.id
+                    ? "bg-slate-950 font-bold text-white"
+                    : "text-slate-600 hover:bg-white",
+                )}
+              >
+                <FileText className="h-3.5 w-3.5 shrink-0" />
+                <span className="truncate">
+                  {file.path.split("/").slice(1).join("/") || file.name}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </nav>
+  );
+}
+
+function FileWorkspace({
+  file,
+  value,
+  onChange,
+  onSave,
+  onDownload,
+  onReset,
+}: {
+  file: LabWorkspaceFileRecord;
+  value: string;
+  onChange: (value: string) => void;
+  onSave: () => void;
+  onDownload: () => void;
+  onReset: () => void;
+}) {
+  if (file.editable)
+    return (
+      <div className="pt-4">
+        <textarea
+          aria-label={`Working copy of ${file.name}`}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          onBlur={onSave}
+          spellCheck={false}
+          className="min-h-[320px] w-full resize-y rounded-xl border border-slate-200 bg-slate-950 p-4 font-mono text-xs leading-6 text-slate-100 outline-none focus:border-slate-400"
+        />
+        <div className="mt-3 flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={onSave}
+            className="inline-flex items-center gap-2 rounded-lg bg-slate-950 px-3 py-2 text-xs font-bold text-white"
+          >
+            <Save className="h-3.5 w-3.5" />
+            Save on this device
+          </button>
+          <button
+            type="button"
+            onClick={onDownload}
+            className="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-xs font-bold text-slate-700"
+          >
+            <Download className="h-3.5 w-3.5" />
+            Download working copy
+          </button>
+          <button
+            type="button"
+            onClick={onReset}
+            className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-xs font-bold text-slate-500"
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+            Reset
+          </button>
+        </div>
+        <p className="mt-2 text-[11px] text-slate-400">
+          Your edits stay privately in this browser until you download them.
+        </p>
+      </div>
+    );
+  if (file.mimeType === "application/pdf")
+    return (
+      <iframe
+        title={file.name}
+        src={file.url}
+        className="mt-4 h-[520px] w-full rounded-xl border border-slate-200 bg-white"
+      />
+    );
+  if (file.mimeType.startsWith("image/"))
+    return (
+      <div className="mt-4 flex min-h-80 items-center justify-center rounded-xl bg-slate-50 p-4">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={file.url}
+          alt={file.name}
+          className="max-h-[520px] max-w-full object-contain"
+        />
+      </div>
+    );
+  return (
+    <div className="mt-4 flex min-h-80 flex-col items-center justify-center rounded-xl border border-dashed border-slate-200 bg-slate-50 p-8 text-center">
+      <File className="h-8 w-8 text-slate-300" />
+      <p className="mt-3 text-sm font-bold text-slate-800">
+        Ready to work with {file.name}
+      </p>
+      <p className="mt-1 max-w-md text-xs leading-5 text-slate-400">
+        This file type opens in its native app. Download it, work normally, and
+        keep the rest of your lab files open here.
+      </p>
+      <a
+        href={file.downloadUrl}
+        className="mt-4 inline-flex items-center gap-2 rounded-lg bg-slate-950 px-4 py-2.5 text-xs font-bold text-white"
+      >
+        <Download className="h-3.5 w-3.5" />
+        Download file
+      </a>
+    </div>
+  );
+}
+
+function groupFiles(files: LabWorkspaceFileRecord[]) {
+  const grouped = new Map<string, LabWorkspaceFileRecord[]>();
+  for (const file of files) {
+    const folder = file.path.includes("/")
+      ? file.path.split("/")[0]
+      : "Start here";
+    grouped.set(folder, [...(grouped.get(folder) || []), file]);
+  }
+  return [...grouped.entries()].map(([name, folderFiles]) => ({
+    name,
+    files: folderFiles,
+  }));
+}
+function storageKey(workspaceId: string, fileId: string) {
+  return `commonlab:lab:${workspaceId}:${fileId}`;
+}
+function formatSize(bytes: number) {
+  return bytes < 1024 * 1024
+    ? `${Math.max(1, Math.round(bytes / 1024))} KB`
+    : `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}

--- a/apps/commons-courses/components/live/live-learner-room.tsx
+++ b/apps/commons-courses/components/live/live-learner-room.tsx
@@ -29,6 +29,7 @@ import {
 } from "lucide-react";
 import { CourseAgentDrawer } from "@/components/course-agents/course-agent-drawer";
 import { CourseMaterialViewer } from "@/components/course-material-viewer";
+import { LearnerLabWorkspace } from "@/components/labs/learner-lab-workspace";
 import { cn } from "@/lib/utils";
 import { getCourseThemeStyle } from "@/lib/course-theme";
 import {
@@ -820,6 +821,11 @@ function LearnerActivity({
       {activity.materialId ? (
         <div className="border-t border-slate-100 p-4 sm:p-6">
           <CourseMaterialViewer materialId={activity.materialId} compact />
+        </div>
+      ) : null}
+      {activity.labWorkspaceId ? (
+        <div className="border-t border-slate-100 p-4 sm:p-6">
+          <LearnerLabWorkspace workspaceId={activity.labWorkspaceId} compact />
         </div>
       ) : null}
       {isChoice ? (

--- a/apps/commons-courses/lib/course-input.ts
+++ b/apps/commons-courses/lib/course-input.ts
@@ -82,6 +82,7 @@ export type CourseInput = {
       description?: string;
       assetUrl?: string;
       assetAlt?: string;
+      labWorkspaceId?: string;
       isFree?: boolean;
     }>;
   }>;
@@ -638,6 +639,7 @@ export function normalizeCourseInput(input: CourseInput) {
               description: sanitizeRichTextHtml(lesson.description) || undefined,
               assetUrl: normalizeImageUrl(lesson.assetUrl),
               assetAlt: lesson.assetAlt?.trim() || undefined,
+              labWorkspaceId: lesson.labWorkspaceId?.trim() || undefined,
             }))
           : [],
       }))

--- a/apps/commons-courses/lib/lab-archive.test.mts
+++ b/apps/commons-courses/lib/lab-archive.test.mts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import JSZip from "jszip";
+import { normalizeArchivePath, parseLabArchive } from "./lab-archive.ts";
+
+test("rejects traversal paths", () => {
+  assert.throws(
+    () => normalizeArchivePath("../answer-key.pdf"),
+    /Unsafe ZIP path/,
+  );
+  assert.throws(() => normalizeArchivePath("/absolute.txt"), /Unsafe ZIP path/);
+});
+
+test("uses the manifest to keep facilitator files out of the learner pack", async () => {
+  const zip = new JSZip();
+  zip.file(
+    "Pack/Lab_Asset_Manifest.csv",
+    'Path,Audience,Purpose\nnotes.md,Learner,"Editable notes"\nfacilitator/key.txt,Facilitator,"Private key"\n',
+  );
+  zip.file("Pack/notes.md", "Learner copy");
+  zip.file("Pack/facilitator/key.txt", "Private answer");
+  const parsed = await parseLabArchive(
+    Buffer.from(await zip.generateAsync({ type: "uint8array" })),
+  );
+  assert.equal(
+    parsed.files.find((file) => file.path === "notes.md")?.audience,
+    "learner",
+  );
+  assert.equal(
+    parsed.files.find((file) => file.path === "facilitator/key.txt")?.audience,
+    "facilitator",
+  );
+  const learner = await JSZip.loadAsync(parsed.learnerPack);
+  assert.ok(learner.file("notes.md"));
+  assert.equal(learner.file("facilitator/key.txt"), null);
+});

--- a/apps/commons-courses/lib/lab-archive.ts
+++ b/apps/commons-courses/lib/lab-archive.ts
@@ -1,0 +1,238 @@
+import { randomUUID } from "crypto";
+import path from "path";
+import JSZip from "jszip";
+import type { LabWorkspaceAudience } from "@/types/lab-workspace";
+
+const maxFiles = 120;
+const maxExpandedSize = 100 * 1024 * 1024;
+const maxFileSize = 25 * 1024 * 1024;
+const maxPreviewSize = 250 * 1024;
+
+export type ParsedLabFile = {
+  id: string;
+  path: string;
+  name: string;
+  mimeType: string;
+  size: number;
+  audience: LabWorkspaceAudience;
+  purpose?: string;
+  editable: boolean;
+  preview?: string;
+  bytes: Buffer;
+};
+
+export async function parseLabArchive(bytes: Buffer) {
+  const archive = await JSZip.loadAsync(bytes, {
+    checkCRC32: true,
+    createFolders: false,
+  });
+  const entries = Object.values(archive.files).filter(
+    (entry) => !entry.dir && !isJunk(entry.name),
+  );
+  if (!entries.length)
+    throw new Error("The ZIP file does not contain any files.");
+  if (entries.length > maxFiles) {
+    throw new Error(`A lab pack can contain at most ${maxFiles} files.`);
+  }
+  const declaredExpandedSize = entries.reduce(
+    (total, entry) => total + declaredSize(entry),
+    0,
+  );
+  if (declaredExpandedSize > maxExpandedSize) {
+    throw new Error("The expanded lab pack is larger than 100 MB.");
+  }
+
+  const raw = await Promise.all(
+    entries.map(async (entry) => {
+      const normalized = normalizeArchivePath(entry.name);
+      const data = Buffer.from(await entry.async("uint8array"));
+      if (data.length > maxFileSize) {
+        throw new Error(`${normalized} is larger than 25 MB.`);
+      }
+      return { path: normalized, bytes: data };
+    }),
+  );
+  const expandedSize = raw.reduce(
+    (total, item) => total + item.bytes.length,
+    0,
+  );
+  if (expandedSize > maxExpandedSize) {
+    throw new Error("The expanded lab pack is larger than 100 MB.");
+  }
+
+  const commonRoot = findCommonRoot(raw.map((item) => item.path));
+  const stripped = raw.map((item) => ({
+    ...item,
+    path: commonRoot ? item.path.slice(commonRoot.length + 1) : item.path,
+  }));
+  const manifestEntry = stripped.find(
+    (item) => item.path.toLowerCase() === "lab_asset_manifest.csv",
+  );
+  const manifest = manifestEntry
+    ? parseManifest(manifestEntry.bytes.toString("utf8"))
+    : new Map<string, { audience: LabWorkspaceAudience; purpose?: string }>();
+
+  const files: ParsedLabFile[] = stripped.map((item) => {
+    const metadata = manifest.get(item.path.toLowerCase());
+    const audience =
+      metadata?.audience ||
+      (item.path.toLowerCase().startsWith("facilitator/")
+        ? "facilitator"
+        : "learner");
+    const mimeType = mimeFor(item.path);
+    const editable =
+      isEditable(item.path, mimeType) && item.bytes.length <= maxPreviewSize;
+    return {
+      id: randomUUID(),
+      path: item.path,
+      name: path.posix.basename(item.path),
+      mimeType,
+      size: item.bytes.length,
+      audience,
+      purpose: metadata?.purpose,
+      editable,
+      preview: editable ? item.bytes.toString("utf8") : undefined,
+      bytes: item.bytes,
+    };
+  });
+
+  const learnerArchive = new JSZip();
+  for (const file of files) {
+    if (file.audience === "learner") learnerArchive.file(file.path, file.bytes);
+  }
+  const learnerPack = Buffer.from(
+    await learnerArchive.generateAsync({
+      type: "uint8array",
+      compression: "DEFLATE",
+    }),
+  );
+  return { files, learnerPack };
+}
+
+function declaredSize(entry: JSZip.JSZipObject) {
+  const internal = entry as JSZip.JSZipObject & {
+    _data?: { uncompressedSize?: number };
+  };
+  return Number(internal._data?.uncompressedSize || 0);
+}
+
+export function normalizeArchivePath(value: string) {
+  const normalized = value.replaceAll("\\", "/").replace(/^\.\//, "");
+  if (
+    !normalized ||
+    normalized.startsWith("/") ||
+    normalized.includes("\0") ||
+    normalized.split("/").some((part) => !part || part === "." || part === "..")
+  ) {
+    throw new Error(`Unsafe ZIP path: ${value}`);
+  }
+  return normalized;
+}
+
+function findCommonRoot(paths: string[]) {
+  const roots = new Set(paths.map((item) => item.split("/")[0]));
+  return roots.size === 1 && paths.every((item) => item.includes("/"))
+    ? [...roots][0]
+    : undefined;
+}
+
+function isJunk(name: string) {
+  return name.startsWith("__MACOSX/") || /(^|\/)\.DS_Store$/i.test(name);
+}
+
+function parseManifest(value: string) {
+  const rows = parseCsv(value);
+  const headers = rows.shift()?.map((cell) => cell.trim().toLowerCase()) || [];
+  const pathIndex = headers.indexOf("path");
+  const audienceIndex = headers.indexOf("audience");
+  const purposeIndex = headers.indexOf("purpose");
+  const result = new Map<
+    string,
+    { audience: LabWorkspaceAudience; purpose?: string }
+  >();
+  if (pathIndex < 0) return result;
+  for (const row of rows) {
+    const entryPath = row[pathIndex]
+      ?.trim()
+      .replaceAll("\\", "/")
+      .toLowerCase();
+    if (!entryPath) continue;
+    const audience =
+      row[audienceIndex]?.trim().toLowerCase() === "facilitator"
+        ? "facilitator"
+        : "learner";
+    result.set(entryPath, {
+      audience,
+      purpose: row[purposeIndex]?.trim() || undefined,
+    });
+  }
+  return result;
+}
+
+function parseCsv(value: string) {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let quoted = false;
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (character === '"') {
+      if (quoted && value[index + 1] === '"') {
+        cell += '"';
+        index += 1;
+      } else quoted = !quoted;
+    } else if (character === "," && !quoted) {
+      row.push(cell);
+      cell = "";
+    } else if ((character === "\n" || character === "\r") && !quoted) {
+      if (character === "\r" && value[index + 1] === "\n") index += 1;
+      row.push(cell);
+      if (row.some(Boolean)) rows.push(row);
+      row = [];
+      cell = "";
+    } else cell += character;
+  }
+  row.push(cell);
+  if (row.some(Boolean)) rows.push(row);
+  return rows;
+}
+
+function isEditable(filePath: string, mimeType: string) {
+  return (
+    mimeType.startsWith("text/") ||
+    /\.(md|markdown|json|ya?ml|js|jsx|ts|tsx|py|sql)$/i.test(filePath)
+  );
+}
+
+function mimeFor(filePath: string) {
+  const extension = path.posix.extname(filePath).toLowerCase();
+  return (
+    (
+      {
+        ".md": "text/markdown; charset=utf-8",
+        ".txt": "text/plain; charset=utf-8",
+        ".csv": "text/csv; charset=utf-8",
+        ".json": "application/json; charset=utf-8",
+        ".yaml": "text/yaml; charset=utf-8",
+        ".yml": "text/yaml; charset=utf-8",
+        ".pdf": "application/pdf",
+        ".docx":
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ".xlsx":
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ".pptx":
+          "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".gif": "image/gif",
+        ".svg": "image/svg+xml",
+        ".html": "text/html; charset=utf-8",
+        ".css": "text/css; charset=utf-8",
+        ".js": "text/javascript; charset=utf-8",
+        ".ts": "text/typescript; charset=utf-8",
+        ".py": "text/x-python; charset=utf-8",
+      } as Record<string, string>
+    )[extension] || "application/octet-stream"
+  );
+}

--- a/apps/commons-courses/lib/lab-workspace-access.ts
+++ b/apps/commons-courses/lib/lab-workspace-access.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from "next/server";
+import { Types } from "mongoose";
+import { auth } from "@/lib/auth";
+import { connectDB } from "@/lib/db";
+import { getCourseCollaboratorRole } from "@/lib/educator-auth";
+import Course from "@/models/Course";
+import Enrollment from "@/models/Enrollment";
+import LabWorkspace from "@/models/LabWorkspace";
+import LiveParticipant from "@/models/LiveParticipant";
+import LiveSession from "@/models/LiveSession";
+
+export async function authorizeLabWorkspace(id: string) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return {
+      error: NextResponse.json({ error: "Unauthorized." }, { status: 401 }),
+    };
+  }
+  if (!Types.ObjectId.isValid(id)) {
+    return {
+      error: NextResponse.json(
+        { error: "Lab workspace not found." },
+        { status: 404 },
+      ),
+    };
+  }
+  await connectDB();
+  const workspace = await LabWorkspace.findById(id);
+  if (!workspace) {
+    return {
+      error: NextResponse.json(
+        { error: "Lab workspace not found." },
+        { status: 404 },
+      ),
+    };
+  }
+  const course = await Course.findById(workspace.courseId);
+  if (!course) {
+    return {
+      error: NextResponse.json(
+        { error: "Lab workspace not found." },
+        { status: 404 },
+      ),
+    };
+  }
+  const manages =
+    session.user.role === "admin" ||
+    course.educator?.userId?.toString() === session.user.id ||
+    Boolean(
+      getCourseCollaboratorRole(course, {
+        userId: session.user.id,
+        email: session.user.email,
+      }),
+    );
+  if (!manages && !course.published) {
+    return {
+      error: NextResponse.json(
+        { error: "Lab workspace not found." },
+        { status: 404 },
+      ),
+    };
+  }
+  if (!manages && workspace.visibility === "live") {
+    const sessionIds = await LiveSession.find({
+      courseId: workspace.courseId,
+      "activities.labWorkspaceId": String(workspace._id),
+    }).distinct("_id");
+    const attended = await LiveParticipant.exists({
+      sessionId: { $in: sessionIds },
+      userId: session.user.id,
+    });
+    if (!attended) {
+      return {
+        error: NextResponse.json(
+          { error: "This lab is limited to live-session participants." },
+          { status: 403 },
+        ),
+      };
+    }
+  } else if (!manages) {
+    const enrolled = await Enrollment.exists({
+      userId: session.user.id,
+      courseId: workspace.courseId,
+      status: { $ne: "cancelled" },
+    });
+    if (!enrolled) {
+      return {
+        error: NextResponse.json(
+          { error: "This lab is limited to enrolled learners." },
+          { status: 403 },
+        ),
+      };
+    }
+  }
+  return { error: null, session, course, workspace, manages };
+}

--- a/apps/commons-courses/lib/lab-workspace-data.ts
+++ b/apps/commons-courses/lib/lab-workspace-data.ts
@@ -1,0 +1,52 @@
+import type { ILabWorkspace, ILabWorkspaceFile } from "@/models/LabWorkspace";
+import type { LabWorkspaceRecord } from "@/types/lab-workspace";
+
+export function serializeLabWorkspace(
+  workspace: ILabWorkspace,
+  options: { educator?: boolean } = {},
+): LabWorkspaceRecord {
+  const files = (workspace.files || []).filter(
+    (file) => options.educator || file.audience === "learner",
+  );
+  return {
+    id: String(workspace._id),
+    courseId: String(workspace.courseId),
+    courseSlug: workspace.courseSlug,
+    title: workspace.title,
+    description: workspace.description,
+    instructions: workspace.instructions,
+    visibility: workspace.visibility,
+    sourceFileName: workspace.sourceFileName,
+    learnerFileCount: workspace.files.filter(
+      (file) => file.audience === "learner",
+    ).length,
+    facilitatorFileCount: workspace.files.filter(
+      (file) => file.audience === "facilitator",
+    ).length,
+    learnerPackSize: workspace.learnerPackSize,
+    learnerPackDownloadUrl: `/api/lab-workspaces/${workspace._id}/download`,
+    facilitatorPackDownloadUrl: options.educator
+      ? `/api/lab-workspaces/${workspace._id}/download?audience=facilitator`
+      : undefined,
+    files: files.map((file) => serializeFile(workspace, file)),
+    createdAt: workspace.createdAt.toISOString(),
+    updatedAt: workspace.updatedAt.toISOString(),
+  };
+}
+
+function serializeFile(workspace: ILabWorkspace, file: ILabWorkspaceFile) {
+  const base = `/api/lab-workspaces/${workspace._id}/files/${file.id}`;
+  return {
+    id: file.id,
+    path: file.path,
+    name: file.name,
+    mimeType: file.mimeType,
+    size: file.size,
+    audience: file.audience,
+    purpose: file.purpose,
+    editable: file.editable,
+    preview: file.preview,
+    url: base,
+    downloadUrl: `${base}?download=1`,
+  };
+}

--- a/apps/commons-courses/lib/lab-workspace-storage.ts
+++ b/apps/commons-courses/lib/lab-workspace-storage.ts
@@ -1,0 +1,71 @@
+import { Readable } from "stream";
+import { mongo } from "mongoose";
+import LabWorkspace from "@/models/LabWorkspace";
+
+const bucketName = "labWorkspaces";
+
+function bucket() {
+  const db = LabWorkspace.db.db;
+  if (!db) throw new Error("Lab workspace storage is unavailable.");
+  return new mongo.GridFSBucket(db, { bucketName });
+}
+
+export async function uploadLabFile(
+  bytes: Buffer,
+  filename: string,
+  mimeType: string,
+) {
+  const upload = bucket().openUploadStream(filename, {
+    contentType: mimeType,
+    metadata: { private: true },
+  });
+  await new Promise<void>((resolve, reject) => {
+    Readable.from(bytes).pipe(upload).on("error", reject).on("finish", resolve);
+  });
+  return upload.id;
+}
+
+export async function deleteLabFiles(ids: Array<unknown>) {
+  const storage = bucket();
+  await Promise.allSettled(
+    ids
+      .filter(Boolean)
+      .map((id) => storage.delete(new mongo.ObjectId(String(id)))),
+  );
+}
+
+export function streamLabFile(id: unknown) {
+  return bucket().openDownloadStream(new mongo.ObjectId(String(id)));
+}
+
+export function streamResponse(
+  id: unknown,
+  options: {
+    filename: string;
+    mimeType: string;
+    size?: number;
+    download?: boolean;
+  },
+) {
+  const stream = streamLabFile(id);
+  const body = new ReadableStream({
+    start(controller) {
+      stream.on("data", (chunk) => controller.enqueue(new Uint8Array(chunk)));
+      stream.on("end", () => controller.close());
+      stream.on("error", (error) => controller.error(error));
+    },
+    cancel() {
+      stream.destroy();
+    },
+  });
+  const disposition = options.download ? "attachment" : "inline";
+  const headers: Record<string, string> = {
+    "Content-Type": options.mimeType,
+    "Content-Disposition": `${disposition}; filename*=UTF-8''${encodeURIComponent(options.filename)}`,
+    "Cache-Control": "private, no-store",
+    "X-Content-Type-Options": "nosniff",
+  };
+  if (options.size !== undefined)
+    headers["Content-Length"] = String(options.size);
+  return new Response(body, { headers });
+}

--- a/apps/commons-courses/lib/live-session-input.ts
+++ b/apps/commons-courses/lib/live-session-input.ts
@@ -38,6 +38,7 @@ export function createActivity(
     facilitatorNotes: clean(input.facilitatorNotes),
     resourceUrl: cleanUrl(input.resourceUrl),
     materialId: clean(input.materialId),
+    labWorkspaceId: clean(input.labWorkspaceId),
     estimatedMinutes: clampNumber(input.estimatedMinutes, 1, 480),
     status:
       input.status === "open" || input.status === "closed"

--- a/apps/commons-courses/models/Course.ts
+++ b/apps/commons-courses/models/Course.ts
@@ -13,6 +13,7 @@ export interface ILesson {
   description?: string;
   assetUrl?: string;
   assetAlt?: string;
+  labWorkspaceId?: string;
   isFree: boolean;
 }
 
@@ -175,6 +176,7 @@ const LessonSchema = new Schema<ILesson>({
   description: String,
   assetUrl: String,
   assetAlt: String,
+  labWorkspaceId: String,
   isFree: { type: Boolean, default: false },
 });
 

--- a/apps/commons-courses/models/LabWorkspace.ts
+++ b/apps/commons-courses/models/LabWorkspace.ts
@@ -1,0 +1,85 @@
+import mongoose, { Document, Schema } from "mongoose";
+import type {
+  LabWorkspaceAudience,
+  LabWorkspaceVisibility,
+} from "@/types/lab-workspace";
+
+export interface ILabWorkspaceFile {
+  id: string;
+  path: string;
+  name: string;
+  mimeType: string;
+  size: number;
+  audience: LabWorkspaceAudience;
+  purpose?: string;
+  editable: boolean;
+  preview?: string;
+  gridFsId: mongoose.Types.ObjectId;
+}
+
+export interface ILabWorkspace extends Document {
+  courseId: mongoose.Types.ObjectId;
+  courseSlug: string;
+  ownerUserId: mongoose.Types.ObjectId;
+  title: string;
+  description?: string;
+  instructions?: string;
+  visibility: LabWorkspaceVisibility;
+  sourceFileName: string;
+  sourcePackGridFsId: mongoose.Types.ObjectId;
+  sourcePackSize: number;
+  learnerPackGridFsId: mongoose.Types.ObjectId;
+  learnerPackSize: number;
+  files: ILabWorkspaceFile[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const LabWorkspaceFileSchema = new Schema<ILabWorkspaceFile>(
+  {
+    id: { type: String, required: true, trim: true },
+    path: { type: String, required: true, trim: true },
+    name: { type: String, required: true, trim: true },
+    mimeType: { type: String, required: true, trim: true },
+    size: { type: Number, required: true, min: 0 },
+    audience: {
+      type: String,
+      enum: ["learner", "facilitator"],
+      required: true,
+    },
+    purpose: { type: String, trim: true },
+    editable: { type: Boolean, default: false },
+    preview: String,
+    gridFsId: { type: Schema.Types.ObjectId, required: true },
+  },
+  { _id: false },
+);
+
+const LabWorkspaceSchema = new Schema<ILabWorkspace>(
+  {
+    courseId: { type: Schema.Types.ObjectId, ref: "Course", required: true },
+    courseSlug: { type: String, required: true, trim: true },
+    ownerUserId: { type: Schema.Types.ObjectId, ref: "User", required: true },
+    title: { type: String, required: true, trim: true },
+    description: { type: String, trim: true },
+    instructions: { type: String, trim: true },
+    visibility: {
+      type: String,
+      enum: ["course", "live"],
+      default: "course",
+    },
+    sourceFileName: { type: String, required: true, trim: true },
+    sourcePackGridFsId: { type: Schema.Types.ObjectId, required: true },
+    sourcePackSize: { type: Number, required: true, min: 0 },
+    learnerPackGridFsId: { type: Schema.Types.ObjectId, required: true },
+    learnerPackSize: { type: Number, required: true, min: 0 },
+    files: { type: [LabWorkspaceFileSchema], default: [] },
+  },
+  { timestamps: true },
+);
+
+LabWorkspaceSchema.index({ courseId: 1, createdAt: -1 });
+LabWorkspaceSchema.index({ courseSlug: 1, visibility: 1 });
+
+export default mongoose.models.LabWorkspace ||
+  mongoose.model<ILabWorkspace>("LabWorkspace", LabWorkspaceSchema);

--- a/apps/commons-courses/models/LiveSession.ts
+++ b/apps/commons-courses/models/LiveSession.ts
@@ -59,6 +59,7 @@ const LiveActivitySchema = new Schema<LiveActivity>(
     facilitatorNotes: { type: String, trim: true },
     resourceUrl: { type: String, trim: true },
     materialId: { type: String, trim: true },
+    labWorkspaceId: { type: String, trim: true },
     estimatedMinutes: { type: Number, min: 1, max: 480 },
     status: {
       type: String,

--- a/apps/commons-courses/package.json
+++ b/apps/commons-courses/package.json
@@ -16,7 +16,8 @@
     "seed:intro-multi-agent-systems-skill": "node scripts/seed-intro-multi-agent-systems-skill.mjs",
     "repair:payments-index": "node scripts/repair-payments-index.mjs",
     "set:ai-quick-wins-start-date": "node scripts/set-ai-quick-wins-start-date.mjs",
-    "migrate:moringa-workshop-course": "node scripts/migrate-moringa-workshop-course.mjs"
+    "migrate:moringa-workshop-course": "node scripts/migrate-moringa-workshop-course.mjs",
+    "import:moringa-lab-workspace": "node scripts/import-moringa-lab-workspace.mjs"
   },
   "dependencies": {
     "@agent-commons/sdk": "workspace:*",
@@ -31,6 +32,7 @@
     "bcryptjs": "^2.4.3",
     "canvas-confetti": "^1.9.4",
     "clsx": "^2.1.1",
+    "jszip": "^3.10.1",
     "lucide-react": "^0.474.0",
     "mongoose": "^8.9.5",
     "next": "16.2.12",

--- a/apps/commons-courses/scripts/import-moringa-lab-workspace.mjs
+++ b/apps/commons-courses/scripts/import-moringa-lab-workspace.mjs
@@ -1,0 +1,296 @@
+import fs from "fs/promises";
+import path from "path";
+import { Readable } from "stream";
+import JSZip from "jszip";
+import mongoose, { mongo } from "mongoose";
+
+const mongoUri = process.env.MONGODB_URI;
+const sourcePath = process.argv[2];
+const learnerPath = process.argv[3];
+const ownerEmail = "bashybaranaba@gmail.com";
+const courseSlug = "claude-skills-for-everyday-work-moringa";
+const liveSessionId = "6a7d76665ca03a4a097ff615";
+const workspaceTitle =
+  "Claude Skills for Everyday Work · Moringa lab workspace";
+const practicalActivityPattern =
+  /setup|lab\s*\d|gallery|build a skill|work safely|first-week plan/i;
+
+if (!mongoUri || !sourcePath || !learnerPath) {
+  console.error(
+    "Usage: MONGODB_URI=… node scripts/import-moringa-lab-workspace.mjs FULL.zip LEARNER.zip",
+  );
+  process.exit(1);
+}
+
+await mongoose.connect(mongoUri);
+try {
+  const db = mongoose.connection.db;
+  if (!db) throw new Error("MongoDB connection is unavailable.");
+  const owner = await db.collection("users").findOne({ email: ownerEmail });
+  const course = await db.collection("courses").findOne({ slug: courseSlug });
+  if (!owner) throw new Error(`Owner not found: ${ownerEmail}`);
+  if (!course) throw new Error(`Course not found: ${courseSlug}`);
+
+  let workspace = await db.collection("labworkspaces").findOne({
+    courseId: course._id,
+    title: workspaceTitle,
+  });
+  if (!workspace) {
+    const sourceBytes = await fs.readFile(sourcePath);
+    const learnerBytes = await fs.readFile(learnerPath);
+    const archive = await JSZip.loadAsync(sourceBytes, { checkCRC32: true });
+    const entries = Object.values(archive.files).filter(
+      (entry) =>
+        !entry.dir &&
+        !entry.name.startsWith("__MACOSX/") &&
+        !entry.name.endsWith("/.DS_Store"),
+    );
+    const commonRoot = findCommonRoot(entries.map((entry) => entry.name));
+    const expanded = await Promise.all(
+      entries.map(async (entry) => ({
+        path: commonRoot ? entry.name.slice(commonRoot.length + 1) : entry.name,
+        bytes: Buffer.from(await entry.async("uint8array")),
+      })),
+    );
+    const manifestFile = expanded.find(
+      (file) => file.path.toLowerCase() === "lab_asset_manifest.csv",
+    );
+    const manifest = manifestFile
+      ? parseManifest(manifestFile.bytes.toString("utf8"))
+      : new Map();
+    const bucket = new mongo.GridFSBucket(db, { bucketName: "labWorkspaces" });
+    const uploadedIds = [];
+    try {
+      const sourcePackGridFsId = await upload(
+        bucket,
+        sourceBytes,
+        path.basename(sourcePath),
+        "application/zip",
+      );
+      uploadedIds.push(sourcePackGridFsId);
+      const learnerPackGridFsId = await upload(
+        bucket,
+        learnerBytes,
+        path.basename(learnerPath),
+        "application/zip",
+      );
+      uploadedIds.push(learnerPackGridFsId);
+      const files = [];
+      for (const file of expanded) {
+        const metadata = manifest.get(file.path.toLowerCase());
+        const audience =
+          metadata?.audience ||
+          (file.path.toLowerCase().startsWith("facilitator/")
+            ? "facilitator"
+            : "learner");
+        const mimeType = mimeFor(file.path);
+        const editable =
+          (mimeType.startsWith("text/") ||
+            /\.(md|json|ya?ml)$/i.test(file.path)) &&
+          file.bytes.length <= 250 * 1024;
+        const gridFsId = await upload(
+          bucket,
+          file.bytes,
+          path.posix.basename(file.path),
+          mimeType,
+        );
+        uploadedIds.push(gridFsId);
+        files.push({
+          id: crypto.randomUUID(),
+          path: file.path,
+          name: path.posix.basename(file.path),
+          mimeType,
+          size: file.bytes.length,
+          audience,
+          purpose: metadata?.purpose,
+          editable,
+          preview: editable ? file.bytes.toString("utf8") : undefined,
+          gridFsId,
+        });
+      }
+      const now = new Date();
+      const document = {
+        courseId: course._id,
+        courseSlug,
+        ownerUserId: owner._id,
+        title: workspaceTitle,
+        description:
+          "All workshop source files in one private, structured workspace. Open text sources here or download the complete learner pack for Claude Cowork and desktop apps.",
+        instructions:
+          "Start with README.md. Download the learner pack when a lab asks you to work in Claude Cowork. Your browser working copies stay on this device; facilitator references are never included.",
+        visibility: "live",
+        sourceFileName: path.basename(sourcePath),
+        sourcePackGridFsId,
+        sourcePackSize: sourceBytes.length,
+        learnerPackGridFsId,
+        learnerPackSize: learnerBytes.length,
+        files,
+        createdAt: now,
+        updatedAt: now,
+      };
+      const inserted = await db.collection("labworkspaces").insertOne(document);
+      workspace = { _id: inserted.insertedId, ...document };
+    } catch (error) {
+      await Promise.allSettled(uploadedIds.map((id) => bucket.delete(id)));
+      throw error;
+    }
+  }
+
+  const sessionObjectId = new mongoose.Types.ObjectId(liveSessionId);
+  const session = await db
+    .collection("livesessions")
+    .findOne({ _id: sessionObjectId });
+  if (!session) throw new Error(`Live session not found: ${liveSessionId}`);
+  const activities = (session.activities || []).map((activity) =>
+    practicalActivityPattern.test(activity.title || "")
+      ? { ...activity, labWorkspaceId: String(workspace._id) }
+      : activity,
+  );
+  await db.collection("livesessions").updateOne(
+    { _id: sessionObjectId },
+    {
+      $set: { activities, updatedAt: new Date() },
+      $inc: { stateVersion: 1 },
+    },
+  );
+
+  const modules = (course.modules || []).map((module, index) =>
+    index === 0
+      ? {
+          ...module,
+          lessons: [
+            ...(module.lessons || []).filter(
+              (lesson) => lesson.title !== "Moringa workshop lab workspace",
+            ),
+            {
+              title: "Moringa workshop lab workspace",
+              duration: "Use throughout the day",
+              description:
+                "<p>Open the structured source files for each workshop lab, keep editable working copies in your browser, or download the learner pack for Claude Cowork.</p>",
+              labWorkspaceId: String(workspace._id),
+              isFree: false,
+            },
+          ],
+        }
+      : module,
+  );
+  await db.collection("courses").updateOne(
+    { _id: course._id },
+    {
+      $set: {
+        modules,
+        modulesCount: modules.length,
+        lessonsCount: modules.reduce(
+          (total, module) => total + (module.lessons || []).length,
+          0,
+        ),
+        updatedAt: new Date(),
+      },
+    },
+  );
+  const attached = activities.filter(
+    (activity) => activity.labWorkspaceId === String(workspace._id),
+  );
+  console.log(
+    JSON.stringify(
+      {
+        workspaceId: String(workspace._id),
+        files: workspace.files.length,
+        learnerFiles: workspace.files.filter(
+          (file) => file.audience === "learner",
+        ).length,
+        facilitatorFiles: workspace.files.filter(
+          (file) => file.audience === "facilitator",
+        ).length,
+        attachedActivities: attached.map((activity) => activity.title),
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  await mongoose.disconnect();
+}
+
+async function upload(bucket, bytes, filename, contentType) {
+  const stream = bucket.openUploadStream(filename, {
+    contentType,
+    metadata: { private: true },
+  });
+  await new Promise((resolve, reject) =>
+    Readable.from(bytes).pipe(stream).on("finish", resolve).on("error", reject),
+  );
+  return stream.id;
+}
+function findCommonRoot(paths) {
+  const roots = new Set(paths.map((item) => item.split("/")[0]));
+  return roots.size === 1 && paths.every((item) => item.includes("/"))
+    ? [...roots][0]
+    : undefined;
+}
+function parseManifest(value) {
+  const rows = parseCsv(value);
+  const headers = rows.shift().map((cell) => cell.trim().toLowerCase());
+  const pathIndex = headers.indexOf("path");
+  const audienceIndex = headers.indexOf("audience");
+  const purposeIndex = headers.indexOf("purpose");
+  const result = new Map();
+  for (const row of rows) {
+    const entryPath = row[pathIndex]?.trim().toLowerCase();
+    if (entryPath)
+      result.set(entryPath, {
+        audience:
+          row[audienceIndex]?.trim().toLowerCase() === "facilitator"
+            ? "facilitator"
+            : "learner",
+        purpose: row[purposeIndex]?.trim() || undefined,
+      });
+  }
+  return result;
+}
+function parseCsv(value) {
+  const rows = [];
+  let row = [],
+    cell = "",
+    quoted = false;
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value[i];
+    if (char === '"') {
+      if (quoted && value[i + 1] === '"') {
+        cell += '"';
+        i += 1;
+      } else quoted = !quoted;
+    } else if (char === "," && !quoted) {
+      row.push(cell);
+      cell = "";
+    } else if ((char === "\n" || char === "\r") && !quoted) {
+      if (char === "\r" && value[i + 1] === "\n") i += 1;
+      row.push(cell);
+      if (row.some(Boolean)) rows.push(row);
+      row = [];
+      cell = "";
+    } else cell += char;
+  }
+  row.push(cell);
+  if (row.some(Boolean)) rows.push(row);
+  return rows;
+}
+function mimeFor(filePath) {
+  const extension = path.posix.extname(filePath).toLowerCase();
+  return (
+    {
+      ".md": "text/markdown; charset=utf-8",
+      ".txt": "text/plain; charset=utf-8",
+      ".csv": "text/csv; charset=utf-8",
+      ".json": "application/json; charset=utf-8",
+      ".pdf": "application/pdf",
+      ".docx":
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      ".xlsx":
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      ".png": "image/png",
+      ".jpg": "image/jpeg",
+      ".jpeg": "image/jpeg",
+    }[extension] || "application/octet-stream"
+  );
+}

--- a/apps/commons-courses/types/lab-workspace.ts
+++ b/apps/commons-courses/types/lab-workspace.ts
@@ -1,0 +1,35 @@
+export type LabWorkspaceVisibility = "course" | "live";
+export type LabWorkspaceAudience = "learner" | "facilitator";
+
+export type LabWorkspaceFileRecord = {
+  id: string;
+  path: string;
+  name: string;
+  mimeType: string;
+  size: number;
+  audience: LabWorkspaceAudience;
+  purpose?: string;
+  editable: boolean;
+  preview?: string;
+  url: string;
+  downloadUrl: string;
+};
+
+export type LabWorkspaceRecord = {
+  id: string;
+  courseId: string;
+  courseSlug: string;
+  title: string;
+  description?: string;
+  instructions?: string;
+  visibility: LabWorkspaceVisibility;
+  sourceFileName: string;
+  learnerFileCount: number;
+  facilitatorFileCount: number;
+  learnerPackSize: number;
+  learnerPackDownloadUrl: string;
+  facilitatorPackDownloadUrl?: string;
+  files: LabWorkspaceFileRecord[];
+  createdAt: string;
+  updatedAt: string;
+};

--- a/apps/commons-courses/types/live-session.ts
+++ b/apps/commons-courses/types/live-session.ts
@@ -31,6 +31,7 @@ export type LiveActivity = {
   facilitatorNotes?: string;
   resourceUrl?: string;
   materialId?: string;
+  labWorkspaceId?: string;
   estimatedMinutes?: number;
   status: LiveActivityStatus;
   required: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,7 +181,7 @@ importers:
         version: 1.3.23(@langchain/core@1.1.33(@opentelemetry/api@1.9.0)(openai@4.95.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@langchain/community':
         specifier: 1.1.24
-        version: 1.1.24(b4aa2f79bfad4c585553bf368fecd6df)
+        version: 1.1.24(ylubjowplmvn2xfjilsbjdn7oe)
       '@langchain/core':
         specifier: 1.1.33
         version: 1.1.33(@opentelemetry/api@1.9.0)(openai@4.95.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -758,6 +758,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lucide-react:
         specifier: ^0.474.0
         version: 0.474.0(react@19.2.4)
@@ -7095,6 +7098,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -16970,7 +16974,7 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/community@1.1.24(b4aa2f79bfad4c585553bf368fecd6df)':
+  '@langchain/community@1.1.24(ylubjowplmvn2xfjilsbjdn7oe)':
     dependencies:
       '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.51.0)(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@16.4.7)(encoding@0.1.13)(openai@4.95.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@ibm-cloud/watsonx-ai': 1.5.1(@langchain/core@1.1.33(@opentelemetry/api@1.9.0)(openai@4.95.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))


### PR DESCRIPTION
## What changed

- adds private, reusable lab workspaces for course lessons and live activities
- imports structured ZIP packs with manifest-driven learner/facilitator audiences
- provides responsive file navigation, inline PDF/image viewing, editable local text working copies, and individual/full-pack downloads
- adds educator upload, preview, attachment, visibility, and deletion controls
- adds an idempotent importer that attaches the exact Moringa pack to practical workshop activities

## Why

Educators need a clean way to prepare the source files learners need for practical work without exposing facilitator references or forcing learners to manage an unstructured collection of downloads.

## Security and access

- all content is stored privately in GridFS
- every file and archive request re-checks enrollment, live attendance, or course-manager access
- facilitator-only files are removed from learner API payloads and generated learner packs
- ZIP paths, file counts, per-file sizes, and total expanded size are validated

## Validation

- `pnpm --filter commons-courses test` (15 passing)
- `pnpm --filter commons-courses lint`
- `pnpm --filter commons-courses exec tsc --noEmit`
- `pnpm --filter commons-courses build` with the Commons Courses environment loaded
