### PR TITLE
Enroll learners when they join live rooms

### DIFF
--- a/apps/commons-courses/app/api/live-sessions/[id]/route.ts
+++ b/apps/commons-courses/app/api/live-sessions/[id]/route.ts
@@ -122,6 +122,24 @@ export async function GET(
     },
     { new: true, upsert: true },
   );
+  const enrollment = await Enrollment.findOneAndUpdate(
+    { userId: currentUser.user.id, courseId: session.courseId },
+    {
+      $setOnInsert: {
+        status: "active",
+        accessLevel: "full",
+        paymentStatus: "free",
+        accessSource: course.isFree ? "free" : "pass",
+        enrolledAt: new Date(),
+      },
+    },
+    { new: true, upsert: true },
+  );
+  if (enrollment.status === "cancelled") {
+    enrollment.status = "active";
+    enrollment.accessLevel = "full";
+    await enrollment.save();
+  }
   const [base, responses, results] = await Promise.all([
     serializeEducatorLiveSession(session, course.title, course.theme),
     getLearnerResponses(session._id, participant._id),


### PR DESCRIPTION
## What changed

- creates a full course enrollment when a learner successfully joins a live room
- records free-course joins as free access and paid/private-course live invitations as pass access
- reactivates cancelled enrollment when the learner has valid access to rejoin the room

## Why

Live participants previously received a room participant record without a corresponding course enrollment. This left post-session assignments and continuity check-ins inaccessible.

The completed Moringa room has also been backfilled directly: all 20 participant accounts now have active, full-access course enrollments.

## Validation

- targeted ESLint check
- `pnpm --filter commons-courses exec tsc --noEmit`
- `pnpm --filter commons-courses test` (25 passing)
