### PR TITLE
Add fillable live worksheets for AI Quick Wins

### DIFF
--- a/apps/commons-courses/app/api/live-sessions/[id]/responses/route.ts
+++ b/apps/commons-courses/app/api/live-sessions/[id]/responses/route.ts
@@ -9,6 +9,7 @@ import type { LiveActivity, LiveActivityOption } from "@/types/live-session";
 import {
   isValidLiveResponse,
   normalizePrioritizationResponse,
+  normalizeWorksheetResponse,
 } from "@/lib/live-response-policy";
 
 export async function POST(
@@ -55,6 +56,8 @@ export async function POST(
   const responseValue =
     activity.type === "prioritization"
       ? normalizePrioritizationResponse(activity, value)
+      : activity.type === "worksheet"
+        ? normalizeWorksheetResponse(activity, value)
       : value;
   if (responseValue === undefined) {
     return NextResponse.json(

--- a/apps/commons-courses/app/courses/[slug]/check-ins/page.tsx
+++ b/apps/commons-courses/app/courses/[slug]/check-ins/page.tsx
@@ -12,6 +12,10 @@ import LiveResponse from "@/models/LiveResponse";
 import LiveSession from "@/models/LiveSession";
 import Submission from "@/models/Submission";
 import type { LiveActivity, LiveResponseValue } from "@/types/live-session";
+import {
+  isPrioritizationResponse,
+  isWorksheetResponse,
+} from "@/lib/live-response-policy";
 
 export default async function CourseCheckInsPage({
   params,
@@ -150,11 +154,14 @@ export default async function CourseCheckInsPage({
 }
 
 function formatResponseValue(value: LiveResponseValue) {
-  if (!Array.isArray(value) && typeof value === "object") {
+  if (isPrioritizationResponse(value)) {
     const selected = value.items
       .filter((item) => item.selected)
       .map((item) => item.text);
     return selected.length ? selected.join(", ") : value.items.map((item) => item.text).join(", ");
+  }
+  if (isWorksheetResponse(value)) {
+    return Object.values(value.values).map(String).join(", ");
   }
   const values = Array.isArray(value) ? value : [value];
   return values

--- a/apps/commons-courses/components/educator/live-facilitator-studio.tsx
+++ b/apps/commons-courses/components/educator/live-facilitator-studio.tsx
@@ -37,6 +37,7 @@ import type {
   LiveActivityType,
   LiveParticipantRecord,
   LiveSessionRecord,
+  LiveWorksheetField,
 } from "@/types/live-session";
 import type { CourseMaterialRecord } from "@/types/course-material";
 import type { LabWorkspaceRecord } from "@/types/lab-workspace";
@@ -70,6 +71,11 @@ const activityChoices: Array<{
     type: "prioritization",
     label: "Idea shortlist",
     hint: "Capture many ideas, then choose priorities",
+  },
+  {
+    type: "worksheet",
+    label: "Fillable worksheet",
+    hint: "Structured fields learners can save and complete",
   },
   {
     type: "reflection",
@@ -253,6 +259,15 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
           : undefined,
       minItems: type === "prioritization" ? 3 : undefined,
       maxSelections: type === "prioritization" ? 3 : undefined,
+      worksheetFields:
+        type === "worksheet"
+          ? [{
+              id: crypto.randomUUID(),
+              label: "Workbook question",
+              type: "long_text",
+              required: true,
+            }]
+          : [],
       points: type === "quiz" ? 1 : 0,
       options: ["poll", "quiz", "setup_check"].includes(type)
         ? [
@@ -1254,6 +1269,29 @@ function ActivityEditor({
       ],
     });
   }
+  function updateWorksheetField(
+    id: string,
+    patch: Partial<LiveWorksheetField>,
+  ) {
+    onChange({
+      worksheetFields: (activity.worksheetFields || []).map((field) =>
+        field.id === id ? { ...field, ...patch } : field,
+      ),
+    });
+  }
+  function addWorksheetField() {
+    onChange({
+      worksheetFields: [
+        ...(activity.worksheetFields || []),
+        {
+          id: crypto.randomUUID(),
+          label: "New question",
+          type: "short_text",
+          required: false,
+        },
+      ],
+    });
+  }
   const selectedLabWorkspace = labWorkspaces.find(
     (workspace) => workspace.id === activity.labWorkspaceId,
   );
@@ -1416,6 +1454,134 @@ function ActivityEditor({
             Learners can add up to 50 entries, save progress, and revise their
             shortlist while the activity remains open.
           </p>
+        </div>
+      ) : null}
+      {activity.type === "worksheet" ? (
+        <div className="mt-5 rounded-xl border border-slate-200 bg-slate-50 p-4">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-wide text-slate-600">
+                Worksheet fields
+              </p>
+              <p className="mt-1 text-[11px] text-slate-500">
+                Group related questions with the same section title.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={addWorksheetField}
+              className="inline-flex items-center gap-1 text-xs font-bold text-slate-700"
+            >
+              <Plus className="h-3.5 w-3.5" /> Add field
+            </button>
+          </div>
+          <div className="mt-4 space-y-3">
+            {(activity.worksheetFields || []).map((field, fieldIndex) => (
+              <div key={field.id} className="rounded-xl border border-slate-200 bg-white p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-[10px] font-bold uppercase tracking-wide text-slate-400">
+                    Field {fieldIndex + 1}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      onChange({
+                        worksheetFields: (activity.worksheetFields || []).filter(
+                          (candidate) => candidate.id !== field.id,
+                        ),
+                      })
+                    }
+                    className="p-1 text-slate-300 hover:text-red-600"
+                    aria-label={`Remove ${field.label}`}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  <Field label="Question">
+                    <input
+                      value={field.label}
+                      onChange={(event) =>
+                        updateWorksheetField(field.id, { label: event.target.value })
+                      }
+                      className={inputClass}
+                    />
+                  </Field>
+                  <Field label="Field type">
+                    <select
+                      value={field.type}
+                      onChange={(event) =>
+                        updateWorksheetField(field.id, {
+                          type: event.target.value as LiveWorksheetField["type"],
+                        })
+                      }
+                      className={inputClass}
+                    >
+                      <option value="short_text">Short answer</option>
+                      <option value="long_text">Long answer</option>
+                      <option value="scale">Number scale</option>
+                      <option value="date">Date</option>
+                    </select>
+                  </Field>
+                  <Field label="Section title">
+                    <input
+                      value={field.section || ""}
+                      onChange={(event) =>
+                        updateWorksheetField(field.id, { section: event.target.value })
+                      }
+                      placeholder="Optional group heading"
+                      className={inputClass}
+                    />
+                  </Field>
+                  <Field label="Help text">
+                    <input
+                      value={field.description || ""}
+                      onChange={(event) =>
+                        updateWorksheetField(field.id, { description: event.target.value })
+                      }
+                      placeholder="Optional guidance"
+                      className={inputClass}
+                    />
+                  </Field>
+                  {field.type === "scale" ? (
+                    <>
+                      <Field label="Minimum">
+                        <input
+                          type="number"
+                          min={0}
+                          max={20}
+                          value={field.min ?? 1}
+                          onChange={(event) =>
+                            updateWorksheetField(field.id, { min: Number(event.target.value) })
+                          }
+                          className={inputClass}
+                        />
+                      </Field>
+                      <Field label="Maximum">
+                        <input
+                          type="number"
+                          min={1}
+                          max={20}
+                          value={field.max ?? 5}
+                          onChange={(event) =>
+                            updateWorksheetField(field.id, { max: Number(event.target.value) })
+                          }
+                          className={inputClass}
+                        />
+                      </Field>
+                    </>
+                  ) : null}
+                </div>
+                <div className="mt-3">
+                  <Toggle
+                    checked={field.required}
+                    onChange={(required) => updateWorksheetField(field.id, { required })}
+                    label="Required to complete"
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
       ) : null}
       <Field label="Private facilitator notes">
@@ -1727,7 +1893,9 @@ function LiveResults({
             </div>
           ))}
         </div>
-      ) : !activity.options.length && !results?.prioritizations?.length ? (
+      ) : !activity.options.length &&
+        !results?.prioritizations?.length &&
+        !results?.worksheets?.length ? (
         <div className="mt-6 rounded-xl border border-dashed border-slate-200 p-8 text-center text-sm text-slate-400">
           Responses will appear here.
         </div>
@@ -1757,6 +1925,32 @@ function LiveResults({
                 {response.items.length} captured
               </p>
             </div>
+          ))}
+        </div>
+      ) : null}
+      {results?.worksheets?.length ? (
+        <div className="mt-5 space-y-3">
+          {results.worksheets.map((response) => (
+            <details key={response.id} className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <summary className="cursor-pointer list-none text-xs font-bold text-slate-700">
+                <span>{response.participantName || "Learner response"}</span>
+                <span className="ml-2 text-[10px] uppercase tracking-wide text-slate-400">
+                  {response.finalized ? "Completed" : "In progress"} · {response.values.length} fields
+                </span>
+              </summary>
+              <dl className="mt-4 space-y-3">
+                {response.values.map((answer) => (
+                  <div key={answer.fieldId}>
+                    <dt className="text-[10px] font-bold uppercase tracking-wide text-slate-400">
+                      {answer.label}
+                    </dt>
+                    <dd className="mt-1 whitespace-pre-wrap text-sm leading-6 text-slate-700">
+                      {answer.value}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </details>
           ))}
         </div>
       ) : null}

--- a/apps/commons-courses/components/live/live-learner-room.tsx
+++ b/apps/commons-courses/components/live/live-learner-room.tsx
@@ -41,6 +41,7 @@ import {
   decodeOtherResponse,
   encodeOtherResponse,
   isPrioritizationResponse,
+  isWorksheetResponse,
   isValidLiveResponse,
   sameLiveResponseValue,
 } from "@/lib/live-response-policy";
@@ -867,7 +868,16 @@ function LearnerActivity({
           />
         </div>
       ) : null}
-      {activity.type === "prioritization" ? (
+      {activity.type === "worksheet" ? (
+        <WorksheetResponsePanel
+          activity={activity}
+          value={value}
+          response={response}
+          submitting={submitting}
+          onChange={onChange}
+          onSubmit={onSubmit}
+        />
+      ) : activity.type === "prioritization" ? (
         <PrioritizationResponsePanel
           activity={activity}
           value={value}
@@ -1067,6 +1077,185 @@ function LearnerActivity({
         </div>
       )}
     </article>
+  );
+}
+
+function WorksheetResponsePanel({
+  activity,
+  value,
+  response,
+  submitting,
+  onChange,
+  onSubmit,
+}: {
+  activity: LiveActivity;
+  value?: LiveResponseValue;
+  response?: LiveResponseRecord;
+  submitting: boolean;
+  onChange: (value: LiveResponseValue) => void;
+  onSubmit: (valueOverride?: LiveResponseValue) => void;
+}) {
+  const current = isWorksheetResponse(value)
+    ? value
+    : { values: {}, finalized: false };
+  const fields = activity.worksheetFields || [];
+  const sections = fields.reduce<Array<{ title: string; fields: typeof fields }>>(
+    (groups, field) => {
+      const title = field.section || "Your responses";
+      const existing = groups.find((group) => group.title === title);
+      if (existing) existing.fields.push(field);
+      else groups.push({ title, fields: [field] });
+      return groups;
+    },
+    [],
+  );
+  const answered = fields.filter(
+    (field) => current.values[field.id] !== undefined,
+  ).length;
+  const requiredComplete = fields.every(
+    (field) => !field.required || current.values[field.id] !== undefined,
+  );
+  const canEdit = activity.status === "open";
+  const changed = response
+    ? !sameLiveResponseValue(current, response.value)
+    : answered > 0;
+
+  function update(fieldId: string, nextValue: string | number) {
+    const values = { ...current.values };
+    if (nextValue === "") delete values[fieldId];
+    else values[fieldId] = nextValue;
+    onChange({ values, finalized: false });
+  }
+
+  return (
+    <div className="border-t border-slate-100 bg-[var(--course-background)] p-4 sm:p-7">
+      <div className="mx-auto max-w-4xl space-y-5">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-bold">Fill in your workbook</p>
+            <p className="mt-1 text-xs opacity-55">
+              Your progress is private to you and your facilitators.
+            </p>
+          </div>
+          <span className="rounded-full bg-[var(--course-surface)] px-3 py-1.5 text-xs font-bold opacity-70">
+            {answered}/{fields.length} answered
+          </span>
+        </div>
+        {sections.map((section) => (
+          <section
+            key={section.title}
+            className="rounded-2xl border border-slate-200 bg-[var(--course-surface)] p-4 sm:p-6"
+          >
+            <h2 className="text-sm font-bold uppercase tracking-[0.14em] opacity-55">
+              {section.title}
+            </h2>
+            <div className="mt-5 grid gap-5 md:grid-cols-2">
+              {section.fields.map((field) => {
+                const fieldValue = current.values[field.id];
+                return (
+                  <label
+                    key={field.id}
+                    className={cn(
+                      "block",
+                      field.type === "long_text" && "md:col-span-2",
+                    )}
+                  >
+                    <span className="text-sm font-bold leading-6">
+                      {field.label}
+                      {field.required ? <span className="ml-1 text-red-500">*</span> : null}
+                    </span>
+                    {field.description ? (
+                      <span className="mt-1 block text-xs leading-5 opacity-55">
+                        {field.description}
+                      </span>
+                    ) : null}
+                    {field.type === "scale" ? (
+                      <div className="mt-3">
+                        <div className="grid grid-cols-5 gap-2">
+                          {Array.from(
+                            { length: (field.max ?? 5) - (field.min ?? 1) + 1 },
+                            (_, index) => (field.min ?? 1) + index,
+                          ).map((number) => (
+                            <button
+                              key={number}
+                              type="button"
+                              disabled={!canEdit}
+                              onClick={() => update(field.id, number)}
+                              className={cn(
+                                "min-h-12 rounded-xl border text-sm font-bold transition",
+                                fieldValue === number
+                                  ? "border-[var(--course-primary)] bg-[var(--course-primary)] text-[var(--course-on-primary)]"
+                                  : "border-slate-200 bg-white hover:border-slate-400",
+                              )}
+                            >
+                              {number}
+                            </button>
+                          ))}
+                        </div>
+                        <div className="mt-2 flex justify-between gap-4 text-[11px] opacity-50">
+                          <span>{field.lowLabel}</span>
+                          <span className="text-right">{field.highLabel}</span>
+                        </div>
+                      </div>
+                    ) : field.type === "long_text" ? (
+                      <textarea
+                        rows={5}
+                        maxLength={10_000}
+                        disabled={!canEdit}
+                        value={typeof fieldValue === "string" ? fieldValue : ""}
+                        onChange={(event) => update(field.id, event.target.value)}
+                        placeholder={field.placeholder}
+                        className="mt-3 w-full resize-y rounded-xl border border-slate-200 bg-white p-4 text-sm leading-6 text-slate-950 outline-none focus:border-slate-500 disabled:bg-slate-100"
+                      />
+                    ) : (
+                      <input
+                        type={field.type === "date" ? "date" : "text"}
+                        maxLength={500}
+                        disabled={!canEdit}
+                        value={typeof fieldValue === "string" ? fieldValue : ""}
+                        onChange={(event) => update(field.id, event.target.value)}
+                        placeholder={field.placeholder}
+                        className="mt-3 w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-950 outline-none focus:border-slate-500 disabled:bg-slate-100"
+                      />
+                    )}
+                  </label>
+                );
+              })}
+            </div>
+          </section>
+        ))}
+        {response ? (
+          <Saved
+            message={
+              isWorksheetResponse(response.value) && response.value.finalized && !changed
+                ? "Workbook section completed"
+                : "Progress saved · You can keep editing while this is open"
+            }
+          />
+        ) : null}
+        {canEdit ? (
+          <div className="grid gap-2 sm:grid-cols-2">
+            <button
+              type="button"
+              onClick={() => onSubmit({ values: current.values, finalized: false })}
+              disabled={!answered || submitting || !changed}
+              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl border border-slate-300 bg-white px-4 text-sm font-bold text-slate-700 disabled:opacity-40"
+            >
+              <Save className="h-4 w-4" /> Save progress
+            </button>
+            <button
+              type="button"
+              onClick={() => onSubmit({ values: current.values, finalized: true })}
+              disabled={!answered || !requiredComplete || submitting}
+              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-[var(--course-primary)] px-4 text-sm font-bold text-[var(--course-on-primary)] disabled:opacity-40"
+            >
+              {submitting ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
+              Complete this section
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </div>
   );
 }
 
@@ -1381,6 +1570,7 @@ function labelFor(type: LiveActivity["type"]) {
       poll: "Quick poll",
       quiz: "Knowledge check",
       prioritization: "Capture and shortlist",
+      worksheet: "Workbook activity",
       reflection: "Reflection",
       task: "Practice",
       break: "Break",

--- a/apps/commons-courses/lib/course-engagement.test.mts
+++ b/apps/commons-courses/lib/course-engagement.test.mts
@@ -137,3 +137,51 @@ test("summarises captured and shortlisted routines for educators", () => {
     "Shortlisted: Prepare weekly updates · 2 captured",
   );
 });
+
+test("summarises structured worksheet progress for educators", () => {
+  const result = buildCourseEngagement({
+    activities: [
+      {
+        id: "contract",
+        type: "worksheet",
+        title: "Outcome contract",
+        status: "closed",
+        required: true,
+        randomizeOptions: false,
+        showResults: false,
+        points: 0,
+        options: [],
+        worksheetFields: [
+          { id: "outcome", label: "Outcome", type: "long_text", required: true },
+          { id: "evidence", label: "Evidence", type: "long_text", required: true },
+        ],
+      },
+    ],
+    participants: [
+      {
+        _id: "participant-1",
+        userId: "user-1",
+        displayName: "Amina",
+        email: "amina@example.com",
+        status: "active",
+        joinedAt: "2026-08-15T08:00:00.000Z",
+        lastSeenAt: "2026-08-15T16:00:00.000Z",
+      },
+    ],
+    responses: [
+      {
+        participantId: "participant-1",
+        userId: "user-1",
+        activityId: "contract",
+        value: {
+          finalized: true,
+          values: { outcome: "Delegate reporting", evidence: "Two hours saved" },
+        },
+        submittedAt: "2026-08-15T10:00:00.000Z",
+      },
+    ],
+  });
+
+  assert.match(result.activities[0].responses[0].value, /Completed · 2\/2 fields/);
+  assert.match(result.activities[0].responses[0].value, /Delegate reporting/);
+});

--- a/apps/commons-courses/lib/course-engagement.ts
+++ b/apps/commons-courses/lib/course-engagement.ts
@@ -1,6 +1,9 @@
 import type { LiveActivity } from "../types/live-session";
 import type { LiveResponseValue } from "../types/live-session";
-import { normalizePrioritizationResponse } from "./live-response-policy.ts";
+import {
+  normalizePrioritizationResponse,
+  normalizeWorksheetResponse,
+} from "./live-response-policy.ts";
 import type {
   EngagementActivity,
   EngagementLearner,
@@ -46,6 +49,23 @@ function responseLabel(activity: LiveActivity, value: LiveResponseValue) {
     return selected.length
       ? `Shortlisted: ${selected.join("; ")} · ${response.items.length} captured`
       : `${response.items.length} routines captured · shortlist in progress`;
+  }
+  if (activity.type === "worksheet") {
+    const response = normalizeWorksheetResponse(activity, value);
+    if (!response) return "No worksheet progress saved";
+    const answered = Object.keys(response.values).length;
+    const total = activity.worksheetFields?.length || 0;
+    const preview = (activity.worksheetFields || [])
+      .flatMap((field) => {
+        const answer = response.values[field.id];
+        if (answer === undefined) return [];
+        const text = String(answer).replace(/\s+/g, " ").trim();
+        const concise = text.length > 160 ? `${text.slice(0, 157)}…` : text;
+        return [`${field.label}: ${concise}`];
+      })
+      .slice(0, 3)
+      .join(" · ");
+    return `${response.finalized ? "Completed" : "In progress"} · ${answered}/${total} fields${preview ? ` · ${preview}` : ""}`;
   }
   const values = Array.isArray(value) ? value : [value];
   return values

--- a/apps/commons-courses/lib/educator-copilot-tools.ts
+++ b/apps/commons-courses/lib/educator-copilot-tools.ts
@@ -338,6 +338,7 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
                   "poll",
                   "quiz",
                   "prioritization",
+                  "worksheet",
                   "reflection",
                   "task",
                   "break",
@@ -401,6 +402,31 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
                 type: "number",
                 description:
                   "For prioritization activities, the maximum number of items learners may shortlist.",
+              },
+              worksheetFields: {
+                type: "array",
+                description:
+                  "For worksheet activities, the structured fields learners fill in and can save as progress.",
+                items: {
+                  type: "object",
+                  properties: {
+                    id: { type: "string" },
+                    label: { type: "string" },
+                    type: {
+                      type: "string",
+                      enum: ["short_text", "long_text", "scale", "date"],
+                    },
+                    section: { type: "string" },
+                    description: { type: "string" },
+                    placeholder: { type: "string" },
+                    required: { type: "boolean" },
+                    min: { type: "number" },
+                    max: { type: "number" },
+                    lowLabel: { type: "string" },
+                    highLabel: { type: "string" },
+                  },
+                  required: ["label", "type"],
+                },
               },
               points: { type: "number" },
               options: {

--- a/apps/commons-courses/lib/live-response-policy.test.mts
+++ b/apps/commons-courses/lib/live-response-policy.test.mts
@@ -14,6 +14,34 @@ test("allows saved poll answers to change only while the poll is open", () => {
   assert.equal(canReviseLiveResponse(activity("poll", "closed")), false);
   assert.equal(canReviseLiveResponse(activity("quiz", "open")), false);
   assert.equal(canReviseLiveResponse(activity("prioritization", "open")), true);
+  assert.equal(canReviseLiveResponse(activity("worksheet", "open")), true);
+});
+
+test("validates worksheet progress and required fields before completion", () => {
+  const worksheet = activity("worksheet", "open");
+  worksheet.worksheetFields = [
+    { id: "outcome", label: "Outcome", type: "long_text", required: true },
+    { id: "confidence", label: "Confidence", type: "scale", required: false, min: 1, max: 5 },
+  ];
+  assert.equal(
+    isValidLiveResponse(worksheet, { values: { confidence: 3 }, finalized: false }),
+    true,
+  );
+  assert.equal(
+    isValidLiveResponse(worksheet, { values: { confidence: 3 }, finalized: true }),
+    false,
+  );
+  assert.equal(
+    isValidLiveResponse(worksheet, {
+      values: { outcome: "Automate my weekly report", confidence: 4 },
+      finalized: true,
+    }),
+    true,
+  );
+  assert.equal(
+    isValidLiveResponse(worksheet, { values: { confidence: 8 }, finalized: false }),
+    false,
+  );
 });
 
 test("validates a multi-entry shortlist while preserving in-progress saves", () => {

--- a/apps/commons-courses/lib/live-response-policy.ts
+++ b/apps/commons-courses/lib/live-response-policy.ts
@@ -2,6 +2,7 @@ import type {
   LiveActivity,
   LivePrioritizationResponse,
   LiveResponseValue,
+  LiveWorksheetResponse,
 } from "@/types/live-session";
 
 export const OTHER_RESPONSE_PREFIX = "__other__:";
@@ -23,6 +24,9 @@ export function isValidLiveResponse(
   if (activity.type === "prioritization") {
     return normalizePrioritizationResponse(activity, value) !== undefined;
   }
+  if (activity.type === "worksheet") {
+    return normalizeWorksheetResponse(activity, value) !== undefined;
+  }
   if (!Array.isArray(value) && typeof value !== "string") return false;
   const values = Array.isArray(value) ? value.map(String) : [String(value)];
   if (!values.length || values.some((item) => !item.trim())) return false;
@@ -38,7 +42,9 @@ export function isValidLiveResponse(
 
 export function canReviseLiveResponse(activity: LiveActivity) {
   return (
-    (activity.type === "poll" || activity.type === "prioritization") &&
+    (activity.type === "poll" ||
+      activity.type === "prioritization" ||
+      activity.type === "worksheet") &&
     activity.status === "open"
   );
 }
@@ -58,6 +64,14 @@ export function sameLiveResponseValue(
         })),
       };
     }
+    if (isWorksheetResponse(value)) {
+      return {
+        finalized: value.finalized,
+        values: Object.fromEntries(
+          Object.entries(value.values).sort(([a], [b]) => a.localeCompare(b)),
+        ),
+      };
+    }
     return Array.isArray(value)
       ? [...value].map(String).sort()
       : String(value || "");
@@ -65,6 +79,59 @@ export function sameLiveResponseValue(
   return (
     JSON.stringify(normalize(current)) === JSON.stringify(normalize(saved))
   );
+}
+
+export function isWorksheetResponse(
+  value: unknown,
+): value is LiveWorksheetResponse {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      (value as { values?: unknown }).values &&
+      typeof (value as { values?: unknown }).values === "object" &&
+      !Array.isArray((value as { values?: unknown }).values),
+  );
+}
+
+export function normalizeWorksheetResponse(
+  activity: LiveActivity,
+  value: unknown,
+): LiveWorksheetResponse | undefined {
+  if (!isWorksheetResponse(value) || !activity.worksheetFields?.length)
+    return undefined;
+  const values: Record<string, string | number> = {};
+  for (const field of activity.worksheetFields) {
+    const source = value.values[field.id];
+    if (source === undefined || source === null || source === "") continue;
+    if (field.type === "scale") {
+      const number = Number(source);
+      const min = field.min ?? 1;
+      const max = field.max ?? 5;
+      if (!Number.isInteger(number) || number < min || number > max)
+        return undefined;
+      values[field.id] = number;
+      continue;
+    }
+    if (typeof source !== "string") return undefined;
+    const cleaned = source.trim();
+    const limit = field.type === "long_text" ? 10_000 : 500;
+    if (!cleaned || cleaned.length > limit) return undefined;
+    if (field.type === "date" && !/^\d{4}-\d{2}-\d{2}$/.test(cleaned))
+      return undefined;
+    values[field.id] = cleaned;
+  }
+  if (!Object.keys(values).length) return undefined;
+  const finalized = Boolean(value.finalized);
+  if (
+    finalized &&
+    activity.worksheetFields.some(
+      (field) => field.required && values[field.id] === undefined,
+    )
+  ) {
+    return undefined;
+  }
+  return { values, finalized };
 }
 
 export function isPrioritizationResponse(

--- a/apps/commons-courses/lib/live-session-data.ts
+++ b/apps/commons-courses/lib/live-session-data.ts
@@ -16,6 +16,7 @@ import type {
 import {
   decodeOtherResponse,
   normalizePrioritizationResponse,
+  normalizeWorksheetResponse,
 } from "@/lib/live-response-policy";
 
 type LiveSessionDocumentLike = ILiveSession & {
@@ -197,6 +198,28 @@ function buildActivityResults(
             finalized: value.finalized,
           },
         ];
+      }),
+    };
+  }
+  if (activity.type === "worksheet") {
+    return {
+      total: responses.length,
+      worksheets: responses.flatMap((response) => {
+        const value = normalizeWorksheetResponse(activity, response.value);
+        if (!value) return [];
+        return [{
+          id: String(response._id),
+          participantName: revealNames
+            ? response.participantId?.displayName || "Learner"
+            : undefined,
+          values: (activity.worksheetFields || []).flatMap((field) => {
+            const answer = value.values[field.id];
+            return answer === undefined
+              ? []
+              : [{ fieldId: field.id, label: field.label, value: String(answer) }];
+          }),
+          finalized: value.finalized,
+        }];
       }),
     };
   }

--- a/apps/commons-courses/lib/live-session-input.ts
+++ b/apps/commons-courses/lib/live-session-input.ts
@@ -3,6 +3,7 @@ import type {
   LiveActivity,
   LiveActivityOption,
   LiveActivityType,
+  LiveWorksheetField,
   LiveSessionAccess,
   LiveSessionPace,
 } from "@/types/live-session";
@@ -17,6 +18,7 @@ const activityTypes: LiveActivityType[] = [
   "poll",
   "quiz",
   "prioritization",
+  "worksheet",
   "reflection",
   "task",
   "break",
@@ -56,9 +58,43 @@ export function createActivity(
     selectionPrompt: clean(input.selectionPrompt),
     minItems: clampNumber(input.minItems, 1, 50),
     maxSelections: clampNumber(input.maxSelections, 1, 10),
+    worksheetFields: normalizeWorksheetFields(input.worksheetFields),
     points: clampNumber(input.points, 0, 10_000) || 0,
     options: normalizeOptions(input.options),
   };
+}
+
+function normalizeWorksheetFields(input: unknown): LiveWorksheetField[] {
+  if (!Array.isArray(input)) return [];
+  const allowedTypes = new Set(["short_text", "long_text", "scale", "date"]);
+  const seen = new Set<string>();
+  return input.slice(0, 80).flatMap((value, index) => {
+    if (!value || typeof value !== "object") return [];
+    const source = value as Partial<LiveWorksheetField>;
+    const sourceId = clean(source.id) || `field-${index + 1}`;
+    const id = sourceId.replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 80);
+    const label = clean(source.label);
+    if (!id || !label || seen.has(id)) return [];
+    seen.add(id);
+    const type = allowedTypes.has(String(source.type))
+      ? (source.type as LiveWorksheetField["type"])
+      : "short_text";
+    const min = type === "scale" ? clampNumber(source.min, 0, 20) ?? 1 : undefined;
+    const max = type === "scale" ? clampNumber(source.max, min || 1, 20) ?? 5 : undefined;
+    return [{
+      id,
+      label,
+      type,
+      section: clean(source.section),
+      description: clean(source.description),
+      placeholder: clean(source.placeholder),
+      required: Boolean(source.required),
+      min,
+      max,
+      lowLabel: clean(source.lowLabel),
+      highLabel: clean(source.highLabel),
+    }];
+  });
 }
 
 function cleanLabEntryPath(value: unknown) {

--- a/apps/commons-courses/models/LiveSession.ts
+++ b/apps/commons-courses/models/LiveSession.ts
@@ -36,6 +36,27 @@ const LiveActivityOptionSchema = new Schema(
   { _id: false },
 );
 
+const LiveWorksheetFieldSchema = new Schema(
+  {
+    id: { type: String, required: true, trim: true },
+    label: { type: String, required: true, trim: true },
+    type: {
+      type: String,
+      enum: ["short_text", "long_text", "scale", "date"],
+      required: true,
+    },
+    section: { type: String, trim: true },
+    description: { type: String, trim: true },
+    placeholder: { type: String, trim: true },
+    required: { type: Boolean, default: false },
+    min: Number,
+    max: Number,
+    lowLabel: { type: String, trim: true },
+    highLabel: { type: String, trim: true },
+  },
+  { _id: false },
+);
+
 const LiveActivitySchema = new Schema<LiveActivity>(
   {
     id: { type: String, required: true, trim: true },
@@ -47,6 +68,7 @@ const LiveActivitySchema = new Schema<LiveActivity>(
         "poll",
         "quiz",
         "prioritization",
+        "worksheet",
         "reflection",
         "task",
         "break",
@@ -82,6 +104,7 @@ const LiveActivitySchema = new Schema<LiveActivity>(
     selectionPrompt: { type: String, trim: true },
     minItems: { type: Number, min: 1, max: 50 },
     maxSelections: { type: Number, min: 1, max: 10 },
+    worksheetFields: { type: [LiveWorksheetFieldSchema], default: [] },
     points: { type: Number, default: 0, min: 0 },
     options: { type: [LiveActivityOptionSchema], default: [] },
   },

--- a/apps/commons-courses/scripts/seed-ai-quick-wins-workshop.mjs
+++ b/apps/commons-courses/scripts/seed-ai-quick-wins-workshop.mjs
@@ -22,8 +22,8 @@ let cachedPdfTools;
 const inputs = {
   deck: requiredArgument("deck"),
   workbook: requiredArgument("workbook"),
-  cards: requiredArgument("cards"),
-  guide: requiredArgument("guide"),
+  cards: argument("cards"),
+  guide: argument("guide"),
 };
 
 if (!dryRun && !process.env.MONGODB_URI) {
@@ -335,6 +335,75 @@ function createDiscoverActivities(materialId) {
     options: [],
     ...extra,
   });
+  const field = (id, label, type = "short_text", extra = {}) => ({
+    id,
+    label,
+    type,
+    required: false,
+    ...extra,
+  });
+  const worksheet = (
+    id,
+    title,
+    prompt,
+    slide,
+    minutes,
+    worksheetFields,
+    extra = {},
+  ) => ({
+    ...content(id, title, prompt, slide, minutes),
+    type: "worksheet",
+    required: true,
+    worksheetFields,
+    ...extra,
+  });
+  const taskCardFields = (card) => [
+    field(`task-${card}-name`, "1. Task name", "short_text", {
+      required: true,
+      placeholder: "Six words or fewer",
+      section: `Task ${card}`,
+    }),
+    field(`task-${card}-trigger`, "2. What triggers it?", "long_text", {
+      required: true,
+      section: `Task ${card}`,
+    }),
+    field(`task-${card}-frequency`, "3. How often, and how long does it take?", "long_text", { section: `Task ${card}` }),
+    field(`task-${card}-tools`, "4. Which tools or apps are involved?", "long_text", { section: `Task ${card}` }),
+    field(`task-${card}-inputs`, "5. What inputs are needed, and where do they live?", "long_text", { section: `Task ${card}` }),
+    field(`task-${card}-steps`, "6. What are the steps?", "long_text", { required: true, section: `Task ${card}` }),
+    field(`task-${card}-judgment`, "7. Where do you pause and think?", "long_text", { section: `Task ${card}` }),
+    field(`task-${card}-exceptions`, "8. What exceptions change the process?", "long_text", { section: `Task ${card}` }),
+    field(`task-${card}-quality`, "9. What separates a good result from a bad one?", "long_text", { required: true, section: `Task ${card}` }),
+    field(`task-${card}-tacit`, "10. What part do you ‘just know’?", "long_text", { section: `Task ${card}` }),
+    field(`task-${card}-loss`, "11. What would be lost if this were delegated?", "long_text", { section: `Task ${card}` }),
+    field(`task-${card}-never`, "12. What should AI never give up?", "long_text", { section: `Task ${card}` }),
+  ];
+  const scoreCriteria = [
+    ["frequency", "Frequency"],
+    ["time", "Time cost"],
+    ["repeatability", "Repeatability"],
+    ["verifiability", "Verifiability"],
+    ["reversibility", "Reversibility"],
+    ["access", "Data access"],
+    ["judgment", "Low judgment density"],
+  ];
+  const scorecardFields = [1, 2, 3, 4].flatMap((task) => [
+    field(`score-task-${task}-name`, `Task ${task} name`, "short_text", {
+      required: true,
+      section: `Candidate ${task}`,
+      placeholder: "Copy one of your shortlisted routines",
+    }),
+    ...scoreCriteria.map(([id, label]) =>
+      field(`score-task-${task}-${id}`, label, "scale", {
+        section: `Candidate ${task}`,
+        min: 1,
+        max: 5,
+        lowLabel: "Low",
+        highLabel: "High",
+      }),
+    ),
+  ]);
+
   return [
     content(
       "discover-welcome",
@@ -347,34 +416,37 @@ function createDiscoverActivities(materialId) {
           "Set the promise and the boundary together: this is a build, not a tour of tools.",
       },
     ),
-    {
-      ...content(
-        "discover-outcome-contract",
-        "Your outcome contract",
-        "By the end of Day 4, what will you be able to do—and what observable evidence will prove it worked?",
-        8,
-        5,
-      ),
-      type: "reflection",
-      instructions:
-        "Complete both halves in one sentence. Make the outcome observable enough that a colleague could tell whether it happened.",
-      successCriteria:
-        "Your sentence names a changed action and evidence you could actually observe.",
-      required: true,
-    },
+    worksheet(
+      "discover-outcome-contract",
+      "Your outcome contract",
+      "Define what will change by the end of Day 4 and how you will know it worked.",
+      7,
+      7,
+      [
+        field("outcome", "By the end of session four, I will be able to…", "long_text", { required: true, section: "Outcome contract" }),
+        field("evidence", "The evidence that it worked will be…", "long_text", { required: true, section: "Outcome contract" }),
+        field("signature", "Name or signature", "short_text", { section: "Outcome contract" }),
+      ],
+      {
+        instructions:
+          "Make the outcome observable enough that a colleague could tell whether it happened. Save progress at any point, then complete the section when you are ready.",
+        successCriteria:
+          "Your statement names a changed action and evidence you could actually observe.",
+      },
+    ),
     content(
       "discover-reality-check",
-      "The reality check",
-      "AI adoption is widespread. Reliable value capture is not. These numbers show why leadership and organisational design matter.",
-      9,
-      7,
+      "Why most AI activity does not become value",
+      "Separate experimentation from reliable organisational value, and identify what has to change.",
+      8,
+      10,
     ),
     content(
       "discover-building-blocks",
       "The building blocks of agentic AI",
-      "Place models, skills, tools, workflows, schedules, and connections on one practical map.",
+      "Place models, skills, tools, workflows, schedules, harnesses, and connections on one practical map.",
       14,
-      20,
+      18,
     ),
     {
       id: "discover-ladder-check",
@@ -384,7 +456,7 @@ function createDiscoverActivities(materialId) {
       instructions:
         "Choose honestly. This is a starting point, not a score, and we will revisit it on Day 4.",
       materialId,
-      materialStartSlide: 20,
+      materialStartSlide: 18,
       estimatedMinutes: 4,
       status: "draft",
       required: true,
@@ -407,113 +479,135 @@ function createDiscoverActivities(materialId) {
       "Live build: the daily email triage",
       "Watch one ordinary task climb from a prompt to a reusable skill, connected workflow, and scheduled task.",
       21,
-      20,
+      18,
       {
         facilitatorNotes:
           "Bashy drives; Jessica narrates the business meaning. Do not teach the clicks.",
       },
     ),
-    content(
+    worksheet(
       "discover-foundations",
       "AI in your organisation",
       "Audit the four foundations: knowledge, tools, procedures, and rules.",
       24,
       15,
+      [
+        field("knowledge", "Knowledge: what does the organisation need to know, and where does it live?", "long_text", { required: true, section: "Organisational foundations" }),
+        field("tools", "Tools: which systems does the organisation actually use?", "long_text", { required: true, section: "Organisational foundations" }),
+        field("procedures", "Procedures: where are repeatable processes written down—or only held in people’s heads?", "long_text", { required: true, section: "Organisational foundations" }),
+        field("rules", "Rules: what policies, boundaries, approvals, and risks must an AI system respect?", "long_text", { required: true, section: "Organisational foundations" }),
+      ],
       {
         instructions:
-          "As a group, capture where organisational knowledge lives and which systems the organisation actually runs.",
+          "Capture your own organisation’s current state. Specific systems, documents, and unwritten rules are more useful than general statements.",
+      },
+    ),
+    worksheet(
+      "discover-tool-trust",
+      "Tool and trust inventory",
+      "Where are you already using AI—and where has trust broken down?",
+      31,
+      8,
+      [
+        ...[1, 2, 3, 4].flatMap((row) => [
+          field(`tool-${row}`, "Tool", "short_text", { section: `Tool ${row}` }),
+          field(`tool-${row}-frequency`, "How often do you use it?", "short_text", { section: `Tool ${row}` }),
+          field(`tool-${row}-use`, "What do you use it for?", "long_text", { section: `Tool ${row}` }),
+          field(`tool-${row}-trust`, "Where did you stop trusting it?", "long_text", { section: `Tool ${row}` }),
+        ]),
+        field("gave-up", "What have you tried and given up on?", "long_text", { required: true, section: "Patterns" }),
+        field("repeated-context", "Where do you paste the same context again and again?", "long_text", { required: true, section: "Patterns" }),
+      ],
+      {
+        instructions:
+          "Repeated context is often a reusable skill waiting to be written. Be specific about where trust broke down.",
       },
     ),
     {
-      ...content(
-        "discover-tool-trust",
-        "Tool and trust inventory",
-        "Where are you already using AI—and where has trust broken down?",
-        31,
-        5,
-      ),
-      type: "reflection",
-      instructions:
-        "Name one thing you tried and gave up on, then identify context you repeatedly paste into an AI tool. Repeated context is often a reusable skill waiting to be written.",
-      required: true,
-    },
-    {
       id: "discover-routine-shortlist",
       type: "prioritization",
-      title: "Routine storm: what repeats in your week?",
+      title: "Sweep your week: what repeats?",
       prompt:
-        "Capture as many recurring routines as you can, then shortlist the ones you would most like to automate or offload.",
+        "Capture as many recurring routines as you can, then shortlist four you would most like to automate or offload.",
       instructions:
         "Think across meetings, reporting, communication, approvals, research, follow-up, planning, data entry, and coordination. Keep each routine short and specific. Quantity first; selection second.",
       successCriteria:
-        "You have at least five real routines and a shortlist of up to three automation candidates.",
+        "You have at least eight real routines and a shortlist of four automation candidates.",
       facilitatorNotes:
-        "Give the room three silent minutes for quantity, then ask them to shortlist. If someone stalls, ask what they did three times last week.",
+        "Give the room four silent minutes for quantity, then ask them to shortlist four. If someone stalls, ask what they did three times last week.",
       materialId,
-      materialStartSlide: 32,
-      estimatedMinutes: 12,
+      materialStartSlide: 34,
+      estimatedMinutes: 14,
       status: "draft",
       required: true,
       randomizeOptions: false,
       showResults: false,
       entryLabel: "Add a routine you repeat",
       selectionPrompt:
-        "Choose up to three routines you would feel relieved to automate or offload.",
-      minItems: 5,
-      maxSelections: 3,
+        "Choose four routines you would feel relieved to automate or offload.",
+      minItems: 8,
+      maxSelections: 4,
       points: 0,
       options: [],
     },
-    {
-      ...content(
-        "discover-pair-interview",
-        "Pair interview: unpack one real routine",
-        "Interview your partner about one shortlisted routine and surface the judgment hidden inside it.",
-        33,
-        18,
-      ),
-      type: "task",
-      instructions:
-        "The interviewer asks and writes. Focus especially on decisions, exceptions, the quality bar, and anything described as ‘I just know’. Add a concise note capturing the most important hidden decision or exception you uncovered.",
-      successCriteria:
-        "You can name the steps, at least one decision point, one exception, and what good looks like.",
-      required: true,
-    },
-    {
-      ...content(
-        "discover-final-choice",
-        "Choose the first task to offload",
-        "Score your shortlisted routines and name the first one you will carry through all four days.",
+    ...[1, 2, 3, 4].map((card) =>
+      worksheet(
+        `discover-task-anatomy-${card}`,
+        `Task anatomy card ${card}`,
+        "Unpack one shortlisted routine and surface the judgment hidden inside it.",
         35,
-        10,
-      ),
-      type: "reflection",
-      instructions:
-        "Consider frequency, time cost, repeatability, verifiability, reversibility, data access, and judgment density. For a first build, favour something easy to verify and easy to reverse.",
-      successCriteria:
-        "Name one task in six words or fewer and explain why it is a safe, useful first build.",
-      required: true,
-    },
-    {
-      ...content(
-        "discover-recording-commitment",
-        "Your recording commitment",
-        "What will you record before Day 2, and by when?",
-        36,
         8,
+        taskCardFields(card),
+        {
+          instructions:
+            "Work from the real task, not the ideal process. Capture decisions, exceptions, the quality bar, and anything you describe as ‘I just know’. Save progress if you need to return to it.",
+          successCriteria:
+            "You can name the steps, at least one decision point, one exception, and what good looks like.",
+        },
       ),
-      type: "task",
-      instructions:
-        "Write: ‘I am recording ___ by ___.’ Record one full run with your voice, narrating decisions rather than clicks. Add any support you need before you begin.",
-      successCriteria:
-        "The task and deadline are explicit enough to read aloud to the room.",
-      required: true,
-    },
+    ),
+    worksheet(
+      "discover-final-choice",
+      "Choose the first task to offload",
+      "Score your four candidates and choose the first one you will carry through all four sessions.",
+      36,
+      12,
+      [
+        ...scorecardFields,
+        field("selected-task", "The first task I will offload is…", "short_text", { required: true, section: "Decision", placeholder: "Six words or fewer" }),
+        field("selection-reason", "Why is this a safe, useful first build?", "long_text", { required: true, section: "Decision" }),
+      ],
+      {
+        instructions:
+          "Consider frequency, time cost, repeatability, verifiability, reversibility, data access, and judgment density. For a first build, favour something easy to verify and easy to reverse.",
+        successCriteria:
+          "Name one task in six words or fewer and explain why it is a safe, useful first build.",
+      },
+    ),
+    worksheet(
+      "discover-recording-commitment",
+      "Your recording commitment",
+      "What will you record before Day 2, and by when?",
+      37,
+      8,
+      [
+        field("recorded-task", "The task I will record", "short_text", { required: true, section: "Assignment" }),
+        field("recording-date", "I will record it by", "date", { required: true, section: "Assignment" }),
+        field("support-needed", "What help, access, or support do you need?", "long_text", { section: "Assignment" }),
+        field("commitment", "Write your commitment in one sentence", "long_text", { required: true, section: "Commitment", placeholder: "I am recording ___ by ___." }),
+      ],
+      {
+        instructions:
+          "Record one full run with your voice, narrating decisions rather than clicks. Add any support you need before you begin.",
+        successCriteria:
+          "The task and deadline are explicit enough to read aloud to the room.",
+      },
+    ),
     content(
       "discover-close",
       "Close and next step",
       "Day 2 turns your recording into a reusable skill file that can run consistently.",
-      37,
+      39,
       2,
     ),
   ];
@@ -528,7 +622,7 @@ async function prepareAssets(source, workDir) {
     ["workbook", source.workbook, "Session 1 Participant Workbook.pdf", "course"],
     ["cards", source.cards, "Session 1 Reference Cards.pdf", "course"],
     ["guide", source.guide, "Session 1 Facilitator Guide.pdf", "educator"],
-  ];
+  ].filter(([, sourcePath]) => Boolean(sourcePath));
   const assets = {
     deck: {
       key: "deck",
@@ -540,6 +634,7 @@ async function prepareAssets(source, workDir) {
       bytes: deckBytes,
       pages: deckPages,
       textPreview: deckText,
+      aliases: ["AI Quick Win for Leaders.pptx"],
     },
   };
   for (const [key, sourcePath, name, visibility] of documentDefinitions) {
@@ -559,6 +654,9 @@ async function prepareAssets(source, workDir) {
 }
 
 async function convertToPdf(sourcePath, workDir, prefix) {
+  if (path.extname(sourcePath).toLowerCase() === ".pdf") {
+    return readFile(sourcePath);
+  }
   const inputDir = path.join(workDir, `${prefix}-input`);
   const outputDir = path.join(workDir, `${prefix}-output`);
   const profileDir = path.join(workDir, `${prefix}-profile`);
@@ -789,8 +887,11 @@ async function syncMaterial({
   const collection = db.collection("coursematerials");
   const existing = await collection.findOne({
     courseId: course._id,
-    name: asset.name,
+    name: { $in: [asset.name, ...(asset.aliases || [])] },
   });
+  const materialFilter = existing?._id
+    ? { _id: existing._id }
+    : { courseId: course._id, name: asset.name };
   const newIds = [];
   let committed = false;
   try {
@@ -813,9 +914,10 @@ async function syncMaterial({
       slideIds.push(slideId);
     }
     const material = await collection.findOneAndUpdate(
-      { courseId: course._id, name: asset.name },
+      materialFilter,
       {
         $set: {
+          name: asset.name,
           courseSlug: slug,
           ownerUserId: owner._id,
           ownerPrincipalId: String(principalId),
@@ -873,7 +975,7 @@ async function createUniqueJoinCode(db) {
 
 async function writePreviews(pages, targetDir) {
   await mkdir(targetDir, { recursive: true });
-  const indexes = [0, 7, 31, pages.length - 1].filter(
+  const indexes = [0, 6, 7, 17, 20, 23, 30, 31, 33, 34, 35, 36, 37, pages.length - 1].filter(
     (value, index, values) =>
       value >= 0 && value < pages.length && values.indexOf(value) === index,
   );

--- a/apps/commons-courses/types/live-session.ts
+++ b/apps/commons-courses/types/live-session.ts
@@ -10,6 +10,7 @@ export type LiveActivityType =
   | "poll"
   | "quiz"
   | "prioritization"
+  | "worksheet"
   | "reflection"
   | "task"
   | "break";
@@ -17,6 +18,26 @@ export type LiveActivityType =
 export type LiveActivityStatus = "draft" | "open" | "closed";
 
 export type LiveActivityResponseStyle = "cards" | "scale";
+
+export type LiveWorksheetFieldType =
+  | "short_text"
+  | "long_text"
+  | "scale"
+  | "date";
+
+export type LiveWorksheetField = {
+  id: string;
+  label: string;
+  type: LiveWorksheetFieldType;
+  section?: string;
+  description?: string;
+  placeholder?: string;
+  required: boolean;
+  min?: number;
+  max?: number;
+  lowLabel?: string;
+  highLabel?: string;
+};
 
 export type LiveActivityOption = {
   id: string;
@@ -49,6 +70,7 @@ export type LiveActivity = {
   selectionPrompt?: string;
   minItems?: number;
   maxSelections?: number;
+  worksheetFields?: LiveWorksheetField[];
   points: number;
   options: LiveActivityOption[];
 };
@@ -64,10 +86,16 @@ export type LivePrioritizationResponse = {
   finalized: boolean;
 };
 
+export type LiveWorksheetResponse = {
+  values: Record<string, string | number>;
+  finalized: boolean;
+};
+
 export type LiveResponseValue =
   | string
   | string[]
-  | LivePrioritizationResponse;
+  | LivePrioritizationResponse
+  | LiveWorksheetResponse;
 
 export type LiveSessionSettings = {
   allowLateJoin: boolean;
@@ -149,6 +177,12 @@ export type LiveActivityResults = {
     participantName?: string;
     items: string[];
     selectedItems: string[];
+    finalized: boolean;
+  }>;
+  worksheets?: Array<{
+    id: string;
+    participantName?: string;
+    values: Array<{ fieldId: string; label: string; value: string }>;
     finalized: boolean;
   }>;
 };


### PR DESCRIPTION
## Summary
- add a reusable structured worksheet activity for live courses
- let learners save progress, complete required fields, and revise while activities remain open
- give facilitators expandable learner worksheet responses and engagement summaries
- update the AI Quick Wins seed plan for the revised 39-slide Discover deck and fillable participant workbook

## Validation
- 35 commons-courses tests pass
- TypeScript passes
- targeted ESLint passes
- revised deck renders as 39 styled slides; key activity slide mapping visually verified
- Next production compilation succeeds; local page-data collection requires production service credentials