### PR TITLE
Track learner check-in delivery and progress

### DIFF
--- a/apps/commons-courses/app/api/assignments/[id]/check-in-progress/route.ts
+++ b/apps/commons-courses/app/api/assignments/[id]/check-in-progress/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { connectDB } from "@/lib/db";
+import Assignment from "@/models/Assignment";
+import CheckInNotification from "@/models/CheckInNotification";
+import Enrollment from "@/models/Enrollment";
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  const { id } = await params;
+  await connectDB();
+  const assignment = await Assignment.findById(id).select(
+    "_id courseId kind published targetUserIds",
+  );
+  if (!assignment || assignment.kind !== "follow_up" || !assignment.published) {
+    return NextResponse.json({ error: "Check-in not found." }, { status: 404 });
+  }
+  if (
+    assignment.targetUserIds.length > 0 &&
+    !assignment.targetUserIds.some(
+      (userId: { toString(): string }) => String(userId) === session.user.id,
+    )
+  ) {
+    return NextResponse.json(
+      { error: "This check-in is not assigned to you." },
+      { status: 403 },
+    );
+  }
+  const enrolled = await Enrollment.exists({
+    courseId: assignment.courseId,
+    userId: session.user.id,
+    status: { $ne: "cancelled" },
+  });
+  if (!enrolled) {
+    return NextResponse.json({ error: "Not enrolled." }, { status: 403 });
+  }
+
+  const notification = await CheckInNotification.findOneAndUpdate(
+    { assignmentId: assignment._id, userId: session.user.id },
+    {
+      $min: { startedAt: new Date() },
+      $setOnInsert: {
+        courseId: assignment.courseId,
+        email: session.user.email,
+        emailStatus: "not_sent",
+      },
+    },
+    { upsert: true, new: true, runValidators: true },
+  );
+  return NextResponse.json({ startedAt: notification.startedAt });
+}

--- a/apps/commons-courses/app/api/assignments/[id]/submissions/route.ts
+++ b/apps/commons-courses/app/api/assignments/[id]/submissions/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth";
 import { connectDB } from "@/lib/db";
 import { indexSubmissionForSearch } from "@/lib/search-indexers";
 import Assignment from "@/models/Assignment";
+import CheckInNotification from "@/models/CheckInNotification";
 import Enrollment from "@/models/Enrollment";
 import LiveParticipant from "@/models/LiveParticipant";
 import Submission from "@/models/Submission";
@@ -84,6 +85,21 @@ export async function POST(
     },
     { upsert: true, new: true, runValidators: true }
   );
+  if (assignment.kind === "follow_up") {
+    await CheckInNotification.findOneAndUpdate(
+      { assignmentId: assignment._id, userId: session.user.id },
+      {
+        $set: { submittedAt: submission.submittedAt },
+        $min: { startedAt: submission.submittedAt },
+        $setOnInsert: {
+          courseId: assignment.courseId,
+          email: session.user.email,
+          emailStatus: "not_sent",
+        },
+      },
+      { upsert: true, runValidators: true },
+    );
+  }
   await indexSubmissionForSearch(submission);
 
   return NextResponse.json({ submission }, { status: 201 });

--- a/apps/commons-courses/app/api/educator/assignments/[id]/notifications/route.ts
+++ b/apps/commons-courses/app/api/educator/assignments/[id]/notifications/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { connectDB } from "@/lib/db";
+import { requireEducatorCourse } from "@/lib/educator-auth";
+import { sendAssignmentNotification } from "@/lib/email/resend";
+import Assignment from "@/models/Assignment";
+import Course from "@/models/Course";
+import User from "@/models/User";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  await connectDB();
+  const assignment = await Assignment.findById(id);
+  if (!assignment || assignment.kind !== "follow_up" || !assignment.published) {
+    return NextResponse.json({ error: "Check-in not found." }, { status: 404 });
+  }
+
+  const course = await Course.findById(assignment.courseId).select(
+    "_id title slug emailSettings",
+  );
+  if (!course) {
+    return NextResponse.json({ error: "Course not found." }, { status: 404 });
+  }
+  const authorization = await requireEducatorCourse(course.slug);
+  if (authorization.error) return authorization.error;
+
+  const body = await req.json().catch(() => ({}));
+  const requestedUserIds = Array.isArray(body.userIds)
+    ? body.userIds.map(String)
+    : [];
+  const allowedUserIds = assignment.targetUserIds.map(String);
+  const userIds = requestedUserIds.length
+    ? requestedUserIds.filter((userId: string) => allowedUserIds.includes(userId))
+    : allowedUserIds;
+  if (!userIds.length) {
+    return NextResponse.json(
+      { error: "Choose at least one learner assigned to this check-in." },
+      { status: 400 },
+    );
+  }
+
+  const users = await User.find({ _id: { $in: userIds } })
+    .select("_id name email")
+    .lean();
+  const results = await sendAssignmentNotification({
+    recipients: users.map((user) => ({
+      userId: String(user._id),
+      name: user.name,
+      email: user.email,
+    })),
+    course: {
+      id: String(course._id),
+      title: course.title,
+      slug: course.slug,
+      settings: course.emailSettings,
+    },
+    assignment: {
+      id: String(assignment._id),
+      title: assignment.title,
+      dueAt: assignment.dueAt,
+      points: assignment.points,
+      instructions: assignment.instructions,
+      context: assignment.context,
+      kind: "follow_up",
+    },
+    event: "updated",
+    force: true,
+  });
+
+  return NextResponse.json({ results });
+}

