### PR TITLE
Guide learners to live lab materials

### DIFF
--- a/apps/commons-courses/components/educator/live-facilitator-studio.tsx
+++ b/apps/commons-courses/components/educator/live-facilitator-studio.tsx
@@ -30,6 +30,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getCourseThemeStyle } from "@/lib/course-theme";
+import { labWorkspaceFolderPaths } from "@/lib/lab-workspace-entry";
 import type {
   LiveActivity,
   LiveActivityResults,
@@ -118,7 +119,9 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
     void fetch(`/api/educator/courses/${slug}/materials`, { cache: "no-store" })
       .then((res) => (res.ok ? res.json() : null))
       .then((body) => setMaterials(body?.materials || []));
-    void fetch(`/api/educator/courses/${slug}/lab-workspaces`, { cache: "no-store" })
+    void fetch(`/api/educator/courses/${slug}/lab-workspaces`, {
+      cache: "no-store",
+    })
       .then((res) => (res.ok ? res.json() : null))
       .then((body) => setLabWorkspaces(body?.workspaces || []));
   }, [data?.session.courseSlug]);
@@ -796,7 +799,11 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
                 ) : null}
                 {current.labWorkspaceId ? (
                   <div className="border-b border-slate-100 p-4 sm:p-6">
-                    <LearnerLabWorkspace workspaceId={current.labWorkspaceId} compact />
+                    <LearnerLabWorkspace
+                      workspaceId={current.labWorkspaceId}
+                      entryPath={current.labEntryPath}
+                      compact
+                    />
                   </div>
                 ) : null}
                 <LiveResults
@@ -1231,6 +1238,13 @@ function ActivityEditor({
       ],
     });
   }
+  const selectedLabWorkspace = labWorkspaces.find(
+    (workspace) => workspace.id === activity.labWorkspaceId,
+  );
+  const learnerLabFiles = (selectedLabWorkspace?.files || []).filter(
+    (file) => file.audience === "learner",
+  );
+  const labFolders = labWorkspaceFolderPaths(learnerLabFiles);
   return (
     <section className="rounded-2xl border border-slate-200 bg-white p-5 sm:p-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -1352,7 +1366,10 @@ function ActivityEditor({
           <select
             value={activity.labWorkspaceId || ""}
             onChange={(event) =>
-              onChange({ labWorkspaceId: event.target.value || undefined })
+              onChange({
+                labWorkspaceId: event.target.value || undefined,
+                labEntryPath: undefined,
+              })
             }
             className={inputClass}
           >
@@ -1364,6 +1381,40 @@ function ActivityEditor({
             ))}
           </select>
         </Field>
+        {selectedLabWorkspace ? (
+          <Field label="Open learners at">
+            <select
+              value={activity.labEntryPath || ""}
+              onChange={(event) =>
+                onChange({ labEntryPath: event.target.value || undefined })
+              }
+              className={inputClass}
+            >
+              <option value="">Workspace home</option>
+              {labFolders.length ? (
+                <optgroup label="Folders">
+                  {labFolders.map((path) => (
+                    <option key={path} value={path}>
+                      {labPathLabel(path)}
+                    </option>
+                  ))}
+                </optgroup>
+              ) : null}
+              {learnerLabFiles.length ? (
+                <optgroup label="Files">
+                  {learnerLabFiles.map((file) => (
+                    <option key={file.id} value={file.path}>
+                      {labPathLabel(file.path)}
+                    </option>
+                  ))}
+                </optgroup>
+              ) : null}
+            </select>
+            <span className="mt-1.5 block text-[11px] leading-5 text-slate-400">
+              Learners land here when this activity is presented.
+            </span>
+          </Field>
+        ) : null}
         <Field label="External resource link">
           <input
             type="url"
