### PR TITLE
Fix computer wake metering

### DIFF
--- a/apps/commons-api/.env.example
+++ b/apps/commons-api/.env.example
@@ -109,6 +109,8 @@ OPENAI_IMAGE_OUTPUT_PRICE_USD_JSON=""
 
 # ── Compute metering + tier gating (Phase 5) ──────────────────────────────
 COMPUTE_METERING_ENABLED="true"
+# Safety ceiling for a single delayed metering tick (valid range: 1-60).
+COMPUTE_MAX_CATCH_UP_MINUTES="10"
 BILLING_ENFORCEMENT="true"
 # Optional JSON override of credits/min per profile, e.g.
 # {"starter":2,"standard":7,"performance":14,"gpu":70}

--- a/apps/commons-api/src/computer/compute-metering.service.spec.ts
+++ b/apps/commons-api/src/computer/compute-metering.service.spec.ts
@@ -1,0 +1,121 @@
+import { ComputeMeteringService } from './compute-metering.service';
+
+describe('ComputeMeteringService', () => {
+  const now = new Date('2026-08-16T20:13:29.000Z');
+  const previousMaxCatchUp = process.env.COMPUTE_MAX_CATCH_UP_MINUTES;
+  let service: ComputeMeteringService;
+  let credits: {
+    getBalance: jest.Mock;
+    record: jest.Mock;
+  };
+  let insertValues: jest.Mock;
+  let updateSet: jest.Mock;
+
+  beforeEach(() => {
+    insertValues = jest.fn().mockReturnValue({
+      onConflictDoNothing: jest.fn().mockResolvedValue(undefined),
+    });
+    updateSet = jest.fn().mockReturnValue({
+      where: jest.fn().mockResolvedValue(undefined),
+    });
+    const db = {
+      insert: jest.fn().mockReturnValue({ values: insertValues }),
+      update: jest.fn().mockReturnValue({ set: updateSet }),
+    };
+    credits = {
+      getBalance: jest
+        .fn()
+        .mockResolvedValue({ balance: 10_000, reserved: 0, available: 10_000 }),
+      record: jest.fn().mockResolvedValue({ entryId: 'entry_1' }),
+    };
+    service = new ComputeMeteringService(
+      db as any,
+      credits as any,
+      { stopComputer: jest.fn() } as any,
+    );
+    delete process.env.COMPUTE_MAX_CATCH_UP_MINUTES;
+  });
+
+  afterEach(() => {
+    if (previousMaxCatchUp === undefined) {
+      delete process.env.COMPUTE_MAX_CATCH_UP_MINUTES;
+    } else {
+      process.env.COMPUTE_MAX_CATCH_UP_MINUTES = previousMaxCatchUp;
+    }
+  });
+
+  it('caps a stale cursor instead of charging the entire inactive gap', async () => {
+    const staleCursor = new Date(now.getTime() - 642 * 60_000);
+
+    await (service as any).meterInstance(
+      {
+        computerId: '11111111-1111-4111-8111-111111111111',
+        agentId: 'agent_1',
+        ownerUserId: 'user_1',
+        workspaceId: null,
+        resourceProfile: 'standard',
+        startedAt: staleCursor,
+        meteredThroughAt: staleCursor,
+        status: 'running',
+      },
+      now,
+    );
+
+    expect(credits.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 70,
+        description: 'Computer use (standard) 10m',
+        idempotencyKey: `compute:11111111-1111-4111-8111-111111111111:${staleCursor.toISOString()}`,
+        metadata: expect.objectContaining({
+          minutes: 10,
+          perMin: 7,
+          catchUpCappedFromMinutes: 642,
+        }),
+      }),
+    );
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intervalStart: new Date(now.getTime() - 10 * 60_000),
+        intervalEnd: now,
+        minutes: 10,
+        creditsCharged: 70,
+      }),
+    );
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ meteredThroughAt: now }),
+    );
+  });
+
+  it('charges ordinary minute intervals without rebasing them', async () => {
+    const cursor = new Date(now.getTime() - 3 * 60_000);
+
+    await (service as any).meterInstance(
+      {
+        computerId: '22222222-2222-4222-8222-222222222222',
+        agentId: 'agent_1',
+        ownerUserId: 'user_1',
+        workspaceId: null,
+        resourceProfile: 'standard',
+        startedAt: cursor,
+        meteredThroughAt: cursor,
+        status: 'running',
+      },
+      now,
+    );
+
+    expect(credits.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 21,
+        description: 'Computer use (standard) 3m',
+        metadata: {
+          computerId: '22222222-2222-4222-8222-222222222222',
+          minutes: 3,
+          perMin: 7,
+        },
+      }),
+    );
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ meteredThroughAt: now }),
+    );
+  });
+});