--- a/apps/commons-courses/app/api/educator/courses/[slug]/assignments/route.ts
+++ b/apps/commons-courses/app/api/educator/courses/[slug]/assignments/route.ts
@@ -3,6 +3,7 @@ import { requireEducatorCourse } from "@/lib/educator-auth";
 import { sendAssignmentNotification } from "@/lib/email/resend";
 import { indexAssignmentForSearch } from "@/lib/search-indexers";
 import Assignment from "@/models/Assignment";
+import CheckInNotification from "@/models/CheckInNotification";
 import Enrollment from "@/models/Enrollment";
 import Submission from "@/models/Submission";
 
@@ -15,14 +16,21 @@ export async function GET(
   if (result.error) return result.error;
 
   const assignments = await Assignment.find({ courseId: result.course._id })
+    .populate("targetUserIds", "name email")
     .sort({ moduleIndex: 1, lessonIndex: 1, createdAt: -1 })
     .lean();
   const submissions = await Submission.find({ courseId: result.course._id })
     .populate("userId", "name email")
     .sort({ submittedAt: -1 })
     .lean();
+  const checkInNotifications = await CheckInNotification.find({
+    courseId: result.course._id,
+  })
+    .populate("userId", "name email")
+    .sort({ updatedAt: -1 })
+    .lean();
 
-  return NextResponse.json({ assignments, submissions });
+  return NextResponse.json({ assignments, submissions, checkInNotifications });
 }
 
 export async function POST(

--- a/apps/commons-courses/app/api/educator/courses/[slug]/engagement/check-ins/route.ts
+++ b/apps/commons-courses/app/api/educator/courses/[slug]/engagement/check-ins/route.ts
@@ -68,10 +68,12 @@ export async function POST(
 
   await sendAssignmentNotification({
     recipients: participants.map((participant) => ({
+      userId: String(participant.userId),
       name: participant.displayName,
       email: participant.email,
     })),
     course: {
+      id: String(result.course._id),
       title: result.course.title,
       slug: result.course.slug,
       settings: result.course.emailSettings,
@@ -81,6 +83,7 @@ export async function POST(
       dueAt: assignment.dueAt,
       points: assignment.points,
       instructions: assignment.instructions,
+      context: assignment.context,
       kind: "follow_up",
       id: String(assignment._id),
     },

--- a/apps/commons-courses/app/courses/[slug]/check-ins/page.tsx
+++ b/apps/commons-courses/app/courses/[slug]/check-ins/page.tsx
@@ -5,6 +5,7 @@ import { getCourseThemeStyle } from "@/lib/course-theme";
 import { Nav } from "@/components/nav";
 import { LearnerCheckIns } from "@/components/courses/learner-check-ins";
 import Assignment from "@/models/Assignment";
+import CheckInNotification from "@/models/CheckInNotification";
 import Course from "@/models/Course";
 import Enrollment from "@/models/Enrollment";
 import LiveResponse from "@/models/LiveResponse";
@@ -51,6 +52,26 @@ export default async function CourseCheckInsPage({
     .sort({ dueAt: 1, createdAt: -1 })
     .lean();
   const assignmentIds = assignments.map((assignment) => assignment._id);
+  const openedAssignmentId =
+    assignmentIds.find((assignmentId) => String(assignmentId) === checkIn) ||
+    assignmentIds[0];
+  if (openedAssignmentId) {
+    await CheckInNotification.findOneAndUpdate(
+      {
+        assignmentId: openedAssignmentId,
+        userId: currentUser.user.id,
+      },
+      {
+        $min: { openedAt: new Date() },
+        $setOnInsert: {
+          courseId: course._id,
+          email: currentUser.user.email,
+          emailStatus: "not_sent",
+        },
+      },
+      { upsert: true, runValidators: true },
+    );
+  }
   const submissions = assignmentIds.length
     ? await Submission.find({
         assignmentId: { $in: assignmentIds },

--- a/apps/commons-courses/components/courses/learner-check-ins.tsx
+++ b/apps/commons-courses/components/courses/learner-check-ins.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useMemo, useRef, useState } from "react";
 import {
   ArrowLeft,
   CalendarDays,
@@ -159,6 +159,17 @@ function CheckInForm({
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(Boolean(submission));
   const [error, setError] = useState("");
+  const startedRef = useRef(Boolean(submission));
+
+  function markStarted() {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    fetch(`/api/assignments/${checkIn.id}/check-in-progress`, {
+      method: "POST",
+    }).catch(() => {
+      startedRef.current = false;
+    });
+  }
 
   async function submit(event: FormEvent) {
     event.preventDefault();
@@ -203,7 +214,12 @@ function CheckInForm({
         {checkIn.context && (
           <div className="rounded-xl border border-[var(--course-accent,#cbd5e1)] bg-[var(--course-muted,#f8fafc)] p-5">
             <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-slate-500">What you committed to</p>
-            <p className="mt-2 text-base font-semibold leading-7 text-slate-900">“{checkIn.context}”</p>
+            <div
+              tabIndex={0}
+              className="mt-2 max-h-56 overflow-y-auto overscroll-contain pr-2 focus:outline-none focus:ring-2 focus:ring-slate-300 sm:max-h-64"
+            >
+              <p className="whitespace-pre-wrap text-base font-semibold leading-7 text-slate-900">“{checkIn.context}”</p>
+            </div>
           </div>
         )}
 
@@ -217,7 +233,10 @@ function CheckInForm({
                 <button
                   key={item.id}
                   type="button"
-                  onClick={() => setCheckInStatus(item.id)}
+                  onClick={() => {
+                    setCheckInStatus(item.id);
+                    markStarted();
+                  }}
                   className={`flex items-start gap-3 rounded-xl border p-4 text-left ${active ? "border-slate-950 bg-slate-950 text-white" : "border-slate-200 hover:border-slate-400"}`}
                 >
                   <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${active ? "text-emerald-300" : "text-slate-400"}`} />
@@ -235,12 +254,15 @@ function CheckInForm({
             id={`check-in-${checkIn.id}`}
             required
             value={text}
-            onChange={(event) => setText(event.target.value)}
+            onChange={(event) => {
+              setText(event.target.value);
+              if (event.target.value.trim()) markStarted();
+            }}
             placeholder="What have you tried? What happened? What will you do next, or where are you stuck?"
             className="mt-3 min-h-40 w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm leading-6 outline-none focus:border-slate-500"
           />
         </div>
-        <label className="block text-sm font-bold text-slate-900">Evidence or working link <span className="font-normal text-slate-400">(optional)</span><span className="relative mt-2 block"><ExternalLink className="absolute left-3 top-3 h-4 w-4 text-slate-400" /><input value={url} onChange={(event) => setUrl(event.target.value)} placeholder="https://…" className="w-full rounded-xl border border-slate-200 py-2.5 pl-10 pr-3 text-sm font-normal outline-none focus:border-slate-500" /></span></label>
+        <label className="block text-sm font-bold text-slate-900">Evidence or working link <span className="font-normal text-slate-400">(optional)</span><span className="relative mt-2 block"><ExternalLink className="absolute left-3 top-3 h-4 w-4 text-slate-400" /><input value={url} onChange={(event) => { setUrl(event.target.value); if (event.target.value.trim()) markStarted(); }} placeholder="https://…" className="w-full rounded-xl border border-slate-200 py-2.5 pl-10 pr-3 text-sm font-normal outline-none focus:border-slate-500" /></span></label>
         {submission?.feedback && <div className="rounded-xl bg-emerald-50 p-4"><p className="text-xs font-bold uppercase tracking-wider text-emerald-700">Facilitator response</p><p className="mt-2 text-sm leading-6 text-emerald-950">{submission.feedback}</p></div>}
         {error && <p className="rounded-lg bg-red-50 p-3 text-sm text-red-700">{error}</p>}
         <div className="flex flex-col gap-3 border-t border-slate-100 pt-5 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/commons-courses/components/educator/assignment-manager.tsx
+++ b/apps/commons-courses/components/educator/assignment-manager.tsx
@@ -12,7 +12,11 @@ type Assignment = {
   points: number;
   published: boolean;
   kind?: "coursework" | "follow_up";
+  context?: string;
+  targetUserIds?: Person[];
 };
+
+type Person = { _id: string; name?: string; email?: string };
 
 type Submission = {
   _id: string;
@@ -23,12 +27,26 @@ type Submission = {
   score?: number;
   feedback?: string;
   checkInStatus?: "not_started" | "in_progress" | "blocked" | "completed";
-  userId?: { name?: string; email?: string };
+  userId?: Person;
+};
+
+type CheckInNotification = {
+  _id: string;
+  assignmentId: string;
+  userId?: Person;
+  email?: string;
+  emailStatus: "not_sent" | "pending" | "sent" | "skipped" | "failed";
+  lastError?: string;
+  sentAt?: string;
+  openedAt?: string;
+  startedAt?: string;
+  submittedAt?: string;
 };
 
 export function AssignmentManager({ slug }: { slug: string }) {
   const [assignments, setAssignments] = useState<Assignment[]>([]);
   const [submissions, setSubmissions] = useState<Submission[]>([]);
+  const [checkInNotifications, setCheckInNotifications] = useState<CheckInNotification[]>([]);
   const [form, setForm] = useState({
     title: "",
     instructions: "",
@@ -43,6 +61,7 @@ export function AssignmentManager({ slug }: { slug: string }) {
     const data = await res.json();
     setAssignments(data.assignments || []);
     setSubmissions(data.submissions || []);
+    setCheckInNotifications(data.checkInNotifications || []);
   }, [slug]);
 
   useEffect(() => {
@@ -53,6 +72,7 @@ export function AssignmentManager({ slug }: { slug: string }) {
         if (cancelled) return;
         setAssignments(data.assignments || []);
         setSubmissions(data.submissions || []);
+        setCheckInNotifications(data.checkInNotifications || []);
       })
       .catch(() => {});
 
@@ -89,6 +109,24 @@ export function AssignmentManager({ slug }: { slug: string }) {
     });
     load();
   }
+
+  async function sendCheckIn(assignmentId: string, userId: string) {
+    const response = await fetch(
+      `/api/educator/assignments/${assignmentId}/notifications`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userIds: [userId] }),
+      },
+    );
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      throw new Error(data.error || "Could not send this check-in.");
+    }
+    await load();
+  }
+
+  const followUps = assignments.filter((assignment) => assignment.kind === "follow_up");
 
   return (
     <div className="grid gap-6 lg:grid-cols-[360px_1fr]">
@@ -152,6 +190,15 @@ export function AssignmentManager({ slug }: { slug: string }) {
           </div>
         </ScrollableListFrame>
 
+        {followUps.length > 0 && (
+          <CheckInProgress
+            assignments={followUps}
+            notifications={checkInNotifications}
+            submissions={submissions}
+            onSend={sendCheckIn}
+          />
+        )}
+
         <ScrollableListFrame title="Submissions" count={submissions.length} rowHeight={172}>
           <div className="space-y-3 p-3">
             {submissions.map((submission) => (
@@ -168,6 +215,148 @@ export function AssignmentManager({ slug }: { slug: string }) {
       </div>
     </div>
   );
+}
+
+function CheckInProgress({
+  assignments,
+  notifications,
+  submissions,
+  onSend,
+}: {
+  assignments: Assignment[];
+  notifications: CheckInNotification[];
+  submissions: Submission[];
+  onSend: (assignmentId: string, userId: string) => Promise<void>;
+}) {
+  const [sendingKey, setSendingKey] = useState("");
+  const [error, setError] = useState("");
+  const count = assignments.reduce(
+    (total, assignment) => total + (assignment.targetUserIds?.length || 0),
+    0,
+  );
+
+  async function send(assignmentId: string, userId: string) {
+    const key = `${assignmentId}:${userId}`;
+    setSendingKey(key);
+    setError("");
+    try {
+      await onSend(assignmentId, userId);
+    } catch (sendError) {
+      setError(
+        sendError instanceof Error
+          ? sendError.message
+          : "Could not send this check-in.",
+      );
+    } finally {
+      setSendingKey("");
+    }
+  }
+
+  return (
+    <ScrollableListFrame title="Check-in progress" count={count} rowHeight={250}>
+      <div className="space-y-4 p-3">
+        {error && <p className="rounded-lg bg-red-50 p-3 text-sm text-red-700">{error}</p>}
+        {assignments.map((assignment) => (
+          <section key={assignment._id} className="rounded-xl border border-slate-200 bg-white p-4">
+            <div className="border-b border-slate-100 pb-4">
+              <p className="text-[10px] font-bold uppercase tracking-wider text-emerald-700">Continuity check-in</p>
+              <h3 className="mt-1 font-bold text-slate-950">{assignment.title}</h3>
+              {assignment.context && (
+                <p className="mt-2 max-h-24 overflow-y-auto whitespace-pre-wrap pr-2 text-sm leading-6 text-slate-600">
+                  {assignment.context}
+                </p>
+              )}
+            </div>
+            <div className="divide-y divide-slate-100">
+              {(assignment.targetUserIds || []).map((learner) => {
+                const notification = notifications.find(
+                  (item) =>
+                    item.assignmentId === assignment._id &&
+                    personId(item.userId) === learner._id,
+                );
+                const submission = submissions.find(
+                  (item) =>
+                    item.assignmentId === assignment._id &&
+                    personId(item.userId) === learner._id,
+                );
+                const key = `${assignment._id}:${learner._id}`;
+                return (
+                  <div key={learner._id} className="py-4 first:pt-4 last:pb-0">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                      <div>
+                        <p className="text-sm font-bold text-slate-900">{learner.name || learner.email || "Learner"}</p>
+                        <p className="mt-0.5 text-xs text-slate-500">{learner.email}</p>
+                      </div>
+                      <button
+                        type="button"
+                        disabled={sendingKey === key}
+                        onClick={() => send(assignment._id, learner._id)}
+                        className="h-9 rounded-lg border border-slate-200 px-3 text-xs font-bold text-slate-700 hover:border-slate-400 disabled:opacity-50"
+                      >
+                        {sendingKey === key ? "Sending…" : notification?.sentAt ? "Resend check-in" : "Send check-in"}
+                      </button>
+                    </div>
+                    <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4">
+                      <ProgressStep label="Sent" active={Boolean(notification?.sentAt)} date={notification?.sentAt} />
+                      <ProgressStep label="Opened" active={Boolean(notification?.openedAt)} date={notification?.openedAt} />
+                      <ProgressStep label="Responding" active={Boolean(notification?.startedAt)} date={notification?.startedAt} />
+                      <ProgressStep label="Submitted" active={Boolean(submission)} date={notification?.submittedAt} />
+                    </div>
+                    {notification?.emailStatus === "failed" && (
+                      <p className="mt-3 text-xs font-semibold text-red-600">Email failed{notification.lastError ? `: ${notification.lastError}` : "."}</p>
+                    )}
+                    {submission && (
+                      <div className="mt-4 rounded-lg bg-slate-50 p-4">
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <p className="text-xs font-bold uppercase tracking-wider text-slate-500">Final response</p>
+                          {submission.checkInStatus && <span className="rounded-full bg-white px-2.5 py-1 text-[11px] font-bold capitalize text-slate-600">{submission.checkInStatus.replace("_", " ")}</span>}
+                        </div>
+                        {submission.text && <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-800">{submission.text}</p>}
+                        {submission.url && <a href={submission.url} target="_blank" className="mt-2 inline-block text-sm font-bold text-slate-900 underline">Open evidence</a>}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        ))}
+      </div>
+    </ScrollableListFrame>
+  );
+}
+
+function ProgressStep({
+  label,
+  active,
+  date,
+}: {
+  label: string;
+  active: boolean;
+  date?: string;
+}) {
+  return (
+    <div className={`rounded-lg border px-3 py-2 ${active ? "border-emerald-200 bg-emerald-50" : "border-slate-200 bg-slate-50"}`}>
+      <div className="flex items-center gap-2">
+        <span className={`h-1.5 w-1.5 rounded-full ${active ? "bg-emerald-500" : "bg-slate-300"}`} />
+        <span className={`text-xs font-bold ${active ? "text-emerald-800" : "text-slate-500"}`}>{label}</span>
+      </div>
+      <p className="mt-1 text-[10px] text-slate-400">{date ? formatDate(date) : "Not yet"}</p>
+    </div>
+  );
+}
+
+function personId(person?: Person) {
+  return person?._id ? String(person._id) : "";
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
 }
 
 function SubmissionReview({

--- a/apps/commons-courses/lib/email-truncate.test.mts
+++ b/apps/commons-courses/lib/email-truncate.test.mts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { truncateEmailText } from "./email/truncate.ts";
+
+test("keeps short commitment copy intact", () => {
+  assert.equal(
+    truncateEmailText("Use Claude to prepare the next team update."),
+    "Use Claude to prepare the next team update.",
+  );
+});
+
+test("normalizes whitespace and truncates on a meaningful sentence boundary", () => {
+  const value = `${"A".repeat(170)}. ${"B".repeat(180)}.`;
+  const result = truncateEmailText(value, 280);
+  assert.equal(result, `${"A".repeat(170)}.…`);
+  assert.ok(result.length <= 281);
+});
+
+test("falls back to a word boundary for long unpunctuated copy", () => {
+  const result = truncateEmailText("meaningful ".repeat(50), 90);
+  assert.ok(result.endsWith("…"));
+  assert.ok(!result.endsWith(" …"));
+  assert.ok(result.length <= 91);
+});

--- a/apps/commons-courses/lib/email/resend.tsx
+++ b/apps/commons-courses/lib/email/resend.tsx
@@ -3,9 +3,12 @@ import "server-only";
 import { render } from "@react-email/render";
 import { Resend } from "resend";
 import { getAppBaseUrl } from "@/lib/app-url";
-import { CommonsEmail, DetailList, Paragraph } from "@/lib/email/templates";
+import { Callout, CommonsEmail, DetailList, Paragraph } from "@/lib/email/templates";
+import { truncateEmailText } from "@/lib/email/truncate";
+import CheckInNotification from "@/models/CheckInNotification";
 
 type Recipient = {
+  userId?: string | null;
   email?: string | null;
   name?: string | null;
 };
@@ -22,6 +25,7 @@ type CourseEmailSettings = {
 };
 
 type CourseEmailContext = {
+  id?: string;
   title: string;
   slug: string;
   instructor?: string;
@@ -35,6 +39,7 @@ type AssignmentEmailContext = {
   dueAt?: Date | string | null;
   points?: number;
   instructions?: string;
+  context?: string;
   kind?: "coursework" | "follow_up";
 };
 
@@ -233,66 +238,147 @@ export async function sendAssignmentNotification({
   course,
   assignment,
   event,
+  force = false,
 }: {
   recipients: Recipient[];
   course: CourseEmailContext;
   assignment: AssignmentEmailContext;
   event: "created" | "updated";
+  force?: boolean;
 }) {
   const enabled =
     event === "created"
       ? course.settings?.assignmentCreatedEnabled
       : course.settings?.assignmentUpdatedEnabled;
-  if (!enabled) return;
+  if (!enabled && !force) return [];
 
-  const subjectPrefix = event === "created" ? "New assignment" : "Assignment updated";
-  const to = recipients
-    .map((recipient) => recipient.email)
-    .filter((email): email is string => Boolean(email));
-  if (!to.length) return;
+  const isCheckIn = assignment.kind === "follow_up";
+  const subjectPrefix = isCheckIn
+    ? "Your check-in"
+    : event === "created"
+      ? "New assignment"
+      : "Assignment updated";
+  const deliverable = recipients.filter(
+    (recipient): recipient is Recipient & { email: string } =>
+      Boolean(recipient.email),
+  );
+  if (!deliverable.length) return [];
 
-  await Promise.all(
-    to.map((email) =>
-      sendEmail({
-        to: [email],
+  return Promise.all(
+    deliverable.map(async (recipient) => {
+      const tracking =
+        isCheckIn && assignment.id && course.id && recipient.userId
+          ? await CheckInNotification.findOneAndUpdate(
+              {
+                assignmentId: assignment.id,
+                userId: recipient.userId,
+              },
+              {
+                $set: {
+                  courseId: course.id,
+                  email: recipient.email,
+                  emailStatus: "pending",
+                },
+                $unset: { lastError: 1 },
+              },
+              { upsert: true, new: true, runValidators: true },
+            )
+          : null;
+      const actionHref = absoluteUrl(
+        isCheckIn
+          ? `/courses/${course.slug}/check-ins${assignment.id ? `?checkIn=${assignment.id}` : ""}`
+          : `/courses/${course.slug}/learn`,
+      );
+      const result = await sendEmail({
+        to: [recipient.email],
         subject: `${subjectPrefix}: ${assignment.title}`,
         replyTo: course.settings?.replyTo,
         react: (
           <CommonsEmail
             preview={`${subjectPrefix} in ${course.title}: ${assignment.title}.`}
-            eyebrow={course.title}
-            title={subjectPrefix}
-            intro={`${assignment.title} is ${
-              event === "created" ? "now available" : "updated"
-            } in ${course.title}.`}
+            eyebrow={isCheckIn ? "CommonLab follow-up" : course.title}
+            title={isCheckIn ? "How is your commitment going?" : subjectPrefix}
+            intro={
+              isCheckIn
+                ? `Your facilitators from ${course.title} are checking in on the next step you planned.`
+                : `${assignment.title} is ${
+                    event === "created" ? "now available" : "updated"
+                  } in ${course.title}.`
+            }
             action={{
-              label:
-                assignment.kind === "follow_up"
-                  ? "Open your check-in"
-                  : "View assignment",
-              href: absoluteUrl(
-                assignment.kind === "follow_up"
-                  ? `/courses/${course.slug}/check-ins${assignment.id ? `?checkIn=${assignment.id}` : ""}`
-                  : `/courses/${course.slug}/learn`,
-              ),
+              label: isCheckIn ? "Open your check-in" : "View assignment",
+              href: actionHref,
             }}
             footerNote="You are receiving this course notification because you are enrolled in this CommonLab course."
           >
             <DetailList
               items={[
-                ["Assignment", assignment.title],
+                [isCheckIn ? "Check-in" : "Assignment", assignment.title],
+                ["Course", course.title],
                 ["Due", formatDate(assignment.dueAt)],
-                ["Points", assignment.points ? String(assignment.points) : undefined],
+                [
+                  "Points",
+                  !isCheckIn && assignment.points
+                    ? String(assignment.points)
+                    : undefined,
+                ],
               ]}
             />
+            {isCheckIn && assignment.context ? (
+              <Callout label="What you committed to">
+                {truncateEmailText(assignment.context)}
+              </Callout>
+            ) : null}
             {assignment.instructions ? (
-              <Paragraph>{assignment.instructions.slice(0, 320)}</Paragraph>
+              <Paragraph>{truncateEmailText(assignment.instructions, 320)}</Paragraph>
             ) : null}
           </CommonsEmail>
         ),
-      })
-    )
+      });
+
+      if (tracking) {
+        const providerMessageId =
+          "data" in result && result.data?.id ? result.data.id : undefined;
+        const skipped = "skipped" in result && result.skipped;
+        const errorMessage =
+          "error" in result && result.error
+            ? getErrorMessage(result.error)
+            : undefined;
+        await CheckInNotification.updateOne(
+          { _id: tracking._id },
+          providerMessageId
+            ? {
+                $set: {
+                  emailStatus: "sent",
+                  providerMessageId,
+                  sentAt: new Date(),
+                },
+                $unset: { lastError: 1 },
+              }
+            : {
+                $set: {
+                  emailStatus: skipped ? "skipped" : "failed",
+                  lastError: errorMessage,
+                },
+              },
+        );
+      }
+
+      return {
+        userId: recipient.userId,
+        email: recipient.email,
+        sent: "data" in result && Boolean(result.data?.id),
+      };
+    }),
   );
+}
+
+function getErrorMessage(value: unknown) {
+  if (value instanceof Error) return value.message;
+  if (value && typeof value === "object" && "message" in value) {
+    return String(value.message);
+  }
+  return "Email could not be sent.";
 }
 
 export async function sendCourseCollaboratorInvite({

--- a/apps/commons-courses/lib/email/templates.tsx
+++ b/apps/commons-courses/lib/email/templates.tsx
@@ -148,6 +148,21 @@ export function Paragraph({ children }: { children: React.ReactNode }) {
   return <p style={styles.paragraph}>{children}</p>;
 }
 
+export function Callout({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div style={styles.callout}>
+      <p style={styles.calloutLabel}>{label}</p>
+      <p style={styles.calloutText}>{children}</p>
+    </div>
+  );
+}
+
 const styles: Record<string, React.CSSProperties> = {
   body: {
     margin: 0,
@@ -251,6 +266,29 @@ const styles: Record<string, React.CSSProperties> = {
     color: colors.slate,
     fontSize: "15px",
     lineHeight: "24px",
+  },
+  callout: {
+    margin: "0 0 18px",
+    padding: "18px 20px",
+    backgroundColor: "#f0fdf4",
+    border: "1px solid #bbf7d0",
+    borderRadius: "10px",
+  },
+  calloutLabel: {
+    margin: "0 0 7px",
+    color: "#047857",
+    fontSize: "11px",
+    lineHeight: "16px",
+    fontWeight: 800,
+    letterSpacing: "0.08em",
+    textTransform: "uppercase",
+  },
+  calloutText: {
+    margin: 0,
+    color: colors.ink,
+    fontSize: "15px",
+    lineHeight: "24px",
+    fontWeight: 700,
   },
   actionRow: {
     margin: "28px 0 0",

--- a/apps/commons-courses/lib/email/truncate.ts
+++ b/apps/commons-courses/lib/email/truncate.ts
@@ -1,0 +1,21 @@
+export function truncateEmailText(value: string, maxLength = 280) {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) return normalized;
+
+  const window = normalized.slice(0, maxLength + 1);
+  const minimumUsefulLength = Math.floor(maxLength * 0.6);
+  const punctuationBreak = Math.max(
+    window.lastIndexOf(". "),
+    window.lastIndexOf("? "),
+    window.lastIndexOf("! "),
+  );
+  const wordBreak = window.lastIndexOf(" ");
+  const breakAt =
+    punctuationBreak >= minimumUsefulLength
+      ? punctuationBreak + 1
+      : wordBreak >= minimumUsefulLength
+        ? wordBreak
+        : maxLength;
+
+  return `${normalized.slice(0, breakAt).trimEnd()}…`;
+}

--- a/apps/commons-courses/models/Assignment.ts
+++ b/apps/commons-courses/models/Assignment.ts
@@ -40,7 +40,7 @@ const AssignmentSchema = new Schema<IAssignment>(
     },
     sourceLiveSessionId: { type: Schema.Types.ObjectId, ref: "LiveSession" },
     targetUserIds: [{ type: Schema.Types.ObjectId, ref: "User" }],
-    context: { type: String, trim: true, maxlength: 2_000 },
+    context: { type: String, trim: true, maxlength: 12_000 },
   },
   { timestamps: true }
 );

--- a/apps/commons-courses/models/CheckInNotification.ts
+++ b/apps/commons-courses/models/CheckInNotification.ts
@@ -1,0 +1,61 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+export type CheckInEmailStatus =
+  | "not_sent"
+  | "pending"
+  | "sent"
+  | "skipped"
+  | "failed";
+
+export interface ICheckInNotification extends Document {
+  assignmentId: mongoose.Types.ObjectId;
+  courseId: mongoose.Types.ObjectId;
+  userId: mongoose.Types.ObjectId;
+  email?: string;
+  emailStatus: CheckInEmailStatus;
+  providerMessageId?: string;
+  lastError?: string;
+  sentAt?: Date;
+  openedAt?: Date;
+  startedAt?: Date;
+  submittedAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const CheckInNotificationSchema = new Schema<ICheckInNotification>(
+  {
+    assignmentId: {
+      type: Schema.Types.ObjectId,
+      ref: "Assignment",
+      required: true,
+    },
+    courseId: { type: Schema.Types.ObjectId, ref: "Course", required: true },
+    userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
+    email: { type: String, trim: true, lowercase: true },
+    emailStatus: {
+      type: String,
+      enum: ["not_sent", "pending", "sent", "skipped", "failed"],
+      default: "not_sent",
+    },
+    providerMessageId: String,
+    lastError: String,
+    sentAt: Date,
+    openedAt: Date,
+    startedAt: Date,
+    submittedAt: Date,
+  },
+  { timestamps: true },
+);
+
+CheckInNotificationSchema.index(
+  { assignmentId: 1, userId: 1 },
+  { unique: true },
+);
+CheckInNotificationSchema.index({ courseId: 1, updatedAt: -1 });
+
+export default mongoose.models.CheckInNotification ||
+  mongoose.model<ICheckInNotification>(
+    "CheckInNotification",
+    CheckInNotificationSchema,
+  );


### PR DESCRIPTION
## What changed

- retain the standard CommonLab email layout for accountability check-ins
- show a sentence-aware excerpt of long commitments in email while keeping the full commitment in a scrollable learner panel
- persist per-learner sent, opened, responding, and submitted milestones
- add an educator check-in progress view with final responses and per-learner send/resend controls
- increase supported commitment length and record opens after authenticated check-in access

## Why

Long commitments could overwhelm both the learner page and notification email, while educators had no visibility between creating a check-in and receiving a final submission.

## Validation

- TypeScript passes
- targeted ESLint passes
- 28 tests pass, including new email truncation tests
- production-configured Next.js build passes