### PR TITLE
Add paid educator email branding

### DIFF
--- a/apps/commons-courses/app/api/educator/assignments/[id]/route.ts
+++ b/apps/commons-courses/app/api/educator/assignments/[id]/route.ts
@@ -73,6 +73,7 @@ export async function PUT(
         return { name: user?.name, email: user?.email };
       }),
       course: {
+        id: String(result.course._id),
         title: result.course.title,
         slug: result.course.slug,
         settings: result.course.emailSettings,

--- a/apps/commons-courses/app/api/educator/courses/[slug]/assignments/route.ts
+++ b/apps/commons-courses/app/api/educator/courses/[slug]/assignments/route.ts
@@ -85,6 +85,7 @@ export async function POST(
         return { name: user?.name, email: user?.email };
       }),
       course: {
+        id: String(result.course._id),
         title: result.course.title,
         slug: result.course.slug,
         settings: result.course.emailSettings,

--- a/apps/commons-courses/app/api/educator/courses/[slug]/collaborators/route.ts
+++ b/apps/commons-courses/app/api/educator/courses/[slug]/collaborators/route.ts
@@ -136,6 +136,7 @@ export async function POST(
     inviterName: result.session.email,
     role,
     course: {
+      id: String(result.course._id),
       title: result.course.title,
       slug: result.course.slug,
       instructor: result.course.instructor,

--- a/apps/commons-courses/app/api/educator/courses/[slug]/route.ts
+++ b/apps/commons-courses/app/api/educator/courses/[slug]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { normalizeCourseInput } from "@/lib/course-input";
+import { canUseCustomEmailBranding } from "@/lib/educator-entitlements";
 import {
   canManageCourseCollaborators,
   requireEducatorCourse,
@@ -16,7 +17,11 @@ export async function GET(
   const result = await requireEducatorCourse(slug);
   if (result.error) return result.error;
 
-  return NextResponse.json({ course: result.course });
+  const emailBranding = await canUseCustomEmailBranding(result.course);
+  return NextResponse.json({
+    course: result.course,
+    entitlements: { customEmailBranding: emailBranding },
+  });
 }
 
 export async function PUT(
@@ -32,6 +37,13 @@ export async function PUT(
     const nextSlug = body.slug ? slugifyCourseTitle(body.slug) : result.course.slug;
     const normalized = normalizeCourseBody(body);
     if (normalized instanceof NextResponse) return normalized;
+    const emailBranding = await canUseCustomEmailBranding(result.course);
+    if (normalized.emailSettings?.branding?.enabled && !emailBranding) {
+      return NextResponse.json(
+        { error: "Custom email branding is available on paid educator plans." },
+        { status: 403 },
+      );
+    }
 
     result.course.set({
       ...normalized,

--- a/apps/commons-courses/app/api/educator/courses/route.ts
+++ b/apps/commons-courses/app/api/educator/courses/route.ts
@@ -7,6 +7,7 @@ import {
   slugifyCourseTitle,
 } from "@/lib/educator-auth";
 import { normalizeCourseInput } from "@/lib/course-input";
+import { isPaidEducatorPlan } from "@/lib/email/branding";
 import { indexCourseForSearch } from "@/lib/search-indexers";
 import Course from "@/models/Course";
 import EducatorProfile from "@/models/EducatorProfile";
@@ -58,6 +59,15 @@ export async function POST(req: NextRequest) {
 
   const normalized = normalizeCourseBody(body);
   if (normalized instanceof NextResponse) return normalized;
+  if (
+    normalized.emailSettings?.branding?.enabled &&
+    (profile?.status !== "active" || !isPaidEducatorPlan(profile?.plan))
+  ) {
+    return NextResponse.json(
+      { error: "Custom email branding is available on paid educator plans." },
+      { status: 403 },
+    );
+  }
 
   const course = await Course.create({
     ...normalized,

--- a/apps/commons-courses/app/api/enrollments/route.ts
+++ b/apps/commons-courses/app/api/enrollments/route.ts
@@ -67,6 +67,7 @@ export async function POST(req: NextRequest) {
     await sendEnrollmentEmail(
       { name: session.user.name, email: session.user.email },
       {
+        id: String(course._id),
         title: course.title,
         slug: course.slug,
         instructor: course.instructor,

--- a/apps/commons-courses/app/api/payments/checkout/route.ts
+++ b/apps/commons-courses/app/api/payments/checkout/route.ts
@@ -411,6 +411,7 @@ export async function GET(req: NextRequest) {
       await sendEnrollmentEmail(
         { name: checkoutUser.name, email: checkoutUser.email },
         {
+          id: String(dbCourse._id),
           title: dbCourse.title,
           slug: dbCourse.slug,
           instructor: dbCourse.instructor,
@@ -514,6 +515,7 @@ export async function GET(req: NextRequest) {
       await sendEnrollmentEmail(
         { name: checkoutUser.name, email: checkoutUser.email },
         {
+          id: String(dbCourse._id),
           title: dbCourse.title,
           slug: dbCourse.slug,
           instructor: dbCourse.instructor,

--- a/apps/commons-courses/components/educator/course-editor.tsx
+++ b/apps/commons-courses/components/educator/course-editor.tsx
@@ -88,6 +88,13 @@ type CourseForm = {
     agentManaged: boolean;
     replyTo?: string;
     customIntro?: string;
+    branding: {
+      enabled: boolean;
+      senderName: string;
+      logoUrl: string;
+      accentColor: string;
+      footerText: string;
+    };
   };
   modules: Module[];
   skillPack: SkillPack;
@@ -161,6 +168,13 @@ const emptyCourse: CourseForm = {
     agentManaged: false,
     replyTo: "",
     customIntro: "",
+    branding: {
+      enabled: false,
+      senderName: "",
+      logoUrl: "",
+      accentColor: "#020617",
+      footerText: "",
+    },
   },
   modules: [
     {
@@ -200,6 +214,7 @@ export function CourseEditor({
   const [error, setError] = useState("");
   const [draftSavedAt, setDraftSavedAt] = useState<Date | null>(null);
   const [labWorkspaces, setLabWorkspaces] = useState<LabWorkspaceRecord[]>([]);
+  const [customEmailBranding, setCustomEmailBranding] = useState(false);
   const isFullEditor = section === "all";
   const show = (name: CourseEditorSection) => isFullEditor || section === name;
   const sectionLabel = getSectionLabel(section);
@@ -210,12 +225,24 @@ export function CourseEditor({
   const hasUnsavedChanges = currentSectionSnapshot !== savedSectionSnapshot;
 
   useEffect(() => {
-    if (!slug) return;
+    if (!slug) {
+      void fetch("/api/educator/profile")
+        .then((res) => (res.ok ? res.json() : null))
+        .then((data) => {
+          const profile = data?.profile;
+          setCustomEmailBranding(
+            profile?.status === "active" &&
+              ["starter", "growth", "institution"].includes(profile?.plan),
+          );
+        });
+      return;
+    }
     fetch(`/api/educator/courses/${slug}`)
       .then((res) => res.json())
       .then((data) => {
         const c = data.course;
         if (!c) return;
+        setCustomEmailBranding(Boolean(data.entitlements?.customEmailBranding));
         const nextCourse = hydrateCourse(c);
         setCourse(nextCourse);
         setSavedSectionSnapshot(stringifySectionSnapshot(nextCourse, section));
@@ -324,6 +351,7 @@ export function CourseEditor({
       | "imageUrl"
       | "bannerImageUrl"
       | "previewImageUrl"
+      | "emailSettings.logoUrl"
       | "skillPack.coverUrl"
       | `skillPack.${number}.assetUrl`
       | `skillPacks.${number}.coverUrl`
@@ -348,7 +376,18 @@ export function CourseEditor({
       });
       return;
     }
-    if (field === "skillPack.coverUrl") {
+    if (field === "emailSettings.logoUrl") {
+      setCourse((current) => ({
+        ...current,
+        emailSettings: {
+          ...current.emailSettings,
+          branding: {
+            ...current.emailSettings.branding,
+            logoUrl: data.url,
+          },
+        },
+      }));
+    } else if (field === "skillPack.coverUrl") {
       setCourse((current) => ({
         ...current,
         skillPack: { ...current.skillPack, coverUrl: data.url },
@@ -794,6 +833,98 @@ export function CourseEditor({
             }
           />
         </div>
+        <div className="mt-6 rounded-xl border border-slate-200 bg-slate-50 p-4 sm:p-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <div className="flex flex-wrap items-center gap-2">
+                <h3 className="font-bold text-slate-950">Custom email branding</h3>
+                <span className="rounded-full bg-slate-950 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider text-white">Paid feature</span>
+              </div>
+              <p className="mt-1 max-w-2xl text-sm leading-6 text-slate-600">
+                Use your logo, accent color, sender name, and footer while retaining a dependable CommonLab email structure.
+              </p>
+            </div>
+            <label className="flex items-center gap-2 text-sm font-bold text-slate-700">
+              <input
+                type="checkbox"
+                disabled={!customEmailBranding}
+                checked={course.emailSettings.branding.enabled}
+                onChange={(event) =>
+                  setCourse({
+                    ...course,
+                    emailSettings: {
+                      ...course.emailSettings,
+                      branding: {
+                        ...course.emailSettings.branding,
+                        enabled: event.target.checked,
+                      },
+                    },
+                  })
+                }
+              />
+              Enable
+            </label>
+          </div>
+          {!customEmailBranding && (
+            <p className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2.5 text-sm leading-6 text-amber-900">
+              Upgrade to Starter, Growth, or Institution to apply custom branding to learner emails.
+            </p>
+          )}
+          <fieldset
+            disabled={!customEmailBranding || !course.emailSettings.branding.enabled}
+            className="mt-5 grid gap-4 disabled:opacity-50 md:grid-cols-2"
+          >
+            <label className="block">
+              <span className="text-sm font-bold text-slate-700">Sender display name</span>
+              <input
+                value={course.emailSettings.branding.senderName}
+                maxLength={80}
+                onChange={(event) => setCourse({ ...course, emailSettings: { ...course.emailSettings, branding: { ...course.emailSettings.branding, senderName: event.target.value } } })}
+                placeholder="Your organization"
+                className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm outline-none focus:border-slate-400"
+              />
+            </label>
+            <label className="block">
+              <span className="text-sm font-bold text-slate-700">Accent color</span>
+              <span className="mt-2 flex h-10 items-center gap-3 rounded-lg border border-slate-200 bg-white px-3">
+                <input
+                  type="color"
+                  value={course.emailSettings.branding.accentColor}
+                  onChange={(event) => setCourse({ ...course, emailSettings: { ...course.emailSettings, branding: { ...course.emailSettings.branding, accentColor: event.target.value } } })}
+                  className="h-6 w-8 border-0 bg-transparent p-0"
+                />
+                <span className="text-xs font-semibold text-slate-500">{course.emailSettings.branding.accentColor}</span>
+              </span>
+            </label>
+            <label className="block md:col-span-2">
+              <span className="text-sm font-bold text-slate-700">Logo</span>
+              <input
+                type="url"
+                value={course.emailSettings.branding.logoUrl}
+                onChange={(event) => setCourse({ ...course, emailSettings: { ...course.emailSettings, branding: { ...course.emailSettings.branding, logoUrl: event.target.value } } })}
+                placeholder="https://…"
+                className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm outline-none focus:border-slate-400"
+              />
+              <input
+                type="file"
+                accept="image/png,image/jpeg,image/webp"
+                disabled={uploadingMedia === "emailSettings.logoUrl"}
+                onChange={(event) => uploadMedia("emailSettings.logoUrl", event.target.files?.[0])}
+                className="mt-2 w-full text-xs text-slate-600 file:mr-3 file:rounded-md file:border-0 file:bg-slate-950 file:px-3 file:py-2 file:text-xs file:font-bold file:text-white disabled:opacity-50"
+              />
+            </label>
+            <label className="block md:col-span-2">
+              <span className="text-sm font-bold text-slate-700">Footer message</span>
+              <textarea
+                value={course.emailSettings.branding.footerText}
+                maxLength={240}
+                onChange={(event) => setCourse({ ...course, emailSettings: { ...course.emailSettings, branding: { ...course.emailSettings.branding, footerText: event.target.value } } })}
+                placeholder="A short organization or support message"
+                className="mt-2 min-h-20 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm outline-none focus:border-slate-400"
+              />
+            </label>
+          </fieldset>
+        </div>
       </section>
       )}
 
@@ -1032,6 +1163,10 @@ function hydrateCourse(course: CourseResponse): CourseForm {
     emailSettings: {
       ...emptyCourse.emailSettings,
       ...(course.emailSettings || {}),
+      branding: {
+        ...emptyCourse.emailSettings.branding,
+        ...(course.emailSettings?.branding || {}),
+      },
     },
     theme: { ...defaultCourseTheme, ...(course.theme || {}) },
   };

--- a/apps/commons-courses/lib/course-input.ts
+++ b/apps/commons-courses/lib/course-input.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/course-schedule";
 import { sanitizeRichTextHtml } from "@/lib/rich-text";
 import type { CourseAgentConfig } from "@/types/course-agent";
+import { normalizeEmailBranding } from "@/lib/email/branding";
 import type {
   AgentSandboxCapability,
   AgentSandboxConfig,
@@ -119,6 +120,13 @@ export type CourseInput = {
     agentManaged?: boolean;
     replyTo?: string;
     customIntro?: string;
+    branding?: {
+      enabled?: boolean;
+      senderName?: string;
+      logoUrl?: string;
+      accentColor?: string;
+      footerText?: string;
+    };
   };
 };
 
@@ -706,6 +714,7 @@ export function normalizeCourseInput(input: CourseInput) {
       agentManaged: Boolean(input.emailSettings?.agentManaged),
       replyTo: input.emailSettings?.replyTo?.trim() || undefined,
       customIntro: input.emailSettings?.customIntro?.trim() || undefined,
+      branding: normalizeEmailBranding(input.emailSettings?.branding),
     },
   };
 }

--- a/apps/commons-courses/lib/educator-entitlements.ts
+++ b/apps/commons-courses/lib/educator-entitlements.ts
@@ -1,0 +1,37 @@
+import "server-only";
+
+import {
+  isPaidEducatorPlan,
+  normalizeEmailBranding,
+  type EmailBranding,
+} from "@/lib/email/branding";
+import Course from "@/models/Course";
+import EducatorProfile from "@/models/EducatorProfile";
+import type { ICourse } from "@/models/Course";
+
+export async function canUseCustomEmailBranding(
+  course: Pick<ICourse, "educator">,
+) {
+  const ownerId = course.educator?.userId;
+  if (!ownerId) return false;
+  const profile = await EducatorProfile.findOne({
+    userId: ownerId,
+  })
+    .select("plan status")
+    .lean<{ plan?: string; status?: string }>();
+  if (profile) {
+    return profile.status === "active" && isPaidEducatorPlan(profile.plan);
+  }
+  return isPaidEducatorPlan(course.educator?.plan);
+}
+
+export async function resolveCourseEmailBranding(
+  courseId?: string,
+  input?: Partial<EmailBranding> | null,
+) {
+  const branding = normalizeEmailBranding(input);
+  if (!courseId || !branding.enabled) return undefined;
+  const course = await Course.findById(courseId).select("educator");
+  if (!course || !(await canUseCustomEmailBranding(course))) return undefined;
+  return branding;
+}

--- a/apps/commons-courses/lib/email-branding.test.mts
+++ b/apps/commons-courses/lib/email-branding.test.mts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isPaidEducatorPlan,
+  normalizeEmailBranding,
+} from "./email/branding.ts";
+
+test("treats every non-free educator plan as paid", () => {
+  assert.equal(isPaidEducatorPlan("free"), false);
+  assert.equal(isPaidEducatorPlan("starter"), true);
+  assert.equal(isPaidEducatorPlan("growth"), true);
+  assert.equal(isPaidEducatorPlan("institution"), true);
+});
+
+test("normalizes safe email branding values", () => {
+  assert.deepEqual(
+    normalizeEmailBranding({
+      enabled: true,
+      senderName: "  Moringa   School  ",
+      logoUrl: "https://assets.example.com/logo.png",
+      accentColor: "#ea580c",
+      footerText: "  Learning together.  ",
+    }),
+    {
+      enabled: true,
+      senderName: "Moringa School",
+      logoUrl: "https://assets.example.com/logo.png",
+      accentColor: "#EA580C",
+      footerText: "Learning together.",
+    },
+  );
+});
+
+test("drops unsafe logo and color values", () => {
+  const branding = normalizeEmailBranding({
+    enabled: true,
+    logoUrl: "javascript:alert(1)",
+    accentColor: "red",
+  });
+  assert.equal(branding.logoUrl, undefined);
+  assert.equal(branding.accentColor, undefined);
+});

--- a/apps/commons-courses/lib/email/branding.ts
+++ b/apps/commons-courses/lib/email/branding.ts
@@ -1,0 +1,46 @@
+export type EmailBranding = {
+  enabled: boolean;
+  senderName?: string;
+  logoUrl?: string;
+  accentColor?: string;
+  footerText?: string;
+};
+
+export type EducatorPlan = "free" | "starter" | "growth" | "institution";
+
+export function isPaidEducatorPlan(plan?: string | null) {
+  return plan === "starter" || plan === "growth" || plan === "institution";
+}
+
+export function normalizeEmailBranding(input?: Partial<EmailBranding> | null) {
+  if (!input) return { enabled: false } satisfies EmailBranding;
+  return {
+    enabled: Boolean(input.enabled),
+    senderName: cleanText(input.senderName, 80),
+    logoUrl: normalizeBrandLogoUrl(input.logoUrl),
+    accentColor: normalizeBrandColor(input.accentColor),
+    footerText: cleanText(input.footerText, 240),
+  } satisfies EmailBranding;
+}
+
+export function normalizeBrandColor(value?: string | null) {
+  const color = value?.trim();
+  return color && /^#[0-9a-f]{6}$/i.test(color) ? color.toUpperCase() : undefined;
+}
+
+export function normalizeBrandLogoUrl(value?: string | null) {
+  const url = value?.trim();
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" ? parsed.toString() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function cleanText(value: unknown, maxLength: number) {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.replace(/\s+/g, " ").trim();
+  return normalized ? normalized.slice(0, maxLength) : undefined;
+}

--- a/apps/commons-courses/lib/email/resend.tsx
+++ b/apps/commons-courses/lib/email/resend.tsx
@@ -5,6 +5,8 @@ import { Resend } from "resend";
 import { getAppBaseUrl } from "@/lib/app-url";
 import { Callout, CommonsEmail, DetailList, Paragraph } from "@/lib/email/templates";
 import { truncateEmailText } from "@/lib/email/truncate";
+import type { EmailBranding } from "@/lib/email/branding";
+import { resolveCourseEmailBranding } from "@/lib/educator-entitlements";
 import CheckInNotification from "@/models/CheckInNotification";
 
 type Recipient = {
@@ -22,6 +24,7 @@ type CourseEmailSettings = {
   agentManaged?: boolean;
   replyTo?: string;
   customIntro?: string;
+  branding?: EmailBranding;
 };
 
 type CourseEmailContext = {
@@ -72,11 +75,13 @@ async function sendEmail({
   subject,
   react,
   replyTo,
+  senderName,
 }: {
   to: string[];
   subject: string;
   react: React.ReactElement;
   replyTo?: string;
+  senderName?: string;
 }) {
   const recipients = to.filter(Boolean);
   if (!recipients.length) return { skipped: true, reason: "missing_recipient" };
@@ -91,7 +96,7 @@ async function sendEmail({
       render(react, { plainText: true }),
     ]);
     const { data, error } = await resend.emails.send({
-      from: fromAddress,
+      from: getFromAddress(senderName),
       to: recipients,
       subject,
       html,
@@ -202,11 +207,16 @@ export async function sendPasswordResetEmail({
 
 export async function sendEnrollmentEmail(user: Recipient, course: CourseEmailContext) {
   if (!course.settings?.enrollmentEnabled || !user.email) return;
+  const branding = await resolveCourseEmailBranding(
+    course.id,
+    course.settings.branding,
+  );
 
   await sendEmail({
     to: [user.email],
     subject: `You're enrolled in ${course.title}`,
     replyTo: course.settings.replyTo,
+    senderName: branding?.senderName,
     react: (
       <CommonsEmail
         preview={`You're enrolled in ${course.title}.`}
@@ -220,6 +230,7 @@ export async function sendEnrollmentEmail(user: Recipient, course: CourseEmailCo
           label: "Go to course",
           href: absoluteUrl(`/courses/${course.slug}/learn`),
         }}
+        branding={branding}
       >
         <DetailList
           items={[
@@ -253,6 +264,10 @@ export async function sendAssignmentNotification({
   if (!enabled && !force) return [];
 
   const isCheckIn = assignment.kind === "follow_up";
+  const branding = await resolveCourseEmailBranding(
+    course.id,
+    course.settings?.branding,
+  );
   const subjectPrefix = isCheckIn
     ? "Your check-in"
     : event === "created"
@@ -293,6 +308,7 @@ export async function sendAssignmentNotification({
         to: [recipient.email],
         subject: `${subjectPrefix}: ${assignment.title}`,
         replyTo: course.settings?.replyTo,
+        senderName: branding?.senderName,
         react: (
           <CommonsEmail
             preview={`${subjectPrefix} in ${course.title}: ${assignment.title}.`}
@@ -310,6 +326,7 @@ export async function sendAssignmentNotification({
               href: actionHref,
             }}
             footerNote="You are receiving this course notification because you are enrolled in this CommonLab course."
+            branding={branding}
           >
             <DetailList
               items={[
@@ -393,11 +410,16 @@ export async function sendCourseCollaboratorInvite({
   role: "co_owner" | "editor";
 }) {
   if (!recipient.email) return;
+  const branding = await resolveCourseEmailBranding(
+    course.id,
+    course.settings?.branding,
+  );
 
   await sendEmail({
     to: [recipient.email],
     subject: `You're invited to collaborate on ${course.title}`,
     replyTo: course.settings?.replyTo,
+    senderName: branding?.senderName,
     react: (
       <CommonsEmail
         preview={`You've been invited to help manage ${course.title} on CommonLab.`}
@@ -408,6 +430,7 @@ export async function sendCourseCollaboratorInvite({
           label: "Open course",
           href: absoluteUrl(`/educator/courses/${course.slug}/edit`),
         }}
+        branding={branding}
       >
         <DetailList
           items={[
@@ -423,4 +446,11 @@ export async function sendCourseCollaboratorInvite({
       </CommonsEmail>
     ),
   });
+}
+
+function getFromAddress(senderName?: string) {
+  if (!senderName) return fromAddress;
+  const address = fromAddress.match(/<([^>]+)>/)?.[1] || fromAddress.trim();
+  const safeName = senderName.replace(/[<>\r\n]/g, "").trim();
+  return safeName ? `${safeName} <${address}>` : fromAddress;
 }

--- a/apps/commons-courses/lib/email/templates.tsx
+++ b/apps/commons-courses/lib/email/templates.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { getAppBaseUrl } from "@/lib/app-url";
+import type { EmailBranding } from "@/lib/email/branding";
 
 export type EmailAction = {
   label: string;
@@ -14,6 +15,7 @@ type CommonsEmailProps = {
   children?: React.ReactNode;
   action?: EmailAction;
   footerNote?: string;
+  branding?: EmailBranding;
 };
 
 const colors = {
@@ -38,7 +40,11 @@ export function CommonsEmail({
   children,
   action,
   footerNote,
+  branding,
 }: CommonsEmailProps) {
+  const accentColor = branding?.accentColor;
+  const brandName = branding?.senderName || "CommonLab";
+  const logoUrl = branding?.logoUrl || `${baseUrl}/icon.svg`;
   return (
     <html lang="en">
       <body style={styles.body}>
@@ -54,10 +60,10 @@ export function CommonsEmail({
                         <table role="presentation" width="100%" cellPadding="0" cellSpacing="0">
                           <tbody>
                             <tr>
-                              <td style={{ ...styles.colorCell, backgroundColor: colors.lime }} />
-                              <td style={{ ...styles.colorCell, backgroundColor: colors.cyan }} />
-                              <td style={{ ...styles.colorCell, backgroundColor: colors.violet }} />
-                              <td style={{ ...styles.colorCell, backgroundColor: colors.rose }} />
+                              <td style={{ ...styles.colorCell, backgroundColor: accentColor || colors.lime }} />
+                              <td style={{ ...styles.colorCell, backgroundColor: accentColor || colors.cyan }} />
+                              <td style={{ ...styles.colorCell, backgroundColor: accentColor || colors.violet }} />
+                              <td style={{ ...styles.colorCell, backgroundColor: accentColor || colors.rose }} />
                             </tr>
                           </tbody>
                         </table>
@@ -71,16 +77,16 @@ export function CommonsEmail({
                               <td style={styles.logoMark}>
                                 {/* eslint-disable-next-line @next/next/no-img-element */}
                                 <img
-                                  src={`${baseUrl}/icon.svg`}
-                                  alt="CommonLab"
+                                  src={logoUrl}
+                                  alt={brandName}
                                   width="42"
                                   height="42"
                                   style={styles.logoImage}
                                 />
                               </td>
                               <td style={styles.logoText}>
-                                <p style={styles.brand}>CommonLab</p>
-                                <p style={styles.tagline}>Courses and learning sandboxes</p>
+                                <p style={styles.brand}>{brandName}</p>
+                                <p style={styles.tagline}>{branding ? "Powered by CommonLab" : "Courses and learning sandboxes"}</p>
                               </td>
                             </tr>
                           </tbody>
@@ -95,7 +101,18 @@ export function CommonsEmail({
                         {children ? <div style={styles.section}>{children}</div> : null}
                         {action ? (
                           <p style={styles.actionRow}>
-                            <a href={action.href} style={styles.button}>
+                            <a
+                              href={action.href}
+                              style={
+                                accentColor
+                                  ? {
+                                      ...styles.button,
+                                      backgroundColor: accentColor,
+                                      color: getReadableTextColor(accentColor),
+                                    }
+                                  : styles.button
+                              }
+                            >
                               {action.label}
                             </a>
                           </p>
@@ -104,6 +121,9 @@ export function CommonsEmail({
                     </tr>
                     <tr>
                       <td style={styles.footer}>
+                        {branding?.footerText ? (
+                          <p style={styles.brandFooterText}>{branding.footerText}</p>
+                        ) : null}
                         <p style={styles.footerText}>
                           {footerNote ||
                             "You are receiving this because you use CommonLab courses."}
@@ -337,9 +357,25 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: "12px",
     lineHeight: "18px",
   },
+  brandFooterText: {
+    margin: "0 0 10px",
+    color: colors.ink,
+    fontSize: "13px",
+    lineHeight: "19px",
+    fontWeight: 700,
+  },
   footerLink: {
     color: colors.ink,
     textDecoration: "none",
     fontWeight: 800,
   },
 };
+
+function getReadableTextColor(color: string) {
+  const red = Number.parseInt(color.slice(1, 3), 16);
+  const green = Number.parseInt(color.slice(3, 5), 16);
+  const blue = Number.parseInt(color.slice(5, 7), 16);
+  return (0.2126 * red + 0.7152 * green + 0.0722 * blue) / 255 > 0.57
+    ? colors.ink
+    : "#ffffff";
+}

--- a/apps/commons-courses/lib/payment-fulfillment.ts
+++ b/apps/commons-courses/lib/payment-fulfillment.ts
@@ -138,6 +138,7 @@ export async function fulfillCompletedPayment(params: FulfillmentParams) {
     await sendEnrollmentEmail(
       { name: user?.name, email: user?.email },
       {
+        id: String(course._id),
         title: course.title,
         slug: course.slug,
         instructor: course.instructor,

--- a/apps/commons-courses/models/Course.ts
+++ b/apps/commons-courses/models/Course.ts
@@ -6,6 +6,7 @@ import {
 import type { CourseAgentConfig } from "@/types/course-agent";
 import type { SkillPack } from "@/types/skills";
 import type { CourseTheme } from "@/lib/course-theme";
+import type { EmailBranding } from "@/lib/email/branding";
 
 export interface ILesson {
   title: string;
@@ -74,6 +75,7 @@ export interface ICourseEmailSettings {
   agentManaged: boolean;
   replyTo?: string;
   customIntro?: string;
+  branding?: EmailBranding;
 }
 
 export interface ICourseCollaborator {
@@ -317,6 +319,13 @@ const CourseEmailSettingsSchema = new Schema<ICourseEmailSettings>(
     agentManaged: { type: Boolean, default: false },
     replyTo: { type: String, trim: true },
     customIntro: { type: String, trim: true },
+    branding: {
+      enabled: { type: Boolean, default: false },
+      senderName: { type: String, trim: true, maxlength: 80 },
+      logoUrl: { type: String, trim: true },
+      accentColor: { type: String, trim: true },
+      footerText: { type: String, trim: true, maxlength: 240 },
+    },
   },
   { _id: false },
 );


### PR DESCRIPTION
## Summary
- add paid-plan email branding controls for course notifications
- apply custom logo, sender name, accent colour, and footer through the shared CommonLab template
- enforce entitlement on course writes and at email delivery time

## Validation
- pnpm test (31 passing)
- pnpm exec tsc --noEmit -p tsconfig.json
- targeted ESLint
- pnpm build