--- a/apps/commons-api/src/computer/compute-metering.service.ts
+++ b/apps/commons-api/src/computer/compute-metering.service.ts
@@ -110,11 +110,28 @@ export class ComputeMeteringService implements OnModuleInit, OnModuleDestroy {
     const cursor: Date = inst.meteredThroughAt ?? inst.startedAt;
     if (!cursor) return; // never started — nothing to meter
     const elapsedMs = now.getTime() - new Date(cursor).getTime();
-    let minutes = Math.floor(elapsedMs / 60_000);
-    if (minutes <= 0) return;
+    const elapsedMinutes = Math.floor(elapsedMs / 60_000);
+    if (elapsedMinutes <= 0) return;
 
-    const intervalStart = new Date(cursor);
-    let intervalEnd = new Date(new Date(cursor).getTime() + minutes * 60_000);
+    // Metering normally runs every minute. A much older cursor indicates a
+    // lifecycle discontinuity or an extended metering outage; blindly billing
+    // the entire gap can charge sleeping time and empty a user's account in a
+    // single tick. Bound catch-up and rebase the cursor to now so the same gap
+    // cannot be charged repeatedly on subsequent ticks.
+    const maxCatchUpMinutes = this.maxCatchUpMinutes();
+    const rebased = elapsedMinutes > maxCatchUpMinutes;
+    let minutes = Math.min(elapsedMinutes, maxCatchUpMinutes);
+    let intervalStart = rebased
+      ? new Date(now.getTime() - minutes * 60_000)
+      : new Date(cursor);
+    let intervalEnd = rebased
+      ? now
+      : new Date(new Date(cursor).getTime() + minutes * 60_000);
+    if (rebased) {
+      this.logger.warn(
+        `Capping computer ${inst.computerId} catch-up from ${elapsedMinutes} to ${minutes} minutes`,
+      );
+    }
     const perMin = creditsPerMinute(inst.resourceProfile);
     const principalId = inst.ownerUserId;
     if (!principalId) {
@@ -123,7 +140,10 @@ export class ComputeMeteringService implements OnModuleInit, OnModuleDestroy {
       return;
     }
 
-    const idempotencyKey = `compute:${inst.computerId}:${intervalStart.toISOString()}`;
+    // Keep the persisted cursor in the key even when the displayed/billed
+    // interval is rebased. Concurrent API tasks that observe the same stale
+    // cursor must still converge on one ledger debit.
+    const idempotencyKey = `compute:${inst.computerId}:${new Date(cursor).toISOString()}`;
     const balance = await this.credits.getBalance({
       principalId,
     });
@@ -134,7 +154,12 @@ export class ComputeMeteringService implements OnModuleInit, OnModuleDestroy {
     }
     const exhaustedAfterCharge = affordableMinutes < minutes;
     minutes = Math.min(minutes, affordableMinutes);
-    intervalEnd = new Date(new Date(cursor).getTime() + minutes * 60_000);
+    if (rebased) {
+      intervalStart = new Date(now.getTime() - minutes * 60_000);
+      intervalEnd = now;
+    } else {
+      intervalEnd = new Date(new Date(cursor).getTime() + minutes * 60_000);
+    }
     const charge = perMin * minutes;
 
     const entry: any = await this.credits.record({
@@ -148,7 +173,12 @@ export class ComputeMeteringService implements OnModuleInit, OnModuleDestroy {
       idempotencyKey,
       description: `Computer use (${inst.resourceProfile}) ${minutes}m`,
       agentId: inst.agentId,
-      metadata: { computerId: inst.computerId, minutes, perMin },
+      metadata: {
+        computerId: inst.computerId,
+        minutes,
+        perMin,
+        ...(rebased ? { catchUpCappedFromMinutes: elapsedMinutes } : undefined),
+      },
       createdBy: 'metering',
     });
 
@@ -176,6 +206,12 @@ export class ComputeMeteringService implements OnModuleInit, OnModuleDestroy {
     await this.advanceCursor(inst.computerId, intervalEnd);
 
     if (exhaustedAfterCharge) await this.handleExhausted(inst, principalId);
+  }
+
+  private maxCatchUpMinutes(): number {
+    const configured = Number(process.env.COMPUTE_MAX_CATCH_UP_MINUTES ?? 10);
+    if (!Number.isFinite(configured)) return 10;
+    return Math.min(Math.max(Math.floor(configured), 1), 60);
   }
 
   private async advanceCursor(computerId: string, through: Date) {

--- a/apps/commons-api/src/computer/computer.service.spec.ts
+++ b/apps/commons-api/src/computer/computer.service.spec.ts
@@ -327,4 +327,82 @@ describe('ComputerService', () => {
       'agent_1',
     );
   });
+
+  it('starts a fresh metering window when a persistent computer wakes', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-16T20:13:29.000Z'));
+    const returning = jest.fn().mockResolvedValue([
+      {
+        computerId: '11111111-1111-4111-8111-111111111111',
+        status: 'running',
+      },
+    ]);
+    const set = jest.fn().mockReturnValue({
+      where: jest.fn().mockReturnValue({ returning }),
+    });
+    db.update.mockReturnValue({ set });
+    jest.spyOn(service as any, 'commonOsConfigured').mockReturnValue(true);
+    jest.spyOn(service as any, 'recordEvent').mockResolvedValue(undefined);
+    jest.spyOn(service as any, 'commonOsComputerRequest').mockResolvedValue({
+      _id: 'commonos_agent_1',
+      status: 'running',
+      desiredState: 'running',
+      // Providers may retain the original runtime timestamp across a wake.
+      startedAt: '2026-08-16T09:31:29.000Z',
+    });
+
+    try {
+      await (service as any).deployWithCommonOs({
+        agent: {
+          agentId: 'agent_1',
+          name: 'Test agent',
+          runtimeType: 'native',
+          runtimeConfig: {},
+          runtimeSecrets: {},
+          modelApiKey: null,
+          modelProvider: 'openai',
+          modelId: 'gpt-5',
+          ownerUserId: 'user_1',
+          owner: null,
+          workspaceId: null,
+        },
+        config: {
+          image: null,
+          region: null,
+          resourceProfile: 'standard',
+          resourceMode: 'elastic',
+          cpuRequest: '500m',
+          cpuLimit: '2',
+          memoryRequest: '1Gi',
+          memoryLimit: '4Gi',
+          storageLimit: '20Gi',
+          gpuType: null,
+          gpuCount: 0,
+          idleTtlMinutes: 60,
+          allowBrowser: true,
+          allowTerminal: true,
+          allowFilesystem: true,
+          networkAccess: 'standard',
+        },
+        computer: {
+          computerId: '11111111-1111-4111-8111-111111111111',
+          sessionId: null,
+          runtimeGeneration: 1,
+          persistentVolumeId: 'volume_1',
+          computeTenantId: null,
+          computeCellId: null,
+        },
+        name: 'Test agent computer',
+      });
+
+      expect(set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startedAt: new Date('2026-08-16T09:31:29.000Z'),
+          meteredThroughAt: new Date('2026-08-16T20:13:29.000Z'),
+          stoppedAt: null,
+        }),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/apps/commons-api/src/computer/computer.service.ts
+++ b/apps/commons-api/src/computer/computer.service.ts
@@ -1634,6 +1634,11 @@ export class ComputerService {
       throw new Error('CommonOS did not return an agent id');
     }
 
+    // A successful deploy can be either the first boot or a wake of the same
+    // persistent workspace. Start a fresh billing window in both cases. The
+    // previous metering cursor belongs to the prior runtime window and must
+    // never make sleeping time look like active computer use.
+    const meteringStartedAt = new Date();
     const [updated] = await this.db
       .update(schema.agentComputerInstance)
       .set({
@@ -1679,8 +1684,10 @@ export class ComputerService {
         errorMessage: commonOsAgent.pod?.lastError ?? null,
         startedAt: commonOsAgent.startedAt
           ? new Date(commonOsAgent.startedAt)
-          : new Date(),
-        updatedAt: new Date(),
+          : meteringStartedAt,
+        meteredThroughAt: meteringStartedAt,
+        stoppedAt: null,
+        updatedAt: meteringStartedAt,
       })
       .where(
         eq(schema.agentComputerInstance.computerId, args.computer.computerId),

--- a/docs/billing/credit-economics-2026-07.md
+++ b/docs/billing/credit-economics-2026-07.md
@@ -51,6 +51,9 @@ Top-ups are deliberately less generous than subscription allowances:
 - Active computer rates are 2/7/14/70 credits per minute for Starter,
   Standard, Performance, and GPU. Metering is wake-to-sleep. With no available
   credits the runtime is stopped; negative credit balances are not permitted.
+  Each wake starts a new metering window. Delayed ticks default to a 10-minute
+  catch-up ceiling so a stale lifecycle cursor cannot bill sleeping time or
+  drain an account in one pass.
 - Persistent workspace retention is included in the subscription computer slot.
   Storage remains measured internally. A future separately billed storage SKU
   should be added only after retained-GB telemetry is reliable; storage may grow


### PR DESCRIPTION
## What changed

- reset the compute metering cursor whenever a persistent computer successfully wakes
- cap abnormal delayed-meter catch-up at 10 minutes by default (configurable from 1 to 60 minutes)
- preserve cursor-based debit idempotency when a stale interval is rebased
- document the safety ceiling and add regression tests for both stale and normal metering

## Root cause

A persistent computer wake updated `startedAt` but retained the previous `meteredThroughAt`. The next metering tick therefore treated sleeping time as active use. At the Standard rate, the reported 4,494-credit debit corresponds exactly to 642 incorrectly accumulated minutes.

## Impact

Sleeping time can no longer roll into a new active billing window. A stale lifecycle cursor also cannot drain an account in one delayed tick.

## Validation

- `pnpm --filter commons-api test -- --runInBand computer/compute-metering.service.spec.ts computer/computer.service.spec.ts` (12 tests passed)
- `pnpm --filter commons-api build` (passed)
- `git diff --check` (passed)

Targeted ESLint could not run because the repository currently uses an ESLint 9 binary with a legacy `.eslintrc.json` and does not install its referenced `@remix-run/eslint-config`.