@@ -1708,6 +1759,17 @@ function ShareRow({ label, value }: { label: string; value: string }) {
 }
 function activityLabel(type: LiveActivityType) {
   return activityChoices.find((choice) => choice.type === type)?.label || type;
+}
+function labPathLabel(path: string) {
+  return path
+    .split("/")
+    .map((segment) =>
+      segment
+        .replace(/\.[^.]+$/, "")
+        .replace(/^\d+_/, "")
+        .replaceAll("_", " "),
+    )
+    .join(" › ");
 }
 function formatCode(code: string) {
   return `${code.slice(0, 3)} ${code.slice(3)}`;

--- a/apps/commons-courses/components/labs/learner-lab-workspace.tsx
+++ b/apps/commons-courses/components/labs/learner-lab-workspace.tsx
@@ -23,6 +23,7 @@ import {
   X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { resolveLabWorkspaceEntry } from "@/lib/lab-workspace-entry";
 import type {
   LabWorkspaceFileRecord,
   LabWorkspaceRecord,
@@ -35,9 +36,11 @@ type FolderIndex = Map<
 
 export function LearnerLabWorkspace({
   workspaceId,
+  entryPath,
   compact = false,
 }: {
   workspaceId: string;
+  entryPath?: string;
   compact?: boolean;
 }) {
   const [workspace, setWorkspace] = useState<LabWorkspaceRecord | null>(null);
@@ -54,13 +57,28 @@ export function LearnerLabWorkspace({
         const body = await response.json().catch(() => ({}));
         if (!response.ok)
           throw new Error(body.error || "Could not open this lab.");
-        if (active) setWorkspace(body.workspace);
+        if (!active) return;
+        const next = body.workspace as LabWorkspaceRecord;
+        const entry = resolveLabWorkspaceEntry(next.files, entryPath);
+        setError("");
+        setWorkspace(next);
+        setFolderPath(entry.folderPath);
+        setOpenFile(entry.file || null);
+        setWorkingCopy(
+          entry.file
+            ? (window.localStorage.getItem(
+                storageKey(workspaceId, entry.file.id),
+              ) ??
+                entry.file.preview ??
+                "")
+            : "",
+        );
       })
       .catch((reason) => active && setError(reason.message));
     return () => {
       active = false;
     };
-  }, [workspaceId]);
+  }, [entryPath, workspaceId]);
 
   const folders = useMemo(
     () => buildFolderIndex(workspace?.files || []),

--- a/apps/commons-courses/components/live/live-learner-room.tsx
+++ b/apps/commons-courses/components/live/live-learner-room.tsx
@@ -23,6 +23,7 @@ import {
   LoaderCircle,
   LockKeyhole,
   Radio,
+  Save,
   Send,
   Users,
   X,
@@ -32,6 +33,10 @@ import { CourseMaterialViewer } from "@/components/course-material-viewer";
 import { LearnerLabWorkspace } from "@/components/labs/learner-lab-workspace";
 import { cn } from "@/lib/utils";
 import { getCourseThemeStyle } from "@/lib/course-theme";
+import {
+  canReviseLiveResponse,
+  sameLiveResponseValue,
+} from "@/lib/live-response-policy";
 import {
   learnerAvailableActivities,
   resolveLearnerActivitySelection,
@@ -405,8 +410,14 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
             <p className="truncate text-xs font-bold sm:text-sm">
               {session.title}
             </p>
-            <p className="text-[9px] font-bold uppercase tracking-widest text-red-600 sm:text-[10px]">
-              {session.status === "ended" ? "Session ended" : "Live now"}
+            <p className="mt-0.5 inline-flex items-center gap-1.5 text-[9px] font-medium text-slate-500 sm:text-[10px]">
+              <span
+                className={cn(
+                  "h-1.5 w-1.5 rounded-full",
+                  session.status === "live" ? "bg-emerald-500" : "bg-slate-300",
+                )}
+              />
+              {session.status === "live" ? "Live" : "Not live"}
             </p>
           </div>
           <span
@@ -773,6 +784,10 @@ function LearnerActivity({
 }) {
   const isChoice = activity.options.length > 0;
   const result = activity.status === "closed" && activity.showResults;
+  const canRevisePoll = canReviseLiveResponse(activity);
+  const responseChanged = response
+    ? !sameLiveResponseValue(value, response.value)
+    : false;
   return (
     <article className="overflow-hidden rounded-2xl border border-slate-200 bg-[var(--course-surface)]">
       <div className="p-6 sm:p-9">
@@ -825,7 +840,11 @@ function LearnerActivity({
       ) : null}
       {activity.labWorkspaceId ? (
         <div className="border-t border-slate-100 p-4 sm:p-6">
-          <LearnerLabWorkspace workspaceId={activity.labWorkspaceId} compact />
+          <LearnerLabWorkspace
+            workspaceId={activity.labWorkspaceId}
+            entryPath={activity.labEntryPath}
+            compact
+          />
         </div>
       ) : null}
       {isChoice ? (
@@ -838,7 +857,10 @@ function LearnerActivity({
               return (
                 <button
                   key={option.id}
-                  disabled={activity.status !== "open" || Boolean(response)}
+                  disabled={
+                    activity.status !== "open" ||
+                    (Boolean(response) && !canRevisePoll)
+                  }
                   onClick={() => onChange(option.id)}
                   className={cn(
                     "min-h-16 rounded-xl border bg-white p-4 text-left text-sm font-bold transition",
@@ -859,7 +881,23 @@ function LearnerActivity({
               );
             })}
           </div>
-          {response ? (
+          {response && canRevisePoll ? (
+            <>
+              <Saved message="Response saved · You can change it while the poll is open" />
+              <button
+                onClick={() => onSubmit()}
+                disabled={!value || submitting || !responseChanged}
+                className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-slate-950 px-5 py-3 text-sm font-bold text-white disabled:opacity-40"
+              >
+                {submitting ? (
+                  <LoaderCircle className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="h-4 w-4" />
+                )}
+                {responseChanged ? "Update response" : "Response is up to date"}
+              </button>
+            </>
+          ) : response ? (
             <Saved />
           ) : activity.status !== "open" ? (
             <ResponsesClosed />
@@ -935,10 +973,10 @@ function LearnerActivity({
   );
 }
 
-function Saved() {
+function Saved({ message = "Response saved" }: { message?: string }) {
   return (
     <div className="mt-3 flex items-center justify-center gap-2 rounded-xl bg-emerald-50 px-4 py-3 text-sm font-bold text-emerald-700">
-      <CheckCircle2 className="h-4 w-4" /> Response saved
+      <CheckCircle2 className="h-4 w-4 shrink-0" /> {message}
     </div>
   );
 }

--- a/apps/commons-courses/lib/educator-copilot-tools.ts
+++ b/apps/commons-courses/lib/educator-copilot-tools.ts
@@ -353,6 +353,16 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
                 description:
                   "ID of a private course material to present inside this activity.",
               },
+              labWorkspaceId: {
+                type: "string",
+                description:
+                  "ID of a private lab workspace to embed in this activity.",
+              },
+              labEntryPath: {
+                type: "string",
+                description:
+                  "Optional learner-visible file or folder path inside the selected lab workspace. Use this to land learners directly at the materials needed for the activity.",
+              },
               estimatedMinutes: { type: "number" },
               required: { type: "boolean" },
               randomizeOptions: { type: "boolean" },

--- a/apps/commons-courses/lib/lab-workspace-entry.test.mts
+++ b/apps/commons-courses/lib/lab-workspace-entry.test.mts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { LabWorkspaceFileRecord } from "../types/lab-workspace.ts";
+import { resolveLabWorkspaceEntry } from "./lab-workspace-entry.ts";
+
+const files = [
+  file("04_Block2_Assistant/zawadi_monday_inbox.md"),
+  file("04_Block2_Assistant/Recording_Lab/Roleplay_Script.md"),
+];
+
+test("opens an exact contextual lab artifact", () => {
+  const entry = resolveLabWorkspaceEntry(
+    files,
+    "04_Block2_Assistant/zawadi_monday_inbox.md",
+  );
+  assert.equal(entry.folderPath, "04_Block2_Assistant");
+  assert.equal(entry.file?.path, "04_Block2_Assistant/zawadi_monday_inbox.md");
+});
+
+test("opens a contextual lab folder and falls back to its nearest parent", () => {
+  assert.deepEqual(
+    resolveLabWorkspaceEntry(files, "04_Block2_Assistant/Recording_Lab"),
+    { folderPath: "04_Block2_Assistant/Recording_Lab" },
+  );
+  assert.deepEqual(
+    resolveLabWorkspaceEntry(files, "04_Block2_Assistant/missing.txt"),
+    { folderPath: "04_Block2_Assistant" },
+  );
+});
+
+function file(path: string): LabWorkspaceFileRecord {
+  return {
+    id: path,
+    path,
+    name: path.split("/").at(-1) || path,
+    mimeType: "text/markdown",
+    size: 10,
+    audience: "learner",
+    editable: true,
+    url: "/file",
+    downloadUrl: "/file?download=1",
+  };
+}

--- a/apps/commons-courses/lib/lab-workspace-entry.ts
+++ b/apps/commons-courses/lib/lab-workspace-entry.ts
@@ -1,0 +1,65 @@
+import type { LabWorkspaceFileRecord } from "@/types/lab-workspace";
+
+export type LabWorkspaceEntry = {
+  folderPath: string;
+  file?: LabWorkspaceFileRecord;
+};
+
+export function resolveLabWorkspaceEntry(
+  files: LabWorkspaceFileRecord[],
+  requestedPath?: string,
+): LabWorkspaceEntry {
+  const target = normalize(requestedPath);
+  if (!target) return { folderPath: "" };
+
+  const file = files.find((candidate) => normalize(candidate.path) === target);
+  if (file) return { folderPath: parentPath(file.path), file };
+
+  const folders = new Map<string, string>();
+  for (const candidate of files) {
+    const segments = candidate.path.split("/");
+    segments.pop();
+    for (let index = 1; index <= segments.length; index += 1) {
+      const path = segments.slice(0, index).join("/");
+      folders.set(normalize(path), path);
+    }
+  }
+
+  let candidate = target;
+  while (candidate) {
+    const folder = folders.get(candidate);
+    if (folder) return { folderPath: folder };
+    candidate = candidate.split("/").slice(0, -1).join("/");
+  }
+  return { folderPath: "" };
+}
+
+export function labWorkspaceFolderPaths(files: LabWorkspaceFileRecord[]) {
+  const folders = new Set<string>();
+  for (const file of files.filter(
+    (candidate) => candidate.audience === "learner",
+  )) {
+    const segments = file.path.split("/");
+    segments.pop();
+    for (let index = 1; index <= segments.length; index += 1) {
+      folders.add(segments.slice(0, index).join("/"));
+    }
+  }
+  return [...folders].sort(naturalCompare);
+}
+
+function normalize(value?: string) {
+  return (value || "")
+    .trim()
+    .replaceAll("\\", "/")
+    .replace(/^\/+|\/+$/g, "")
+    .toLowerCase();
+}
+
+function parentPath(value: string) {
+  return value.split("/").slice(0, -1).join("/");
+}
+
+function naturalCompare(a: string, b: string) {
+  return a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" });
+}

--- a/apps/commons-courses/lib/live-response-policy.test.mts
+++ b/apps/commons-courses/lib/live-response-policy.test.mts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { LiveActivity } from "../types/live-session.ts";
+import {
+  canReviseLiveResponse,
+  sameLiveResponseValue,
+} from "./live-response-policy.ts";
+
+test("allows saved poll answers to change only while the poll is open", () => {
+  assert.equal(canReviseLiveResponse(activity("poll", "open")), true);
+  assert.equal(canReviseLiveResponse(activity("poll", "closed")), false);
+  assert.equal(canReviseLiveResponse(activity("quiz", "open")), false);
+});
+
+test("compares current and saved response values", () => {
+  assert.equal(sameLiveResponseValue("option-a", "option-a"), true);
+  assert.equal(sameLiveResponseValue("option-b", "option-a"), false);
+  assert.equal(sameLiveResponseValue(["b", "a"], ["a", "b"]), true);
+});
+
+function activity(
+  type: LiveActivity["type"],
+  status: LiveActivity["status"],
+): LiveActivity {
+  return {
+    id: "activity",
+    type,
+    title: "Activity",
+    status,
+    required: false,
+    randomizeOptions: false,
+    showResults: false,
+    points: 0,
+    options: [],
+  };
+}

--- a/apps/commons-courses/lib/live-response-policy.ts
+++ b/apps/commons-courses/lib/live-response-policy.ts
@@ -1,0 +1,16 @@
+import type { LiveActivity } from "@/types/live-session";
+
+export function canReviseLiveResponse(activity: LiveActivity) {
+  return activity.type === "poll" && activity.status === "open";
+}
+
+export function sameLiveResponseValue(
+  current: string | string[] | undefined,
+  saved: string | string[],
+) {
+  const normalize = (value: string | string[] | undefined) =>
+    Array.isArray(value) ? [...value].map(String).sort() : String(value || "");
+  return (
+    JSON.stringify(normalize(current)) === JSON.stringify(normalize(saved))
+  );
+}

--- a/apps/commons-courses/lib/live-session-input.ts
+++ b/apps/commons-courses/lib/live-session-input.ts
@@ -39,6 +39,7 @@ export function createActivity(
     resourceUrl: cleanUrl(input.resourceUrl),
     materialId: clean(input.materialId),
     labWorkspaceId: clean(input.labWorkspaceId),
+    labEntryPath: cleanLabEntryPath(input.labEntryPath),
     estimatedMinutes: clampNumber(input.estimatedMinutes, 1, 480),
     status:
       input.status === "open" || input.status === "closed"
@@ -50,6 +51,20 @@ export function createActivity(
     points: clampNumber(input.points, 0, 10_000) || 0,
     options: normalizeOptions(input.options),
   };
+}
+
+function cleanLabEntryPath(value: unknown) {
+  const normalized = clean(value)?.replaceAll("\\", "/").replace(/^\/+/, "");
+  if (
+    !normalized ||
+    normalized.length > 500 ||
+    normalized
+      .split("/")
+      .some((segment) => !segment || segment === "." || segment === "..")
+  ) {
+    return undefined;
+  }
+  return normalized;
 }
 
 export function normalizeActivities(input: unknown): LiveActivity[] {

--- a/apps/commons-courses/models/LiveSession.ts
+++ b/apps/commons-courses/models/LiveSession.ts
@@ -60,6 +60,7 @@ const LiveActivitySchema = new Schema<LiveActivity>(
     resourceUrl: { type: String, trim: true },
     materialId: { type: String, trim: true },
     labWorkspaceId: { type: String, trim: true },
+    labEntryPath: { type: String, trim: true },
     estimatedMinutes: { type: Number, min: 1, max: 480 },
     status: {
       type: String,

--- a/apps/commons-courses/package.json
+++ b/apps/commons-courses/package.json
@@ -18,7 +18,8 @@
     "set:ai-quick-wins-start-date": "node scripts/set-ai-quick-wins-start-date.mjs",
     "migrate:moringa-workshop-course": "node scripts/migrate-moringa-workshop-course.mjs",
     "import:moringa-lab-workspace": "node scripts/import-moringa-lab-workspace.mjs",
-    "replace:moringa-lab-workspace": "node --experimental-strip-types scripts/replace-moringa-lab-workspace.mjs"
+    "replace:moringa-lab-workspace": "node --experimental-strip-types scripts/replace-moringa-lab-workspace.mjs",
+    "set:moringa-lab-entry-paths": "node scripts/set-moringa-lab-entry-paths.mjs"
   },
   "dependencies": {
     "@agent-commons/sdk": "workspace:*",

--- a/apps/commons-courses/scripts/set-moringa-lab-entry-paths.mjs
+++ b/apps/commons-courses/scripts/set-moringa-lab-entry-paths.mjs
@@ -1,0 +1,108 @@
+import mongoose from "mongoose";
+
+const mongoUri = process.env.MONGODB_URI;
+const sessionId = "6a7d76665ca03a4a097ff615";
+const workspaceId = "6a7e4b847bae35c601e113f9";
+const dryRun = process.argv.includes("--dry-run");
+
+const entryPaths = new Map([
+  ["Claude and Cowork setup check", "01_Setup/Pre_Workshop_Setup_Guide.md"],
+  ["Lab 1: ask well", "03_Block1_Ask_Well"],
+  [
+    "Lab 2A: clear the Zawadi inbox",
+    "04_Block2_Assistant/zawadi_monday_inbox.md",
+  ],
+  ["Lab 2B: run the Zawadi desk", "04_Block2_Assistant/Recording_Lab"],
+  ["Everyday-work gallery: five live demos", "05_Block3_Gallery"],
+  ["Lab 3: pick what fits your work", "05_Block3_Gallery"],
+  ["Gallery pair share", "05_Block3_Gallery"],
+  [
+    "Build a Skill: trigger, instructions, and test",
+    "06_Block4_Skills/Skill_Gallery",
+  ],
+  ["Lab 4: build and test your Skill", "06_Block4_Skills"],
+  [
+    "Work safely and connect only what you need",
+    "07_Block5_Safety/Responsible_Use_Checklist.pdf",
+  ],
+  ["Lab 5: de-risk a real workflow", "07_Block5_Safety"],
+  ["Your first-week plan", "08_Block6_Plan/First_Week_Plan.md"],
+]);
+
+if (!mongoUri) {
+  console.error("MONGODB_URI is required.");
+  process.exit(1);
+}
+
+await mongoose.connect(mongoUri);
+try {
+  const db = mongoose.connection.db;
+  if (!db) throw new Error("MongoDB connection is unavailable.");
+  const objectId = new mongoose.Types.ObjectId(sessionId);
+  const workspaceObjectId = new mongoose.Types.ObjectId(workspaceId);
+  const [session, workspace] = await Promise.all([
+    db.collection("livesessions").findOne({ _id: objectId }),
+    db.collection("labworkspaces").findOne({ _id: workspaceObjectId }),
+  ]);
+  if (!session) throw new Error("The Moringa live session was not found.");
+  if (!workspace) throw new Error("The Moringa lab workspace was not found.");
+
+  const availablePaths = workspace.files.map((file) => file.path);
+  for (const target of entryPaths.values()) {
+    const exists = availablePaths.some(
+      (candidate) => candidate === target || candidate.startsWith(`${target}/`),
+    );
+    if (!exists) throw new Error(`Lab entry target does not exist: ${target}`);
+  }
+
+  const matched = [];
+  let changed = false;
+  const activities = session.activities.map((activity) => {
+    const labEntryPath = entryPaths.get(activity.title);
+    if (!labEntryPath) return activity;
+    matched.push(activity.title);
+    if (
+      activity.labWorkspaceId === workspaceId &&
+      activity.labEntryPath === labEntryPath
+    ) {
+      return activity;
+    }
+    changed = true;
+    return { ...activity, labWorkspaceId: workspaceId, labEntryPath };
+  });
+  if (matched.length !== entryPaths.size) {
+    const missing = [...entryPaths.keys()].filter(
+      (title) => !matched.includes(title),
+    );
+    throw new Error(`Could not find mapped activities: ${missing.join(", ")}`);
+  }
+  if (changed && !dryRun) {
+    await db.collection("livesessions").updateOne(
+      { _id: objectId },
+      {
+        $set: { activities, updatedAt: new Date() },
+        $inc: { stateVersion: 1 },
+      },
+    );
+  }
+  console.log(
+    JSON.stringify(
+      {
+        sessionId,
+        workspaceId,
+        changed,
+        dryRun,
+        mappedActivities: activities
+          .filter((activity) => entryPaths.has(activity.title))
+          .map((activity) => ({
+            title: activity.title,
+            labEntryPath: activity.labEntryPath,
+          })),
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  await mongoose.disconnect();
+}

--- a/apps/commons-courses/types/live-session.ts
+++ b/apps/commons-courses/types/live-session.ts
@@ -32,6 +32,7 @@ export type LiveActivity = {
   resourceUrl?: string;
   materialId?: string;
   labWorkspaceId?: string;
+  labEntryPath?: string;
   estimatedMinutes?: number;
   status: LiveActivityStatus;
   required: boolean;


### PR DESCRIPTION
## What changed

- Added an optional per-activity lab entry target so a live activity can open learners directly at a specific lab folder or artifact.
- Added an educator-facing “Open learners at” selector populated from the selected workspace’s learner-visible folders and files.
- Updated the learner and facilitator previews to honor the selected entry target, including resilient nearest-folder fallback.
- Added a validated, idempotent Moringa mapping for all 12 lab-linked activities.
- Replaced the red “Live now” label with a quiet green or grey status dot and minimal text.
- Allowed learners to revise a saved poll response while the poll remains open; quizzes and other submitted activities remain locked.
- Extended educator copilot live-session authoring to understand contextual lab targets.

## Why

Learners were being dropped at the root of a 36-file workspace during focused exercises and had to discover the correct material themselves. Polls were also locked immediately after the first submission despite the response endpoint already supporting safe updates.

## Impact

Applicable live activities now open at the material needed for that moment. Educators can configure the behavior for any future lab workspace without code changes, and active polls clearly support answer changes.

## Validation

- `pnpm --filter commons-courses test` — 20 passing
- `pnpm --filter commons-courses exec tsc --noEmit`
- `pnpm --filter commons-courses lint`
- `pnpm --filter commons-courses build`
- Production Moringa mapping dry run validated 12 activity targets against the current 36-file workspace
