### PR TITLE
Fix learner-paced live session navigation

### DIFF
--- a/apps/commons-courses/app/api/educator/live-sessions/[id]/route.ts
+++ b/apps/commons-courses/app/api/educator/live-sessions/[id]/route.ts
@@ -8,8 +8,23 @@ import {
   getSessionResults,
   serializeEducatorLiveSession,
 } from "@/lib/live-session-data";
-import LiveSession from "@/models/LiveSession";
+import LiveSession, { type ILiveSession } from "@/models/LiveSession";
 import type { LiveActivity } from "@/types/live-session";
+import { activityStatusesForLivePace } from "@/lib/live-session-pacing";
+
+function syncActivityStatusesForPace(
+  session: ILiveSession,
+) {
+  const next = activityStatusesForLivePace({
+    activities: session.activities,
+    currentActivityId: session.currentActivityId,
+    pace: session.pace,
+  });
+  session.currentActivityId = next.currentActivityId;
+  for (const activity of session.activities) {
+    activity.status = next.statuses[activity.id];
+  }
+}
 
 async function authorize(id: string) {
   if (!Types.ObjectId.isValid(id)) return null;
@@ -62,20 +77,7 @@ export async function PATCH(
     session.status = "lobby";
   } else if (record.command === "start") {
     session.status = "live";
-    const current = session.activities.find(
-      (activity: LiveActivity) =>
-        activity.id === session.currentActivityId && activity.status === "open",
-    );
-    const first = current || session.activities[0];
-    if (first) {
-      if (session.pace === "learner") {
-        for (const activity of session.activities) activity.status = "open";
-      } else {
-        for (const activity of session.activities)
-          activity.status = activity.id === first.id ? "open" : "closed";
-      }
-      session.currentActivityId = first.id;
-    }
+    syncActivityStatusesForPace(session);
   } else if (record.command === "end") {
     session.status = "ended";
     for (const activity of session.activities) {
@@ -96,12 +98,7 @@ export async function PATCH(
     }
     session.status = "live";
     session.currentActivityId = activityId;
-    for (const activity of session.activities) {
-      if (activity.id === activityId) activity.status = "open";
-      else if (session.pace === "facilitator" && activity.status === "open") {
-        activity.status = "closed";
-      }
-    }
+    syncActivityStatusesForPace(session);
   } else if (record.command === "close_activity") {
     const activityId =
       typeof record.activityId === "string" ? record.activityId : "";
@@ -116,6 +113,9 @@ export async function PATCH(
     activity.status = "closed";
   } else if (Object.keys(patch).length) {
     session.set(patch);
+    if (session.status === "live" && "pace" in patch) {
+      syncActivityStatusesForPace(session);
+    }
   }
 
   session.stateVersion = (session.stateVersion || 0) + 1;

--- a/apps/commons-courses/components/live/live-learner-room.tsx
+++ b/apps/commons-courses/components/live/live-learner-room.tsx
@@ -293,6 +293,9 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
     [session],
   );
   const activityPosition = activityIndex >= 0 ? activityIndex + 1 : null;
+  const availableActivityIndex = availableActivities.findIndex(
+    (item) => item.id === selectedId,
+  );
 
   async function submit(valueOverride?: LiveResponseValue) {
     if (!activity || submitting) return;
@@ -326,11 +329,8 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
   }
 
   function goNext() {
-    if (!session) return;
-    const index = availableActivities.findIndex(
-      (item) => item.id === selectedId,
-    );
-    const next = availableActivities[index + 1];
+    if (!session || availableActivityIndex < 0) return;
+    const next = availableActivities[availableActivityIndex + 1];
     if (next) setSelectedId(next.id);
   }
 
@@ -530,16 +530,12 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
             <div className="mt-5 flex justify-between">
               <button
                 disabled={
-                  availableActivities.findIndex(
-                    (item) => item.id === activity.id,
-                  ) <= 0
+                  availableActivityIndex <= 0
                 }
                 onClick={() => {
-                  const index = availableActivities.findIndex(
-                    (item) => item.id === activity.id,
-                  );
                   setSelectedId(
-                    availableActivities[index - 1]?.id || activity.id,
+                    availableActivities[availableActivityIndex - 1]?.id ||
+                      activity.id,
                   );
                 }}
                 className="inline-flex items-center gap-2 text-sm font-bold text-slate-500 disabled:opacity-30"
@@ -547,8 +543,12 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
                 <ArrowLeft className="h-4 w-4" /> Previous
               </button>
               <button
+                disabled={
+                  availableActivityIndex < 0 ||
+                  availableActivityIndex >= availableActivities.length - 1
+                }
                 onClick={goNext}
-                className="inline-flex items-center gap-2 text-sm font-bold text-slate-700"
+                className="inline-flex items-center gap-2 text-sm font-bold text-slate-700 disabled:opacity-30"
               >
                 Next <ArrowRight className="h-4 w-4" />
               </button>

--- a/apps/commons-courses/lib/live-session-pacing.test.mts
+++ b/apps/commons-courses/lib/live-session-pacing.test.mts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { LiveActivity } from "../types/live-session.ts";
+import { activityStatusesForLivePace } from "./live-session-pacing.ts";
+
+const activities = [
+  activity("first", "closed"),
+  activity("current", "open"),
+  activity("future", "draft"),
+];
+
+test("learner pace opens the complete run of show", () => {
+  assert.deepEqual(
+    activityStatusesForLivePace({
+      activities,
+      currentActivityId: "current",
+      pace: "learner",
+    }),
+    {
+      currentActivityId: "current",
+      statuses: { first: "open", current: "open", future: "open" },
+    },
+  );
+});
+
+test("facilitator pace keeps only the presented activity open", () => {
+  assert.deepEqual(
+    activityStatusesForLivePace({
+      activities,
+      currentActivityId: "current",
+      pace: "facilitator",
+    }),
+    {
+      currentActivityId: "current",
+      statuses: { first: "closed", current: "open", future: "closed" },
+    },
+  );
+});
+
+test("falls back to the first activity when the presented id is stale", () => {
+  const result = activityStatusesForLivePace({
+    activities,
+    currentActivityId: "missing",
+    pace: "learner",
+  });
+  assert.equal(result.currentActivityId, "first");
+});
+
+function activity(
+  id: string,
+  status: LiveActivity["status"],
+): LiveActivity {
+  return {
+    id,
+    status,
+    type: "content",
+    title: id,
+    required: false,
+    randomizeOptions: false,
+    showResults: false,
+    points: 0,
+    options: [],
+  };
+}

--- a/apps/commons-courses/lib/live-session-pacing.ts
+++ b/apps/commons-courses/lib/live-session-pacing.ts
@@ -1,0 +1,25 @@
+import type {
+  LiveActivity,
+  LiveActivityStatus,
+  LiveSessionPace,
+} from "@/types/live-session";
+
+export function activityStatusesForLivePace({
+  activities,
+  currentActivityId,
+  pace,
+}: {
+  activities: LiveActivity[];
+  currentActivityId?: string;
+  pace: LiveSessionPace;
+}) {
+  const current =
+    activities.find((activity) => activity.id === currentActivityId) ||
+    activities[0];
+  const statuses: Record<string, LiveActivityStatus> = {};
+  for (const activity of activities) {
+    statuses[activity.id] =
+      pace === "learner" || activity.id === current?.id ? "open" : "closed";
+  }
+  return { currentActivityId: current?.id, statuses };
+}


### PR DESCRIPTION
## Summary
- open the full run of show whenever a live room starts or switches to learner pace
- normalize activity states when switching back to facilitator pace
- ensure facilitator activation respects the selected delivery pace
- disable learner Next/Previous controls at real boundaries instead of showing inert navigation

## Validation
- 38 commons-courses tests pass
- TypeScript passes
- targeted ESLint passes
- added regression coverage for learner-paced, facilitator-paced, and stale-current-activity transitions