### PR TITLE
Add secure course library imports

### DIFF
--- a/apps/commons-courses/app/api/admin/library-upload/route.ts
+++ b/apps/commons-courses/app/api/admin/library-upload/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { connectDB } from "@/lib/db";
+import { uploadEducatorCopilotFiles } from "@/lib/educator-copilot-files";
+import { platformServiceToken } from "@/lib/platform-service-token";
+import User from "@/models/User";
+
+const allowed = new Set([
+  "application/pdf",
+  "application/vnd.ms-powerpoint",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+]);
+const maxSize = 50 * 1024 * 1024;
+
+export async function POST(req: NextRequest) {
+  if (
+    !process.env.ADMIN_SECRET ||
+    req.headers.get("x-admin-secret") !== process.env.ADMIN_SECRET
+  ) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+  const form = await req.formData();
+  const ownerEmail = String(form.get("ownerEmail") || "")
+    .trim()
+    .toLowerCase();
+  const files = form
+    .getAll("files")
+    .filter((item): item is File => item instanceof File)
+    .slice(0, 10);
+  if (!ownerEmail || !files.length) {
+    return NextResponse.json(
+      { error: "An owner email and at least one file are required." },
+      { status: 400 },
+    );
+  }
+  const invalid = files.find(
+    (file) => !allowed.has(file.type) || file.size > maxSize,
+  );
+  if (invalid) {
+    return NextResponse.json(
+      {
+        error: `${invalid.name} must be a PDF or PowerPoint file smaller than 50 MB.`,
+      },
+      { status: 400 },
+    );
+  }
+  await connectDB();
+  const owner = (await User.findOne({ email: ownerEmail })
+    .select("identityUserId identityWorkspaceId")
+    .lean()) as {
+    identityUserId?: string;
+    identityWorkspaceId?: string;
+  } | null;
+  if (!owner?.identityUserId) {
+    return NextResponse.json(
+      { error: "The educator is not connected to Commons Identity." },
+      { status: 404 },
+    );
+  }
+  const accessToken = await platformServiceToken(
+    "agent_commons",
+    "activity:read",
+  );
+  if (!accessToken) {
+    return NextResponse.json(
+      { error: "Commons Library service access is unavailable." },
+      { status: 503 },
+    );
+  }
+  const uploaded = await uploadEducatorCopilotFiles(files, {
+    accessToken,
+    principalId: owner.identityUserId,
+    workspaceId: owner.identityWorkspaceId,
+    storageProvider: "s3",
+  });
+  if (uploaded.length !== files.length) {
+    return NextResponse.json(
+      { error: "One or more files could not be stored in Commons Library." },
+      { status: 502 },
+    );
+  }
+  return NextResponse.json({ data: uploaded }, { status: 201 });
+}

--- a/apps/commons-courses/scripts/seed-ai-quick-wins-workshop.mjs
+++ b/apps/commons-courses/scripts/seed-ai-quick-wins-workshop.mjs
@@ -679,8 +679,6 @@ async function extractPresentationText(bytes) {
 }
 
 async function uploadToCommonsLibrary(assets, principalId, workspaceId) {
-  const apiKey = process.env.AGENT_COMMONS_API_KEY;
-  if (!apiKey) throw new Error("AGENT_COMMONS_API_KEY is required.");
   const form = new FormData();
   for (const asset of assets) {
     form.append(
@@ -691,22 +689,42 @@ async function uploadToCommonsLibrary(assets, principalId, workspaceId) {
   }
   if (workspaceId) form.append("workspaceId", String(workspaceId));
   form.append("storageProvider", "s3");
-  const baseUrl = (
-    process.env.AGENT_COMMONS_API_URL || "https://api.agentcommons.io"
-  ).replace(/\/$/, "");
-  const response = await fetch(`${baseUrl}/v1/files/upload`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "x-initiator": String(principalId),
-      "x-owner-id": String(principalId),
-    },
-    body: form,
-  });
+  const adminUploadUrl = process.env.COURSES_ADMIN_UPLOAD_URL?.trim();
+  let response;
+  if (adminUploadUrl) {
+    const adminSecret = process.env.ADMIN_SECRET;
+    if (!adminSecret) throw new Error("ADMIN_SECRET is required.");
+    form.append("ownerEmail", ownerEmail);
+    response = await fetch(adminUploadUrl, {
+      method: "POST",
+      headers: { "x-admin-secret": adminSecret },
+      body: form,
+    });
+  } else {
+    const apiKey = await agentCommonsAccessToken();
+    const baseUrl = (
+      process.env.AGENT_COMMONS_API_URL || "https://api.agentcommons.io"
+    ).replace(/\/$/, "");
+    response = await fetch(`${baseUrl}/v1/files/upload`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "x-initiator": String(principalId),
+        "x-owner-id": String(principalId),
+      },
+      body: form,
+    });
+  }
   const payload = await response.json().catch(() => ({}));
   if (!response.ok || !Array.isArray(payload.data)) {
+    const detail =
+      typeof payload.message === "string"
+        ? payload.message
+        : typeof payload.error === "string"
+          ? payload.error
+          : "Workshop files could not be added to Commons Library.";
     throw new Error(
-      payload.message || "Workshop files could not be added to Commons Library.",
+      `Commons Library upload failed (${response.status}): ${detail}`,
     );
   }
   const byName = new Map(payload.data.map((item) => [item.name, item]));
@@ -719,6 +737,43 @@ async function uploadToCommonsLibrary(assets, principalId, workspaceId) {
     result.set(asset.key, item);
   }
   return result;
+}
+
+async function agentCommonsAccessToken() {
+  if (process.env.AGENT_COMMONS_API_KEY) {
+    return process.env.AGENT_COMMONS_API_KEY;
+  }
+  const issuer = process.env.COMMONS_IDENTITY_ISSUER;
+  const clientId =
+    process.env.AGENT_COMMONS_SERVICE_CLIENT_ID ||
+    process.env.COURSES_VERIFIER_CLIENT_ID;
+  const clientSecret =
+    process.env.AGENT_COMMONS_SERVICE_CLIENT_SECRET ||
+    process.env.COURSES_VERIFIER_CLIENT_SECRET;
+  if (!issuer || !clientId || !clientSecret) {
+    throw new Error(
+      "A Commons API key or Commons Identity service credentials are required.",
+    );
+  }
+  const response = await fetch(`${issuer.replace(/\/$/, "")}/oauth2/token`, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "client_credentials",
+      scope: "activity:read",
+      resource: "commons-platform",
+    }),
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok || typeof payload.access_token !== "string") {
+    throw new Error(
+      `Commons Identity token request failed (${response.status}).`,
+    );
+  }
+  return payload.access_token;
 }
 
 async function syncMaterial({


### PR DESCRIPTION
## What changed

- adds an admin-authenticated, server-side course-library import endpoint
- resolves the existing educator account and uploads with the production Commons service identity
- keeps service credentials inside the deployed application and never returns them to import clients
- lets the AI Quick Wins importer use that endpoint while retaining direct API support for local environments
- improves import failures with safe HTTP status details

## Why

Production Commons service credentials are intentionally non-exportable from Vercel, and the retired legacy management key cannot be used by batch imports. The course source importer needs a narrow way to upload materials with correct educator ownership without creating or exposing persistent credentials.

## Validation

- `node --check scripts/seed-ai-quick-wins-workshop.mjs`
- `pnpm exec tsc --noEmit -p tsconfig.json`
- `pnpm lint`
- `pnpm test` (33 passing)
- `pnpm build` with production-equivalent environment variables
