### PR TITLE
Link repeatable task cards to live scorecards

### DIFF
--- a/apps/commons-courses/app/api/live-sessions/[id]/responses/route.ts
+++ b/apps/commons-courses/app/api/live-sessions/[id]/responses/route.ts
@@ -8,6 +8,8 @@ import LiveSession from "@/models/LiveSession";
 import type { LiveActivity, LiveActivityOption } from "@/types/live-session";
 import {
   isValidLiveResponse,
+  normalizeCardCollectionResponse,
+  normalizeLinkedScorecardResponse,
   normalizePrioritizationResponse,
   normalizeWorksheetResponse,
 } from "@/lib/live-response-policy";
@@ -33,21 +35,62 @@ export async function POST(
       typeof value !== "string" &&
       (!value || typeof value !== "object"))
   ) {
-    return NextResponse.json({ error: "activityId and a response are required." }, { status: 400 });
+    return NextResponse.json(
+      { error: "activityId and a response are required." },
+      { status: 400 },
+    );
   }
   if (typeof value === "string" && (!value.trim() || value.length > 10_000)) {
-    return NextResponse.json({ error: "Enter a response under 10,000 characters." }, { status: 400 });
+    return NextResponse.json(
+      { error: "Enter a response under 10,000 characters." },
+      { status: 400 },
+    );
   }
   await connectDB();
   const session = await LiveSession.findById(id);
-  const activity = session?.activities.find((item: LiveActivity) => item.id === activityId);
+  const activity = session?.activities.find(
+    (item: LiveActivity) => item.id === activityId,
+  );
   if (!session || !activity) {
     return NextResponse.json({ error: "Activity not found." }, { status: 404 });
   }
   if (activity.status !== "open") {
-    return NextResponse.json({ error: "This activity is not open." }, { status: 409 });
+    return NextResponse.json(
+      { error: "This activity is not open." },
+      { status: 409 },
+    );
   }
-  if (!isValidLiveResponse(activity, value)) {
+  if (
+    session.pace === "facilitator" &&
+    session.currentActivityId !== activity.id
+  ) {
+    return NextResponse.json(
+      { error: "Wait for the facilitator to open this activity." },
+      { status: 409 },
+    );
+  }
+  const participant = await LiveParticipant.findOne({
+    sessionId: session._id,
+    userId: currentUser.user.id,
+  });
+  if (!participant) {
+    return NextResponse.json(
+      { error: "Join the session before responding." },
+      { status: 403 },
+    );
+  }
+  const sourceResponse = activity.sourceActivityId
+    ? await LiveResponse.findOne({
+        sessionId: session._id,
+        activityId: activity.sourceActivityId,
+        participantId: participant._id,
+      }).lean()
+    : null;
+  const sourceValue =
+    sourceResponse && !Array.isArray(sourceResponse)
+      ? (sourceResponse as unknown as { value?: unknown }).value
+      : undefined;
+  if (!isValidLiveResponse(activity, value, sourceValue)) {
     return NextResponse.json(
       { error: "Choose a valid response before submitting." },
       { status: 400 },
@@ -58,22 +101,16 @@ export async function POST(
       ? normalizePrioritizationResponse(activity, value)
       : activity.type === "worksheet"
         ? normalizeWorksheetResponse(activity, value)
-      : value;
+        : activity.type === "card_collection"
+          ? normalizeCardCollectionResponse(activity, value)
+          : activity.type === "linked_scorecard"
+            ? normalizeLinkedScorecardResponse(activity, value, sourceValue)
+            : value;
   if (responseValue === undefined) {
     return NextResponse.json(
       { error: "Add a valid response before saving." },
       { status: 400 },
     );
-  }
-  if (session.pace === "facilitator" && session.currentActivityId !== activity.id) {
-    return NextResponse.json({ error: "Wait for the facilitator to open this activity." }, { status: 409 });
-  }
-  const participant = await LiveParticipant.findOne({
-    sessionId: session._id,
-    userId: currentUser.user.id,
-  });
-  if (!participant) {
-    return NextResponse.json({ error: "Join the session before responding." }, { status: 403 });
   }
   const selectedValues = Array.isArray(responseValue)
     ? responseValue.map(String)
@@ -110,7 +147,9 @@ export async function POST(
       activityId,
       value: response.value,
       correct:
-        activity.showResults && activity.status === "closed" ? response.correct : undefined,
+        activity.showResults && activity.status === "closed"
+          ? response.correct
+          : undefined,
       pointsAwarded: response.pointsAwarded,
       submittedAt: response.submittedAt,
     },

--- a/apps/commons-courses/components/educator/live-facilitator-studio.tsx
+++ b/apps/commons-courses/components/educator/live-facilitator-studio.tsx
@@ -78,6 +78,16 @@ const activityChoices: Array<{
     hint: "Structured fields learners can save and complete",
   },
   {
+    type: "card_collection",
+    label: "Repeatable cards",
+    hint: "Learners add any number of structured cards",
+  },
+  {
+    type: "linked_scorecard",
+    label: "Linked scorecard",
+    hint: "Score and choose from cards captured earlier",
+  },
+  {
     type: "reflection",
     label: "Reflection",
     hint: "Open response or exit ticket",
@@ -260,13 +270,38 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
       minItems: type === "prioritization" ? 3 : undefined,
       maxSelections: type === "prioritization" ? 3 : undefined,
       worksheetFields:
-        type === "worksheet"
-          ? [{
-              id: crypto.randomUUID(),
-              label: "Workbook question",
-              type: "long_text",
-              required: true,
-            }]
+        type === "worksheet" || type === "card_collection"
+          ? [
+              {
+                id: "card-title",
+                label:
+                  type === "card_collection"
+                    ? "Card title"
+                    : "Workbook question",
+                type: "long_text",
+                required: true,
+              },
+            ]
+          : [],
+      itemTitleFieldId: type === "card_collection" ? "card-title" : undefined,
+      sourceActivityId:
+        type === "linked_scorecard"
+          ? data.session.activities.find(
+              (item) => item.type === "card_collection",
+            )?.id
+          : undefined,
+      scoreCriteria:
+        type === "linked_scorecard"
+          ? [
+              {
+                id: "impact",
+                label: "Impact",
+                min: 1,
+                max: 5,
+                lowLabel: "Low",
+                highLabel: "High",
+              },
+            ]
           : [],
       points: type === "quiz" ? 1 : 0,
       options: ["poll", "quiz", "setup_check"].includes(type)
@@ -741,6 +776,7 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
             {selected ? (
               <ActivityEditor
                 activity={selected}
+                activities={data.session.activities}
                 materials={materials}
                 labWorkspaces={labWorkspaces}
                 index={data.session.activities.findIndex(
@@ -1232,6 +1268,7 @@ function AddMenu({ onAdd }: { onAdd: (type: LiveActivityType) => void }) {
 
 function ActivityEditor({
   activity,
+  activities,
   materials,
   labWorkspaces,
   index,
@@ -1240,6 +1277,7 @@ function ActivityEditor({
   onRemove,
 }: {
   activity: LiveActivity;
+  activities: LiveActivity[];
   materials: CourseMaterialRecord[];
   labWorkspaces: LabWorkspaceRecord[];
   index: number;
@@ -1456,15 +1494,19 @@ function ActivityEditor({
           </p>
         </div>
       ) : null}
-      {activity.type === "worksheet" ? (
+      {activity.type === "worksheet" || activity.type === "card_collection" ? (
         <div className="mt-5 rounded-xl border border-slate-200 bg-slate-50 p-4">
           <div className="flex items-center justify-between gap-3">
             <div>
               <p className="text-xs font-bold uppercase tracking-wide text-slate-600">
-                Worksheet fields
+                {activity.type === "card_collection"
+                  ? "Fields on every card"
+                  : "Worksheet fields"}
               </p>
               <p className="mt-1 text-[11px] text-slate-500">
-                Group related questions with the same section title.
+                {activity.type === "card_collection"
+                  ? "Learners can create up to 50 cards with this same structure."
+                  : "Group related questions with the same section title."}
               </p>
             </div>
             <button
@@ -1476,8 +1518,48 @@ function ActivityEditor({
             </button>
           </div>
           <div className="mt-4 space-y-3">
+            {activity.type === "card_collection" ? (
+              <div className="grid gap-3 rounded-xl border border-slate-200 bg-white p-4 md:grid-cols-2">
+                <Field label="Card title field">
+                  <select
+                    value={activity.itemTitleFieldId || ""}
+                    onChange={(event) =>
+                      onChange({ itemTitleFieldId: event.target.value })
+                    }
+                    className={inputClass}
+                  >
+                    <option value="">Choose a field</option>
+                    {(activity.worksheetFields || []).map((field) => (
+                      <option key={field.id} value={field.id}>
+                        {field.label}
+                      </option>
+                    ))}
+                  </select>
+                </Field>
+                <Field label="Minimum cards to finish">
+                  <input
+                    type="number"
+                    min={1}
+                    max={50}
+                    value={activity.minItems || 1}
+                    onChange={(event) =>
+                      onChange({
+                        minItems: Math.max(
+                          1,
+                          Math.min(50, Number(event.target.value) || 1),
+                        ),
+                      })
+                    }
+                    className={inputClass}
+                  />
+                </Field>
+              </div>
+            ) : null}
             {(activity.worksheetFields || []).map((field, fieldIndex) => (
-              <div key={field.id} className="rounded-xl border border-slate-200 bg-white p-4">
+              <div
+                key={field.id}
+                className="rounded-xl border border-slate-200 bg-white p-4"
+              >
                 <div className="flex items-center justify-between gap-3">
                   <span className="text-[10px] font-bold uppercase tracking-wide text-slate-400">
                     Field {fieldIndex + 1}
@@ -1486,9 +1568,9 @@ function ActivityEditor({
                     type="button"
                     onClick={() =>
                       onChange({
-                        worksheetFields: (activity.worksheetFields || []).filter(
-                          (candidate) => candidate.id !== field.id,
-                        ),
+                        worksheetFields: (
+                          activity.worksheetFields || []
+                        ).filter((candidate) => candidate.id !== field.id),
                       })
                     }
                     className="p-1 text-slate-300 hover:text-red-600"
@@ -1502,7 +1584,9 @@ function ActivityEditor({
                     <input
                       value={field.label}
                       onChange={(event) =>
-                        updateWorksheetField(field.id, { label: event.target.value })
+                        updateWorksheetField(field.id, {
+                          label: event.target.value,
+                        })
                       }
                       className={inputClass}
                     />
@@ -1512,7 +1596,8 @@ function ActivityEditor({
                       value={field.type}
                       onChange={(event) =>
                         updateWorksheetField(field.id, {
-                          type: event.target.value as LiveWorksheetField["type"],
+                          type: event.target
+                            .value as LiveWorksheetField["type"],
                         })
                       }
                       className={inputClass}
@@ -1527,7 +1612,9 @@ function ActivityEditor({
                     <input
                       value={field.section || ""}
                       onChange={(event) =>
-                        updateWorksheetField(field.id, { section: event.target.value })
+                        updateWorksheetField(field.id, {
+                          section: event.target.value,
+                        })
                       }
                       placeholder="Optional group heading"
                       className={inputClass}
@@ -1537,7 +1624,9 @@ function ActivityEditor({
                     <input
                       value={field.description || ""}
                       onChange={(event) =>
-                        updateWorksheetField(field.id, { description: event.target.value })
+                        updateWorksheetField(field.id, {
+                          description: event.target.value,
+                        })
                       }
                       placeholder="Optional guidance"
                       className={inputClass}
@@ -1552,7 +1641,9 @@ function ActivityEditor({
                           max={20}
                           value={field.min ?? 1}
                           onChange={(event) =>
-                            updateWorksheetField(field.id, { min: Number(event.target.value) })
+                            updateWorksheetField(field.id, {
+                              min: Number(event.target.value),
+                            })
                           }
                           className={inputClass}
                         />
@@ -1564,7 +1655,9 @@ function ActivityEditor({
                           max={20}
                           value={field.max ?? 5}
                           onChange={(event) =>
-                            updateWorksheetField(field.id, { max: Number(event.target.value) })
+                            updateWorksheetField(field.id, {
+                              max: Number(event.target.value),
+                            })
                           }
                           className={inputClass}
                         />
@@ -1575,9 +1668,159 @@ function ActivityEditor({
                 <div className="mt-3">
                   <Toggle
                     checked={field.required}
-                    onChange={(required) => updateWorksheetField(field.id, { required })}
+                    onChange={(required) =>
+                      updateWorksheetField(field.id, { required })
+                    }
                     label="Required to complete"
                   />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+      {activity.type === "linked_scorecard" ? (
+        <div className="mt-5 rounded-xl border border-slate-200 bg-slate-50 p-4">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-wide text-slate-600">
+                Linked scoring criteria
+              </p>
+              <p className="mt-1 text-[11px] text-slate-500">
+                Learners score cards they captured in an earlier repeatable-card
+                activity.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() =>
+                onChange({
+                  scoreCriteria: [
+                    ...(activity.scoreCriteria || []),
+                    {
+                      id: crypto.randomUUID(),
+                      label: "New criterion",
+                      min: 1,
+                      max: 5,
+                    },
+                  ],
+                })
+              }
+              className="inline-flex items-center gap-1 text-xs font-bold text-slate-700"
+            >
+              <Plus className="h-3.5 w-3.5" /> Add criterion
+            </button>
+          </div>
+          <Field label="Source card activity">
+            <select
+              value={activity.sourceActivityId || ""}
+              onChange={(event) =>
+                onChange({ sourceActivityId: event.target.value })
+              }
+              className={inputClass}
+            >
+              <option value="">Choose repeatable cards</option>
+              {activities
+                .filter(
+                  (item) =>
+                    item.type === "card_collection" && item.id !== activity.id,
+                )
+                .map((item) => (
+                  <option key={item.id} value={item.id}>
+                    {item.title}
+                  </option>
+                ))}
+            </select>
+          </Field>
+          <div className="mt-4 space-y-3">
+            {(activity.scoreCriteria || []).map((criterion, criterionIndex) => (
+              <div
+                key={criterion.id}
+                className="rounded-xl border border-slate-200 bg-white p-4"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-[10px] font-bold uppercase tracking-wide text-slate-400">
+                    Criterion {criterionIndex + 1}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      onChange({
+                        scoreCriteria: (activity.scoreCriteria || []).filter(
+                          (item) => item.id !== criterion.id,
+                        ),
+                      })
+                    }
+                    className="p-1 text-slate-300 hover:text-red-600"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  <Field label="Label">
+                    <input
+                      value={criterion.label}
+                      onChange={(event) =>
+                        onChange({
+                          scoreCriteria: (activity.scoreCriteria || []).map(
+                            (item) =>
+                              item.id === criterion.id
+                                ? { ...item, label: event.target.value }
+                                : item,
+                          ),
+                        })
+                      }
+                      className={inputClass}
+                    />
+                  </Field>
+                  <Field label="Help text">
+                    <input
+                      value={criterion.description || ""}
+                      onChange={(event) =>
+                        onChange({
+                          scoreCriteria: (activity.scoreCriteria || []).map(
+                            (item) =>
+                              item.id === criterion.id
+                                ? { ...item, description: event.target.value }
+                                : item,
+                          ),
+                        })
+                      }
+                      className={inputClass}
+                    />
+                  </Field>
+                  <Field label="Low-end label">
+                    <input
+                      value={criterion.lowLabel || ""}
+                      onChange={(event) =>
+                        onChange({
+                          scoreCriteria: (activity.scoreCriteria || []).map(
+                            (item) =>
+                              item.id === criterion.id
+                                ? { ...item, lowLabel: event.target.value }
+                                : item,
+                          ),
+                        })
+                      }
+                      className={inputClass}
+                    />
+                  </Field>
+                  <Field label="High-end label">
+                    <input
+                      value={criterion.highLabel || ""}
+                      onChange={(event) =>
+                        onChange({
+                          scoreCriteria: (activity.scoreCriteria || []).map(
+                            (item) =>
+                              item.id === criterion.id
+                                ? { ...item, highLabel: event.target.value }
+                                : item,
+                          ),
+                        })
+                      }
+                      className={inputClass}
+                    />
+                  </Field>
                 </div>
               </div>
             ))}
@@ -1895,7 +2138,9 @@ function LiveResults({
         </div>
       ) : !activity.options.length &&
         !results?.prioritizations?.length &&
-        !results?.worksheets?.length ? (
+        !results?.worksheets?.length &&
+        !results?.cardCollections?.length &&
+        !results?.scorecards?.length ? (
         <div className="mt-6 rounded-xl border border-dashed border-slate-200 p-8 text-center text-sm text-slate-400">
           Responses will appear here.
         </div>
@@ -1903,7 +2148,10 @@ function LiveResults({
       {results?.prioritizations?.length ? (
         <div className="mt-5 space-y-3">
           {results.prioritizations.map((response) => (
-            <div key={response.id} className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+            <div
+              key={response.id}
+              className="rounded-xl border border-slate-200 bg-slate-50 p-4"
+            >
               <div className="flex items-center justify-between gap-3">
                 <p className="text-xs font-bold text-slate-700">
                   {response.participantName || "Learner response"}
@@ -1915,7 +2163,10 @@ function LiveResults({
               {response.selectedItems.length ? (
                 <div className="mt-3 flex flex-wrap gap-2">
                   {response.selectedItems.map((item) => (
-                    <span key={item} className="rounded-full bg-emerald-100 px-2.5 py-1 text-xs font-bold text-emerald-800">
+                    <span
+                      key={item}
+                      className="rounded-full bg-emerald-100 px-2.5 py-1 text-xs font-bold text-emerald-800"
+                    >
                       {item}
                     </span>
                   ))}
@@ -1931,11 +2182,15 @@ function LiveResults({
       {results?.worksheets?.length ? (
         <div className="mt-5 space-y-3">
           {results.worksheets.map((response) => (
-            <details key={response.id} className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+            <details
+              key={response.id}
+              className="rounded-xl border border-slate-200 bg-slate-50 p-4"
+            >
               <summary className="cursor-pointer list-none text-xs font-bold text-slate-700">
                 <span>{response.participantName || "Learner response"}</span>
                 <span className="ml-2 text-[10px] uppercase tracking-wide text-slate-400">
-                  {response.finalized ? "Completed" : "In progress"} · {response.values.length} fields
+                  {response.finalized ? "Completed" : "In progress"} ·{" "}
+                  {response.values.length} fields
                 </span>
               </summary>
               <dl className="mt-4 space-y-3">
@@ -1951,6 +2206,89 @@ function LiveResults({
                 ))}
               </dl>
             </details>
+          ))}
+        </div>
+      ) : null}
+      {results?.cardCollections?.length ? (
+        <div className="mt-5 space-y-3">
+          {results.cardCollections.map((response) => (
+            <details
+              key={response.id}
+              className="rounded-xl border border-slate-200 bg-slate-50 p-4"
+            >
+              <summary className="cursor-pointer list-none text-xs font-bold text-slate-700">
+                {response.participantName || "Learner response"}
+                <span className="ml-2 text-[10px] uppercase tracking-wide text-slate-400">
+                  {response.finalized ? "Completed" : "In progress"} ·{" "}
+                  {response.items.length} cards
+                </span>
+              </summary>
+              <div className="mt-4 space-y-3">
+                {response.items.map((item) => (
+                  <div
+                    key={item.id}
+                    className="rounded-xl border border-slate-200 bg-white p-4"
+                  >
+                    <p className="text-sm font-bold text-slate-800">
+                      {item.title}
+                    </p>
+                    <dl className="mt-3 grid gap-3 md:grid-cols-2">
+                      {item.values.map((answer) => (
+                        <div key={answer.fieldId}>
+                          <dt className="text-[10px] font-bold uppercase tracking-wide text-slate-400">
+                            {answer.label}
+                          </dt>
+                          <dd className="mt-1 whitespace-pre-wrap text-xs leading-5 text-slate-700">
+                            {answer.value}
+                          </dd>
+                        </div>
+                      ))}
+                    </dl>
+                  </div>
+                ))}
+              </div>
+            </details>
+          ))}
+        </div>
+      ) : null}
+      {results?.scorecards?.length ? (
+        <div className="mt-5 space-y-3">
+          {results.scorecards.map((response) => (
+            <div
+              key={response.id}
+              className="rounded-xl border border-slate-200 bg-slate-50 p-4"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="text-xs font-bold text-slate-700">
+                    {response.participantName || "Learner response"}
+                  </p>
+                  <p className="mt-1 text-sm font-bold text-slate-950">
+                    {response.selectedTitle || "Selection in progress"}
+                  </p>
+                </div>
+                <span className="text-[10px] font-bold uppercase tracking-wide text-slate-400">
+                  {response.finalized ? "Confirmed" : "In progress"}
+                </span>
+              </div>
+              {response.selectionReason ? (
+                <p className="mt-3 text-xs leading-5 text-slate-600">
+                  {response.selectionReason}
+                </p>
+              ) : null}
+              <div className="mt-3 flex flex-wrap gap-2">
+                {response.items
+                  .sort((a, b) => b.total - a.total)
+                  .map((item) => (
+                    <span
+                      key={item.sourceItemId}
+                      className="rounded-full bg-white px-2.5 py-1 text-[11px] font-bold text-slate-600"
+                    >
+                      {item.title} · {item.total}
+                    </span>
+                  ))}
+              </div>
+            </div>
           ))}
         </div>
       ) : null}

--- a/apps/commons-courses/components/live/live-learner-room.tsx
+++ b/apps/commons-courses/components/live/live-learner-room.tsx
@@ -40,6 +40,8 @@ import {
   canReviseLiveResponse,
   decodeOtherResponse,
   encodeOtherResponse,
+  isCardCollectionResponse,
+  isLinkedScorecardResponse,
   isPrioritizationResponse,
   isWorksheetResponse,
   isValidLiveResponse,
@@ -54,6 +56,7 @@ import type {
   LiveActivity,
   LiveResponseRecord,
   LiveResponseValue,
+  LiveWorksheetField,
 } from "@/types/live-session";
 import type { LiveSessionState } from "@/types/live-session";
 
@@ -323,7 +326,14 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
         sessionRef.current = next;
         return next;
       });
-      if (session?.pace === "learner") goNext();
+      const finalized =
+        value &&
+        typeof value === "object" &&
+        !Array.isArray(value) &&
+        "finalized" in value
+          ? Boolean(value.finalized)
+          : true;
+      if (session?.pace === "learner" && finalized) goNext();
     } else setNotice(data.error || "Could not save your response.");
     setSubmitting(false);
   }
@@ -493,11 +503,20 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
               learnerSeed={session.participant.id}
               value={values[activity.id]}
               response={response}
+              sourceActivity={session.activities.find(
+                (item) => item.id === activity.sourceActivityId,
+              )}
+              sourceResponse={
+                activity.sourceActivityId
+                  ? session.responses[activity.sourceActivityId]
+                  : undefined
+              }
               submitting={submitting}
               onChange={(value) =>
                 setValues((current) => ({ ...current, [activity.id]: value }))
               }
               onSubmit={submit}
+              onOpenActivity={setSelectedId}
             />
           ) : (
             <div className="flex min-h-[55dvh] items-center justify-center rounded-2xl border border-slate-200 bg-[var(--course-surface)] p-8 text-center">
@@ -529,9 +548,7 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
           {session.pace === "learner" && activity ? (
             <div className="mt-5 flex justify-between">
               <button
-                disabled={
-                  availableActivityIndex <= 0
-                }
+                disabled={availableActivityIndex <= 0}
                 onClick={() => {
                   setSelectedId(
                     availableActivities[availableActivityIndex - 1]?.id ||
@@ -780,17 +797,23 @@ function LearnerActivity({
   learnerSeed,
   value,
   response,
+  sourceActivity,
+  sourceResponse,
   submitting,
   onChange,
   onSubmit,
+  onOpenActivity,
 }: {
   activity: LiveActivity;
   learnerSeed: string;
   value?: LiveResponseValue;
   response?: LiveResponseRecord;
+  sourceActivity?: LiveActivity;
+  sourceResponse?: LiveResponseRecord;
   submitting: boolean;
   onChange: (value: LiveResponseValue) => void;
   onSubmit: (valueOverride?: LiveResponseValue) => void;
+  onOpenActivity: (activityId: string) => void;
 }) {
   const isChoice = activity.options.length > 0;
   const result = activity.status === "closed" && activity.showResults;
@@ -799,9 +822,7 @@ function LearnerActivity({
     ? !sameLiveResponseValue(value, response.value)
     : false;
   const typedOther = decodeOtherResponse(value);
-  const hasValidValue = Boolean(
-    value && isValidLiveResponse(activity, value),
-  );
+  const hasValidValue = Boolean(value && isValidLiveResponse(activity, value));
   return (
     <article className="overflow-hidden rounded-2xl border border-slate-200 bg-[var(--course-surface)]">
       <div className="p-6 sm:p-9">
@@ -868,7 +889,28 @@ function LearnerActivity({
           />
         </div>
       ) : null}
-      {activity.type === "worksheet" ? (
+      {activity.type === "card_collection" ? (
+        <CardCollectionResponsePanel
+          activity={activity}
+          value={value}
+          response={response}
+          submitting={submitting}
+          onChange={onChange}
+          onSubmit={onSubmit}
+        />
+      ) : activity.type === "linked_scorecard" ? (
+        <LinkedScorecardResponsePanel
+          activity={activity}
+          sourceActivity={sourceActivity}
+          sourceResponse={sourceResponse}
+          value={value}
+          response={response}
+          submitting={submitting}
+          onChange={onChange}
+          onSubmit={onSubmit}
+          onOpenActivity={onOpenActivity}
+        />
+      ) : activity.type === "worksheet" ? (
         <WorksheetResponsePanel
           activity={activity}
           value={value}
@@ -1080,6 +1122,535 @@ function LearnerActivity({
   );
 }
 
+function CardCollectionResponsePanel({
+  activity,
+  value,
+  response,
+  submitting,
+  onChange,
+  onSubmit,
+}: {
+  activity: LiveActivity;
+  value?: LiveResponseValue;
+  response?: LiveResponseRecord;
+  submitting: boolean;
+  onChange: (value: LiveResponseValue) => void;
+  onSubmit: (valueOverride?: LiveResponseValue) => void;
+}) {
+  const current = isCardCollectionResponse(value)
+    ? value
+    : { items: [], finalized: false };
+  const [activeId, setActiveId] = useState(current.items[0]?.id || "");
+  const fields = activity.worksheetFields || [];
+  const titleFieldId = activity.itemTitleFieldId || fields[0]?.id;
+  const active = current.items.find((item) => item.id === activeId);
+  const canEdit = activity.status === "open";
+  const changed = response
+    ? !sameLiveResponseValue(current, response.value)
+    : current.items.length > 0;
+  const complete =
+    current.items.length >= (activity.minItems || 1) &&
+    current.items.every((item) =>
+      fields.every(
+        (field) => !field.required || item.values[field.id] !== undefined,
+      ),
+    );
+
+  function changeItems(items: typeof current.items) {
+    onChange({ items, finalized: false });
+  }
+
+  function addCard() {
+    if (!canEdit || current.items.length >= 50) return;
+    const id = crypto.randomUUID();
+    changeItems([...current.items, { id, values: {} }]);
+    setActiveId(id);
+  }
+
+  function updateCard(fieldId: string, nextValue: string | number) {
+    if (!active) return;
+    const values = { ...active.values };
+    if (nextValue === "") delete values[fieldId];
+    else values[fieldId] = nextValue;
+    changeItems(
+      current.items.map((item) =>
+        item.id === active.id ? { ...item, values } : item,
+      ),
+    );
+  }
+
+  function removeCard(id: string) {
+    const items = current.items.filter((item) => item.id !== id);
+    changeItems(items);
+    if (activeId === id) setActiveId(items[0]?.id || "");
+  }
+
+  return (
+    <div className="border-t border-slate-100 bg-[var(--course-background)] p-4 sm:p-7">
+      <div className="mx-auto max-w-5xl">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-bold">Your task anatomy cards</p>
+            <p className="mt-1 text-xs opacity-55">
+              Add as many tasks as useful. Each one stays editable while this
+              activity is open.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={addCard}
+            disabled={!canEdit || current.items.length >= 50}
+            className="inline-flex min-h-10 items-center gap-2 rounded-xl bg-[var(--course-primary)] px-4 text-xs font-bold text-[var(--course-on-primary)] disabled:opacity-40"
+          >
+            <Plus className="h-4 w-4" /> Add task card
+          </button>
+        </div>
+        {current.items.length ? (
+          <div className="mt-5 grid gap-4 lg:grid-cols-[260px_minmax(0,1fr)]">
+            <aside className="space-y-2 rounded-2xl border border-slate-200 bg-[var(--course-surface)] p-3">
+              {current.items.map((item, index) => {
+                const title = String(
+                  item.values[titleFieldId || ""] || "",
+                ).trim();
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    onClick={() => setActiveId(item.id)}
+                    className={cn(
+                      "flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left text-sm transition",
+                      item.id === activeId
+                        ? "bg-[var(--course-primary)] text-[var(--course-on-primary)]"
+                        : "hover:bg-[var(--course-background)]",
+                    )}
+                  >
+                    <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-current/10 text-[10px] font-bold">
+                      {index + 1}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate font-bold">
+                      {title || `Untitled task ${index + 1}`}
+                    </span>
+                  </button>
+                );
+              })}
+            </aside>
+            {active ? (
+              <section className="rounded-2xl border border-slate-200 bg-[var(--course-surface)] p-4 sm:p-6">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-xs font-bold uppercase tracking-[0.16em] opacity-50">
+                    Task{" "}
+                    {current.items.findIndex((item) => item.id === active.id) +
+                      1}
+                  </p>
+                  {canEdit ? (
+                    <button
+                      type="button"
+                      onClick={() => removeCard(active.id)}
+                      className="inline-flex items-center gap-1.5 text-xs font-bold text-red-600"
+                    >
+                      <Trash2 className="h-4 w-4" /> Remove
+                    </button>
+                  ) : null}
+                </div>
+                <div className="mt-5 grid gap-5 md:grid-cols-2">
+                  {fields.map((field) => (
+                    <StructuredField
+                      key={field.id}
+                      field={field}
+                      value={active.values[field.id]}
+                      disabled={!canEdit}
+                      onChange={(next) => updateCard(field.id, next)}
+                    />
+                  ))}
+                </div>
+              </section>
+            ) : null}
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={addCard}
+            disabled={!canEdit}
+            className="mt-5 flex min-h-48 w-full flex-col items-center justify-center rounded-2xl border border-dashed border-slate-300 bg-[var(--course-surface)] p-8 text-center disabled:opacity-50"
+          >
+            <Plus className="h-6 w-6 opacity-40" />
+            <span className="mt-3 text-sm font-bold">
+              Add your first task card
+            </span>
+            <span className="mt-1 text-xs opacity-50">
+              Unpack one real task at a time.
+            </span>
+          </button>
+        )}
+        {response ? (
+          <Saved message="Task cards saved · You can add or edit cards while this is open" />
+        ) : null}
+        {canEdit && current.items.length ? (
+          <div className="mt-5 grid gap-2 sm:grid-cols-2">
+            <button
+              type="button"
+              onClick={() =>
+                onSubmit({ items: current.items, finalized: false })
+              }
+              disabled={!changed || submitting}
+              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl border border-slate-300 bg-white px-4 text-sm font-bold text-slate-700 disabled:opacity-40"
+            >
+              <Save className="h-4 w-4" /> Save progress
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                onSubmit({ items: current.items, finalized: true })
+              }
+              disabled={!complete || submitting}
+              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-[var(--course-primary)] px-4 text-sm font-bold text-[var(--course-on-primary)] disabled:opacity-40"
+            >
+              {submitting ? (
+                <LoaderCircle className="h-4 w-4 animate-spin" />
+              ) : (
+                <Check className="h-4 w-4" />
+              )}
+              Finish task cards
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function StructuredField({
+  field,
+  value,
+  disabled,
+  onChange,
+}: {
+  field: LiveWorksheetField;
+  value?: string | number;
+  disabled: boolean;
+  onChange: (value: string | number) => void;
+}) {
+  return (
+    <label
+      className={cn("block", field.type === "long_text" && "md:col-span-2")}
+    >
+      <span className="text-sm font-bold leading-6">
+        {field.label}
+        {field.required ? <span className="ml-1 text-red-500">*</span> : null}
+      </span>
+      {field.description ? (
+        <span className="mt-1 block text-xs leading-5 opacity-55">
+          {field.description}
+        </span>
+      ) : null}
+      {field.type === "scale" ? (
+        <div className="mt-3">
+          <div className="grid grid-cols-5 gap-2">
+            {Array.from(
+              { length: (field.max ?? 5) - (field.min ?? 1) + 1 },
+              (_, index) => (field.min ?? 1) + index,
+            ).map((number) => (
+              <button
+                key={number}
+                type="button"
+                disabled={disabled}
+                onClick={() => onChange(number)}
+                className={cn(
+                  "min-h-11 rounded-xl border text-sm font-bold",
+                  value === number
+                    ? "border-[var(--course-primary)] bg-[var(--course-primary)] text-[var(--course-on-primary)]"
+                    : "border-slate-200 bg-white",
+                )}
+              >
+                {number}
+              </button>
+            ))}
+          </div>
+          <div className="mt-2 flex justify-between text-[11px] opacity-50">
+            <span>{field.lowLabel}</span>
+            <span>{field.highLabel}</span>
+          </div>
+        </div>
+      ) : field.type === "long_text" ? (
+        <textarea
+          rows={4}
+          maxLength={10_000}
+          disabled={disabled}
+          value={typeof value === "string" ? value : ""}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={field.placeholder}
+          className="mt-3 w-full resize-y rounded-xl border border-slate-200 bg-white p-4 text-sm leading-6 text-slate-950 outline-none focus:border-slate-500 disabled:bg-slate-100"
+        />
+      ) : (
+        <input
+          type={field.type === "date" ? "date" : "text"}
+          maxLength={500}
+          disabled={disabled}
+          value={typeof value === "string" ? value : ""}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={field.placeholder}
+          className="mt-3 w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-950 outline-none focus:border-slate-500 disabled:bg-slate-100"
+        />
+      )}
+    </label>
+  );
+}
+
+function LinkedScorecardResponsePanel({
+  activity,
+  sourceActivity,
+  sourceResponse,
+  value,
+  response,
+  submitting,
+  onChange,
+  onSubmit,
+  onOpenActivity,
+}: {
+  activity: LiveActivity;
+  sourceActivity?: LiveActivity;
+  sourceResponse?: LiveResponseRecord;
+  value?: LiveResponseValue;
+  response?: LiveResponseRecord;
+  submitting: boolean;
+  onChange: (value: LiveResponseValue) => void;
+  onSubmit: (valueOverride?: LiveResponseValue) => void;
+  onOpenActivity: (activityId: string) => void;
+}) {
+  const source = isCardCollectionResponse(sourceResponse?.value)
+    ? sourceResponse.value
+    : undefined;
+  const current = isLinkedScorecardResponse(value)
+    ? value
+    : { items: [], finalized: false };
+  const criteria = activity.scoreCriteria || [];
+  const titleFieldId =
+    sourceActivity?.itemTitleFieldId ||
+    sourceActivity?.worksheetFields?.[0]?.id;
+  const canEdit = activity.status === "open";
+  const changed = response
+    ? !sameLiveResponseValue(current, response.value)
+    : current.items.length > 0;
+
+  if (!source?.items.length) {
+    return (
+      <div className="border-t border-slate-100 bg-[var(--course-background)] p-5 sm:p-7">
+        <div className="mx-auto max-w-xl rounded-2xl border border-slate-200 bg-[var(--course-surface)] p-7 text-center">
+          <p className="text-sm font-bold">Create your task cards first</p>
+          <p className="mt-2 text-xs leading-6 opacity-55">
+            Your saved tasks will appear here automatically—there is nothing to
+            retype.
+          </p>
+          {activity.sourceActivityId ? (
+            <button
+              type="button"
+              onClick={() => onOpenActivity(activity.sourceActivityId || "")}
+              className="mt-5 rounded-xl bg-[var(--course-primary)] px-4 py-3 text-xs font-bold text-[var(--course-on-primary)]"
+            >
+              Open task anatomy cards
+            </button>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+  const sourceItems = source.items;
+
+  function titleFor(sourceItemId: string) {
+    const item = sourceItems.find((candidate) => candidate.id === sourceItemId);
+    return String(item?.values[titleFieldId || ""] || "Untitled task");
+  }
+
+  function updateScore(
+    sourceItemId: string,
+    criterionId: string,
+    score: number,
+  ) {
+    const existing = current.items.find(
+      (item) => item.sourceItemId === sourceItemId,
+    );
+    const item = {
+      sourceItemId,
+      scores: { ...(existing?.scores || {}), [criterionId]: score },
+    };
+    onChange({
+      ...current,
+      finalized: false,
+      items: existing
+        ? current.items.map((candidate) =>
+            candidate.sourceItemId === sourceItemId ? item : candidate,
+          )
+        : [...current.items, item],
+    });
+  }
+
+  const ready =
+    Boolean(current.selectedItemId) &&
+    Boolean(current.selectionReason?.trim()) &&
+    sourceItems.every((sourceItem) => {
+      const scored = current.items.find(
+        (item) => item.sourceItemId === sourceItem.id,
+      );
+      return criteria.every(
+        (criterion) => scored?.scores[criterion.id] !== undefined,
+      );
+    });
+
+  return (
+    <div className="border-t border-slate-100 bg-[var(--course-background)] p-4 sm:p-7">
+      <div className="mx-auto max-w-5xl space-y-4">
+        <div>
+          <p className="text-sm font-bold">Compare your captured tasks</p>
+          <p className="mt-1 text-xs opacity-55">
+            Score each task, then choose the strongest first task to offload.
+          </p>
+        </div>
+        {sourceItems.map((sourceItem) => {
+          const scored = current.items.find(
+            (item) => item.sourceItemId === sourceItem.id,
+          );
+          const total = Object.values(scored?.scores || {}).reduce(
+            (sum, score) => sum + score,
+            0,
+          );
+          const selected = current.selectedItemId === sourceItem.id;
+          return (
+            <section
+              key={sourceItem.id}
+              className={cn(
+                "overflow-hidden rounded-2xl border bg-[var(--course-surface)]",
+                selected
+                  ? "border-[var(--course-primary)] ring-1 ring-[var(--course-primary)]"
+                  : "border-slate-200",
+              )}
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 p-4 sm:px-5">
+                <div>
+                  <p className="font-bold">{titleFor(sourceItem.id)}</p>
+                  <p className="mt-1 text-[11px] opacity-50">
+                    Score {total}/
+                    {criteria.reduce(
+                      (sum, criterion) => sum + criterion.max,
+                      0,
+                    )}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  disabled={!canEdit}
+                  onClick={() =>
+                    onChange({
+                      ...current,
+                      selectedItemId: sourceItem.id,
+                      finalized: false,
+                    })
+                  }
+                  className={cn(
+                    "rounded-full border px-3 py-2 text-xs font-bold",
+                    selected
+                      ? "border-[var(--course-primary)] bg-[var(--course-primary)] text-[var(--course-on-primary)]"
+                      : "border-slate-200",
+                  )}
+                >
+                  {selected ? "Chosen first task" : "Choose this task"}
+                </button>
+              </div>
+              <div className="grid gap-4 p-4 sm:p-5 md:grid-cols-2">
+                {criteria.map((criterion) => (
+                  <div key={criterion.id}>
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-xs font-bold">{criterion.label}</p>
+                        {criterion.description ? (
+                          <p className="mt-1 text-[11px] leading-5 opacity-50">
+                            {criterion.description}
+                          </p>
+                        ) : null}
+                      </div>
+                      <span className="text-xs font-bold opacity-50">
+                        {scored?.scores[criterion.id] || "–"}
+                      </span>
+                    </div>
+                    <div className="mt-2 grid grid-cols-5 gap-1.5">
+                      {Array.from(
+                        { length: criterion.max - criterion.min + 1 },
+                        (_, index) => criterion.min + index,
+                      ).map((number) => (
+                        <button
+                          key={number}
+                          type="button"
+                          disabled={!canEdit}
+                          onClick={() =>
+                            updateScore(sourceItem.id, criterion.id, number)
+                          }
+                          className={cn(
+                            "min-h-9 rounded-lg border text-xs font-bold",
+                            scored?.scores[criterion.id] === number
+                              ? "border-[var(--course-primary)] bg-[var(--course-primary)] text-[var(--course-on-primary)]"
+                              : "border-slate-200 bg-white",
+                          )}
+                        >
+                          {number}
+                        </button>
+                      ))}
+                    </div>
+                    <div className="mt-1.5 flex justify-between text-[10px] opacity-40">
+                      <span>{criterion.lowLabel}</span>
+                      <span>{criterion.highLabel}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+          );
+        })}
+        <label className="block rounded-2xl border border-slate-200 bg-[var(--course-surface)] p-4 sm:p-5">
+          <span className="text-sm font-bold">
+            Why is this a safe, useful first build?
+          </span>
+          <textarea
+            rows={3}
+            maxLength={10_000}
+            disabled={!canEdit}
+            value={current.selectionReason || ""}
+            onChange={(event) =>
+              onChange({
+                ...current,
+                selectionReason: event.target.value,
+                finalized: false,
+              })
+            }
+            className="mt-3 w-full resize-y rounded-xl border border-slate-200 bg-white p-4 text-sm leading-6 text-slate-950 outline-none focus:border-slate-500"
+          />
+        </label>
+        {response ? (
+          <Saved message="Scorecard saved · You can revise it while this activity is open" />
+        ) : null}
+        {canEdit ? (
+          <div className="grid gap-2 sm:grid-cols-2">
+            <button
+              type="button"
+              onClick={() => onSubmit({ ...current, finalized: false })}
+              disabled={!changed || submitting}
+              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl border border-slate-300 bg-white px-4 text-sm font-bold text-slate-700 disabled:opacity-40"
+            >
+              <Save className="h-4 w-4" /> Save progress
+            </button>
+            <button
+              type="button"
+              onClick={() => onSubmit({ ...current, finalized: true })}
+              disabled={!ready || submitting}
+              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-[var(--course-primary)] px-4 text-sm font-bold text-[var(--course-on-primary)] disabled:opacity-40"
+            >
+              <Check className="h-4 w-4" /> Confirm first task
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 function WorksheetResponsePanel({
   activity,
   value,
@@ -1099,16 +1670,15 @@ function WorksheetResponsePanel({
     ? value
     : { values: {}, finalized: false };
   const fields = activity.worksheetFields || [];
-  const sections = fields.reduce<Array<{ title: string; fields: typeof fields }>>(
-    (groups, field) => {
-      const title = field.section || "Your responses";
-      const existing = groups.find((group) => group.title === title);
-      if (existing) existing.fields.push(field);
-      else groups.push({ title, fields: [field] });
-      return groups;
-    },
-    [],
-  );
+  const sections = fields.reduce<
+    Array<{ title: string; fields: typeof fields }>
+  >((groups, field) => {
+    const title = field.section || "Your responses";
+    const existing = groups.find((group) => group.title === title);
+    if (existing) existing.fields.push(field);
+    else groups.push({ title, fields: [field] });
+    return groups;
+  }, []);
   const answered = fields.filter(
     (field) => current.values[field.id] !== undefined,
   ).length;
@@ -1162,7 +1732,9 @@ function WorksheetResponsePanel({
                   >
                     <span className="text-sm font-bold leading-6">
                       {field.label}
-                      {field.required ? <span className="ml-1 text-red-500">*</span> : null}
+                      {field.required ? (
+                        <span className="ml-1 text-red-500">*</span>
+                      ) : null}
                     </span>
                     {field.description ? (
                       <span className="mt-1 block text-xs leading-5 opacity-55">
@@ -1203,7 +1775,9 @@ function WorksheetResponsePanel({
                         maxLength={10_000}
                         disabled={!canEdit}
                         value={typeof fieldValue === "string" ? fieldValue : ""}
-                        onChange={(event) => update(field.id, event.target.value)}
+                        onChange={(event) =>
+                          update(field.id, event.target.value)
+                        }
                         placeholder={field.placeholder}
                         className="mt-3 w-full resize-y rounded-xl border border-slate-200 bg-white p-4 text-sm leading-6 text-slate-950 outline-none focus:border-slate-500 disabled:bg-slate-100"
                       />
@@ -1213,7 +1787,9 @@ function WorksheetResponsePanel({
                         maxLength={500}
                         disabled={!canEdit}
                         value={typeof fieldValue === "string" ? fieldValue : ""}
-                        onChange={(event) => update(field.id, event.target.value)}
+                        onChange={(event) =>
+                          update(field.id, event.target.value)
+                        }
                         placeholder={field.placeholder}
                         className="mt-3 w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-950 outline-none focus:border-slate-500 disabled:bg-slate-100"
                       />
@@ -1227,7 +1803,9 @@ function WorksheetResponsePanel({
         {response ? (
           <Saved
             message={
-              isWorksheetResponse(response.value) && response.value.finalized && !changed
+              isWorksheetResponse(response.value) &&
+              response.value.finalized &&
+              !changed
                 ? "Workbook section completed"
                 : "Progress saved · You can keep editing while this is open"
             }
@@ -1237,7 +1815,9 @@ function WorksheetResponsePanel({
           <div className="grid gap-2 sm:grid-cols-2">
             <button
               type="button"
-              onClick={() => onSubmit({ values: current.values, finalized: false })}
+              onClick={() =>
+                onSubmit({ values: current.values, finalized: false })
+              }
               disabled={!answered || submitting || !changed}
               className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl border border-slate-300 bg-white px-4 text-sm font-bold text-slate-700 disabled:opacity-40"
             >
@@ -1245,11 +1825,17 @@ function WorksheetResponsePanel({
             </button>
             <button
               type="button"
-              onClick={() => onSubmit({ values: current.values, finalized: true })}
+              onClick={() =>
+                onSubmit({ values: current.values, finalized: true })
+              }
               disabled={!answered || !requiredComplete || submitting}
               className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-[var(--course-primary)] px-4 text-sm font-bold text-[var(--course-on-primary)] disabled:opacity-40"
             >
-              {submitting ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
+              {submitting ? (
+                <LoaderCircle className="h-4 w-4 animate-spin" />
+              ) : (
+                <Check className="h-4 w-4" />
+              )}
               Complete this section
             </button>
           </div>
@@ -1282,8 +1868,7 @@ function PrioritizationResponsePanel({
   const minItems = activity.minItems || 1;
   const selectedCount = current.items.filter((item) => item.selected).length;
   const canEdit = activity.status === "open";
-  const readyToFinish =
-    current.items.length >= minItems && selectedCount > 0;
+  const readyToFinish = current.items.length >= minItems && selectedCount > 0;
   const savedValue = response?.value;
   const changed = savedValue
     ? !sameLiveResponseValue(current, savedValue)
@@ -1413,7 +1998,8 @@ function PrioritizationResponsePanel({
             Choose up to {maxSelections}
           </h2>
           <p className="mt-1 text-xs leading-5 opacity-60">
-            {activity.selectionPrompt || "Choose the ideas you want to take forward."}
+            {activity.selectionPrompt ||
+              "Choose the ideas you want to take forward."}
           </p>
           <div className="mt-4 space-y-2">
             {current.items.map((item) => {
@@ -1571,6 +2157,8 @@ function labelFor(type: LiveActivity["type"]) {
       quiz: "Knowledge check",
       prioritization: "Capture and shortlist",
       worksheet: "Workbook activity",
+      card_collection: "Repeatable cards",
+      linked_scorecard: "Linked scorecard",
       reflection: "Reflection",
       task: "Practice",
       break: "Break",

--- a/apps/commons-courses/lib/course-engagement.ts
+++ b/apps/commons-courses/lib/course-engagement.ts
@@ -1,6 +1,8 @@
 import type { LiveActivity } from "../types/live-session";
 import type { LiveResponseValue } from "../types/live-session";
 import {
+  normalizeCardCollectionResponse,
+  normalizeLinkedScorecardResponse,
   normalizePrioritizationResponse,
   normalizeWorksheetResponse,
 } from "./live-response-policy.ts";
@@ -67,6 +69,44 @@ function responseLabel(activity: LiveActivity, value: LiveResponseValue) {
       .join(" · ");
     return `${response.finalized ? "Completed" : "In progress"} · ${answered}/${total} fields${preview ? ` · ${preview}` : ""}`;
   }
+  if (activity.type === "card_collection") {
+    const response = normalizeCardCollectionResponse(activity, value);
+    if (!response) return "No cards saved";
+    const titleFieldId =
+      activity.itemTitleFieldId || activity.worksheetFields?.[0]?.id || "";
+    const preview = response.items
+      .map((item) => String(item.values[titleFieldId] || "Untitled card"))
+      .slice(0, 3)
+      .join("; ");
+    return `${response.finalized ? "Completed" : "In progress"} · ${response.items.length} cards${preview ? ` · ${preview}` : ""}`;
+  }
+  if (activity.type === "linked_scorecard") {
+    const sourceLike = {
+      items: [{ id: "placeholder", values: {} }],
+      finalized: false,
+    };
+    const raw =
+      value && typeof value === "object" && !Array.isArray(value)
+        ? (value as {
+            items?: Array<{ sourceItemId?: string }>;
+            selectedItemId?: string;
+            finalized?: boolean;
+          })
+        : undefined;
+    if (!raw?.items?.length) return "No scorecard progress saved";
+    sourceLike.items = raw.items.flatMap((item) =>
+      typeof item.sourceItemId === "string"
+        ? [{ id: item.sourceItemId, values: {} }]
+        : [],
+    );
+    const response = normalizeLinkedScorecardResponse(
+      activity,
+      value,
+      sourceLike,
+    );
+    if (!response) return "Scorecard in progress";
+    return `${response.finalized ? "Confirmed" : "In progress"} · ${response.items.length} candidates scored${response.selectedItemId ? " · first task selected" : ""}`;
+  }
   const values = Array.isArray(value) ? value : [value];
   return values
     .map((item) => {
@@ -75,7 +115,10 @@ function responseLabel(activity: LiveActivity, value: LiveResponseValue) {
         : undefined;
       if (other !== undefined) return other;
       if (item === "complete") return "Completed";
-      return activity.options.find((option) => option.id === item)?.label || String(item);
+      return (
+        activity.options.find((option) => option.id === item)?.label ||
+        String(item)
+      );
     })
     .join(", ");
 }
@@ -86,60 +129,89 @@ export function buildCourseEngagement(args: {
   responses: CourseEngagementResponse[];
 }) {
   const { activities, participants, responses } = args;
-  const participantById = new Map(participants.map((item) => [id(item._id), item]));
+  const participantById = new Map(
+    participants.map((item) => [id(item._id), item]),
+  );
   const responseActivities = activities.filter(
-    (activity) => activity.status !== "draft" && activity.type !== "content" && activity.type !== "break",
+    (activity) =>
+      activity.status !== "draft" &&
+      activity.type !== "content" &&
+      activity.type !== "break",
   );
-  const responseActivityIds = new Set(responseActivities.map((activity) => activity.id));
-  const meaningfulResponses = responses.filter((response) => responseActivityIds.has(response.activityId));
-  const engaged = new Set(meaningfulResponses.map((response) => id(response.userId)));
+  const responseActivityIds = new Set(
+    responseActivities.map((activity) => activity.id),
+  );
+  const meaningfulResponses = responses.filter((response) =>
+    responseActivityIds.has(response.activityId),
+  );
+  const engaged = new Set(
+    meaningfulResponses.map((response) => id(response.userId)),
+  );
   const quizResponses = responses.filter((response) =>
-    activities.some((activity) => activity.id === response.activityId && activity.type === "quiz"),
+    activities.some(
+      (activity) =>
+        activity.id === response.activityId && activity.type === "quiz",
+    ),
   );
-  const quizCorrect = quizResponses.filter((response) => response.correct).length;
+  const quizCorrect = quizResponses.filter(
+    (response) => response.correct,
+  ).length;
 
   const summary: EngagementSummary = {
     attendees: participants.length,
     engagedLearners: engaged.size,
     participationRate: percent(engaged.size, participants.length),
     responseCount: responses.length,
-    quizAccuracy: quizResponses.length ? percent(quizCorrect, quizResponses.length) : undefined,
+    quizAccuracy: quizResponses.length
+      ? percent(quizCorrect, quizResponses.length)
+      : undefined,
   };
 
-  const activityInsights: EngagementActivity[] = activities.map((activity, index) => {
-    const activityResponses = responses.filter((response) => response.activityId === activity.id);
-    const correct = activityResponses.filter((response) => response.correct).length;
-    const values = activityResponses.flatMap((response) =>
-      Array.isArray(response.value)
-        ? response.value
-        : typeof response.value === "string"
-          ? [response.value]
-          : [],
-    );
-    return {
-      id: activity.id,
-      index: index + 1,
-      title: activity.title,
-      type: activity.type,
-      responseCount: activityResponses.length,
-      responseRate: percent(activityResponses.length, participants.length),
-      correctRate:
-        activity.type === "quiz" && activityResponses.length
-          ? percent(correct, activityResponses.length)
-          : undefined,
-      options: activity.options.map((option) => {
-        const count = values.filter((value) => value === option.id).length;
-        return { label: option.label, count, percent: percent(count, activityResponses.length) };
-      }),
-      responses: activityResponses.map((response) => ({
-        participantName:
-          participantById.get(id(response.participantId))?.displayName || "Learner",
-        userId: id(response.userId),
-        value: responseLabel(activity, response.value),
-        submittedAt: new Date(response.submittedAt).toISOString(),
-      })),
-    };
-  });
+  const activityInsights: EngagementActivity[] = activities.map(
+    (activity, index) => {
+      const activityResponses = responses.filter(
+        (response) => response.activityId === activity.id,
+      );
+      const correct = activityResponses.filter(
+        (response) => response.correct,
+      ).length;
+      const values = activityResponses.flatMap((response) =>
+        Array.isArray(response.value)
+          ? response.value
+          : typeof response.value === "string"
+            ? [response.value]
+            : [],
+      );
+      return {
+        id: activity.id,
+        index: index + 1,
+        title: activity.title,
+        type: activity.type,
+        responseCount: activityResponses.length,
+        responseRate: percent(activityResponses.length, participants.length),
+        correctRate:
+          activity.type === "quiz" && activityResponses.length
+            ? percent(correct, activityResponses.length)
+            : undefined,
+        options: activity.options.map((option) => {
+          const count = values.filter((value) => value === option.id).length;
+          return {
+            label: option.label,
+            count,
+            percent: percent(count, activityResponses.length),
+          };
+        }),
+        responses: activityResponses.map((response) => ({
+          participantName:
+            participantById.get(id(response.participantId))?.displayName ||
+            "Learner",
+          userId: id(response.userId),
+          value: responseLabel(activity, response.value),
+          submittedAt: new Date(response.submittedAt).toISOString(),
+        })),
+      };
+    },
+  );
 
   const learners: EngagementLearner[] = participants.map((participant) => {
     const learnerResponses = meaningfulResponses.filter(
@@ -163,6 +235,8 @@ export function buildCourseEngagement(args: {
     };
   });
 
-  learners.sort((a, b) => b.responseCount - a.responseCount || a.name.localeCompare(b.name));
+  learners.sort(
+    (a, b) => b.responseCount - a.responseCount || a.name.localeCompare(b.name),
+  );
   return { summary, activities: activityInsights, learners };
 }

--- a/apps/commons-courses/lib/educator-copilot-tools.ts
+++ b/apps/commons-courses/lib/educator-copilot-tools.ts
@@ -339,6 +339,8 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
                   "quiz",
                   "prioritization",
                   "worksheet",
+                  "card_collection",
+                  "linked_scorecard",
                   "reflection",
                   "task",
                   "break",
@@ -426,6 +428,34 @@ export const educatorCopilotToolCatalog: CopilotToolDefinition[] = [
                     highLabel: { type: "string" },
                   },
                   required: ["label", "type"],
+                },
+              },
+              itemTitleFieldId: {
+                type: "string",
+                description:
+                  "For repeatable cards, the field used as each card's visible title.",
+              },
+              sourceActivityId: {
+                type: "string",
+                description:
+                  "For a linked scorecard, the repeatable-card activity supplying its candidates.",
+              },
+              scoreCriteria: {
+                type: "array",
+                description:
+                  "For a linked scorecard, the scales applied to every source card.",
+                items: {
+                  type: "object",
+                  properties: {
+                    id: { type: "string" },
+                    label: { type: "string" },
+                    description: { type: "string" },
+                    min: { type: "number" },
+                    max: { type: "number" },
+                    lowLabel: { type: "string" },
+                    highLabel: { type: "string" },
+                  },
+                  required: ["label", "min", "max"],
                 },
               },
               points: { type: "number" },

--- a/apps/commons-courses/lib/live-response-policy.test.mts
+++ b/apps/commons-courses/lib/live-response-policy.test.mts
@@ -15,20 +15,140 @@ test("allows saved poll answers to change only while the poll is open", () => {
   assert.equal(canReviseLiveResponse(activity("quiz", "open")), false);
   assert.equal(canReviseLiveResponse(activity("prioritization", "open")), true);
   assert.equal(canReviseLiveResponse(activity("worksheet", "open")), true);
+  assert.equal(
+    canReviseLiveResponse(activity("card_collection", "open")),
+    true,
+  );
+  assert.equal(
+    canReviseLiveResponse(activity("linked_scorecard", "open")),
+    true,
+  );
+});
+
+test("supports any number of structured cards in one repeatable activity", () => {
+  const collection = activity("card_collection", "open");
+  collection.minItems = 2;
+  collection.itemTitleFieldId = "name";
+  collection.worksheetFields = [
+    { id: "name", label: "Task name", type: "short_text", required: true },
+    { id: "steps", label: "Steps", type: "long_text", required: true },
+  ];
+  const oneCard = {
+    items: [{ id: "one", values: { name: "Weekly report" } }],
+    finalized: false,
+  };
+  assert.equal(isValidLiveResponse(collection, oneCard), true);
+  assert.equal(
+    isValidLiveResponse(collection, { ...oneCard, finalized: true }),
+    false,
+  );
+  assert.equal(
+    isValidLiveResponse(collection, {
+      items: [
+        {
+          id: "one",
+          values: { name: "Weekly report", steps: "Collect and summarize" },
+        },
+        {
+          id: "two",
+          values: { name: "Inbox triage", steps: "Sort and route" },
+        },
+      ],
+      finalized: true,
+    }),
+    true,
+  );
+  assert.equal(
+    isValidLiveResponse(collection, {
+      items: [
+        { id: "same", values: { name: "One" } },
+        { id: "same", values: { name: "Two" } },
+      ],
+      finalized: false,
+    }),
+    false,
+  );
+});
+
+test("linked scorecards only accept and finalize cards captured by that learner", () => {
+  const scorecard = activity("linked_scorecard", "open");
+  scorecard.sourceActivityId = "tasks";
+  scorecard.scoreCriteria = [
+    { id: "impact", label: "Impact", min: 1, max: 5 },
+    { id: "safety", label: "Safety", min: 1, max: 5 },
+  ];
+  const source = {
+    items: [
+      { id: "one", values: { name: "Weekly report" } },
+      { id: "two", values: { name: "Inbox triage" } },
+    ],
+    finalized: true,
+  };
+  assert.equal(
+    isValidLiveResponse(
+      scorecard,
+      {
+        items: [{ sourceItemId: "one", scores: { impact: 4 } }],
+        finalized: false,
+      },
+      source,
+    ),
+    true,
+  );
+  assert.equal(
+    isValidLiveResponse(
+      scorecard,
+      {
+        items: [{ sourceItemId: "unknown", scores: { impact: 4 } }],
+        finalized: false,
+      },
+      source,
+    ),
+    false,
+  );
+  assert.equal(
+    isValidLiveResponse(
+      scorecard,
+      {
+        items: [
+          { sourceItemId: "one", scores: { impact: 4, safety: 5 } },
+          { sourceItemId: "two", scores: { impact: 3, safety: 4 } },
+        ],
+        selectedItemId: "two",
+        selectionReason: "Easy to verify and reverse.",
+        finalized: true,
+      },
+      source,
+    ),
+    true,
+  );
 });
 
 test("validates worksheet progress and required fields before completion", () => {
   const worksheet = activity("worksheet", "open");
   worksheet.worksheetFields = [
     { id: "outcome", label: "Outcome", type: "long_text", required: true },
-    { id: "confidence", label: "Confidence", type: "scale", required: false, min: 1, max: 5 },
+    {
+      id: "confidence",
+      label: "Confidence",
+      type: "scale",
+      required: false,
+      min: 1,
+      max: 5,
+    },
   ];
   assert.equal(
-    isValidLiveResponse(worksheet, { values: { confidence: 3 }, finalized: false }),
+    isValidLiveResponse(worksheet, {
+      values: { confidence: 3 },
+      finalized: false,
+    }),
     true,
   );
   assert.equal(
-    isValidLiveResponse(worksheet, { values: { confidence: 3 }, finalized: true }),
+    isValidLiveResponse(worksheet, {
+      values: { confidence: 3 },
+      finalized: true,
+    }),
     false,
   );
   assert.equal(
@@ -39,7 +159,10 @@ test("validates worksheet progress and required fields before completion", () =>
     true,
   );
   assert.equal(
-    isValidLiveResponse(worksheet, { values: { confidence: 8 }, finalized: false }),
+    isValidLiveResponse(worksheet, {
+      values: { confidence: 8 },
+      finalized: false,
+    }),
     false,
   );
 });
@@ -54,10 +177,16 @@ test("validates a multi-entry shortlist while preserving in-progress saves", () 
     { id: "three", text: "Inbox triage", selected: true },
   ];
   assert.equal(
-    isValidLiveResponse(shortlist, { items: items.slice(0, 1), finalized: false }),
+    isValidLiveResponse(shortlist, {
+      items: items.slice(0, 1),
+      finalized: false,
+    }),
     true,
   );
-  assert.equal(isValidLiveResponse(shortlist, { items, finalized: true }), true);
+  assert.equal(
+    isValidLiveResponse(shortlist, { items, finalized: true }),
+    true,
+  );
   assert.equal(
     isValidLiveResponse(shortlist, {
       items: [...items, { id: "four", text: "Research", selected: true }],
@@ -72,17 +201,46 @@ test("accepts a non-empty typed Other response only when enabled", () => {
   poll.options = [{ id: "listed", label: "Listed" }];
   poll.allowOther = true;
   assert.equal(isValidLiveResponse(poll, "listed"), true);
-  assert.equal(isValidLiveResponse(poll, encodeOtherResponse("A different task")), true);
+  assert.equal(
+    isValidLiveResponse(poll, encodeOtherResponse("A different task")),
+    true,
+  );
   assert.equal(isValidLiveResponse(poll, encodeOtherResponse("   ")), false);
   poll.allowOther = false;
-  assert.equal(isValidLiveResponse(poll, encodeOtherResponse("A different task")), false);
-  assert.equal(decodeOtherResponse(encodeOtherResponse("A different task")), "A different task");
+  assert.equal(
+    isValidLiveResponse(poll, encodeOtherResponse("A different task")),
+    false,
+  );
+  assert.equal(
+    decodeOtherResponse(encodeOtherResponse("A different task")),
+    "A different task",
+  );
 });
 
 test("compares current and saved response values", () => {
   assert.equal(sameLiveResponseValue("option-a", "option-a"), true);
   assert.equal(sameLiveResponseValue("option-b", "option-a"), false);
   assert.equal(sameLiveResponseValue(["b", "a"], ["a", "b"]), true);
+  assert.equal(
+    sameLiveResponseValue(
+      { items: [{ id: "one", values: { name: "Task" } }], finalized: false },
+      { items: [{ id: "one", values: { name: "Task" } }], finalized: false },
+    ),
+    true,
+  );
+  assert.equal(
+    sameLiveResponseValue(
+      {
+        items: [{ sourceItemId: "one", scores: { impact: 4 } }],
+        finalized: false,
+      },
+      {
+        items: [{ sourceItemId: "one", scores: { impact: 3 } }],
+        finalized: false,
+      },
+    ),
+    false,
+  );
 });
 
 function activity(

--- a/apps/commons-courses/lib/live-response-policy.ts
+++ b/apps/commons-courses/lib/live-response-policy.ts
@@ -1,5 +1,7 @@
 import type {
   LiveActivity,
+  LiveCardCollectionResponse,
+  LiveLinkedScorecardResponse,
   LivePrioritizationResponse,
   LiveResponseValue,
   LiveWorksheetResponse,
@@ -20,6 +22,7 @@ export function decodeOtherResponse(value: unknown) {
 export function isValidLiveResponse(
   activity: LiveActivity,
   value: unknown,
+  sourceValue?: unknown,
 ) {
   if (activity.type === "prioritization") {
     return normalizePrioritizationResponse(activity, value) !== undefined;
@@ -27,15 +30,27 @@ export function isValidLiveResponse(
   if (activity.type === "worksheet") {
     return normalizeWorksheetResponse(activity, value) !== undefined;
   }
+  if (activity.type === "card_collection") {
+    return normalizeCardCollectionResponse(activity, value) !== undefined;
+  }
+  if (activity.type === "linked_scorecard") {
+    return (
+      normalizeLinkedScorecardResponse(activity, value, sourceValue) !==
+      undefined
+    );
+  }
   if (!Array.isArray(value) && typeof value !== "string") return false;
   const values = Array.isArray(value) ? value.map(String) : [String(value)];
   if (!values.length || values.some((item) => !item.trim())) return false;
-  if (!activity.options.length) return values.every((item) => item.length <= 10_000);
+  if (!activity.options.length)
+    return values.every((item) => item.length <= 10_000);
   const allowed = new Set(activity.options.map((option) => option.id));
   return values.every((item) => {
     const other = decodeOtherResponse(item);
     if (other !== undefined)
-      return Boolean(activity.allowOther && other.trim() && other.length <= 500);
+      return Boolean(
+        activity.allowOther && other.trim() && other.length <= 500,
+      );
     return allowed.has(item);
   });
 }
@@ -44,7 +59,9 @@ export function canReviseLiveResponse(activity: LiveActivity) {
   return (
     (activity.type === "poll" ||
       activity.type === "prioritization" ||
-      activity.type === "worksheet") &&
+      activity.type === "worksheet" ||
+      activity.type === "card_collection" ||
+      activity.type === "linked_scorecard") &&
     activity.status === "open"
   );
 }
@@ -72,6 +89,30 @@ export function sameLiveResponseValue(
         ),
       };
     }
+    if (isCardCollectionResponse(value)) {
+      return {
+        finalized: value.finalized,
+        items: value.items.map((item) => ({
+          id: item.id,
+          values: Object.fromEntries(
+            Object.entries(item.values).sort(([a], [b]) => a.localeCompare(b)),
+          ),
+        })),
+      };
+    }
+    if (isLinkedScorecardResponse(value)) {
+      return {
+        finalized: value.finalized,
+        selectedItemId: value.selectedItemId,
+        selectionReason: value.selectionReason,
+        items: value.items.map((item) => ({
+          sourceItemId: item.sourceItemId,
+          scores: Object.fromEntries(
+            Object.entries(item.scores).sort(([a], [b]) => a.localeCompare(b)),
+          ),
+        })),
+      };
+    }
     return Array.isArray(value)
       ? [...value].map(String).sort()
       : String(value || "");
@@ -79,6 +120,138 @@ export function sameLiveResponseValue(
   return (
     JSON.stringify(normalize(current)) === JSON.stringify(normalize(saved))
   );
+}
+
+export function isCardCollectionResponse(
+  value: unknown,
+): value is LiveCardCollectionResponse {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      Array.isArray((value as { items?: unknown }).items) &&
+      !(value as { items: unknown[] }).items.some(
+        (item) =>
+          !item ||
+          typeof item !== "object" ||
+          !(item as { values?: unknown }).values,
+      ),
+  );
+}
+
+export function normalizeCardCollectionResponse(
+  activity: LiveActivity,
+  value: unknown,
+): LiveCardCollectionResponse | undefined {
+  if (!isCardCollectionResponse(value) || !activity.worksheetFields?.length)
+    return undefined;
+  const seen = new Set<string>();
+  const finalized = Boolean(value.finalized);
+  if (value.items.length > 50) return undefined;
+  const items: LiveCardCollectionResponse["items"] = [];
+  for (const [index, item] of value.items.entries()) {
+    const sourceId = typeof item.id === "string" ? item.id.trim() : "";
+    const id = /^[a-zA-Z0-9_-]{1,80}$/.test(sourceId)
+      ? sourceId
+      : `card-${index + 1}`;
+    if (seen.has(id)) return undefined;
+    seen.add(id);
+    const normalized = normalizeWorksheetResponse(activity, {
+      values: item.values,
+      finalized,
+    });
+    if (!normalized) return undefined;
+    items.push({ id, values: normalized.values });
+  }
+  if (!items.length) return undefined;
+  if (finalized && items.length < (activity.minItems || 1)) return undefined;
+  return { items, finalized };
+}
+
+export function isLinkedScorecardResponse(
+  value: unknown,
+): value is LiveLinkedScorecardResponse {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      Array.isArray((value as { items?: unknown }).items) &&
+      (value as { items: unknown[] }).items.every(
+        (item) =>
+          item &&
+          typeof item === "object" &&
+          typeof (item as { sourceItemId?: unknown }).sourceItemId ===
+            "string" &&
+          (item as { scores?: unknown }).scores &&
+          typeof (item as { scores?: unknown }).scores === "object" &&
+          !Array.isArray((item as { scores?: unknown }).scores),
+      ),
+  );
+}
+
+export function normalizeLinkedScorecardResponse(
+  activity: LiveActivity,
+  value: unknown,
+  sourceValue: unknown,
+): LiveLinkedScorecardResponse | undefined {
+  if (
+    !isLinkedScorecardResponse(value) ||
+    !activity.sourceActivityId ||
+    !activity.scoreCriteria?.length ||
+    !isCardCollectionResponse(sourceValue)
+  )
+    return undefined;
+  const sourceIds = new Set(sourceValue.items.map((item) => item.id));
+  const criterionById = new Map(
+    activity.scoreCriteria.map((criterion) => [criterion.id, criterion]),
+  );
+  const seen = new Set<string>();
+  const items: LiveLinkedScorecardResponse["items"] = [];
+  for (const item of value.items) {
+    if (
+      !item ||
+      typeof item !== "object" ||
+      !sourceIds.has(item.sourceItemId) ||
+      seen.has(item.sourceItemId)
+    )
+      return undefined;
+    seen.add(item.sourceItemId);
+    const scores: Record<string, number> = {};
+    for (const [criterionId, rawScore] of Object.entries(item.scores || {})) {
+      const criterion = criterionById.get(criterionId);
+      const score = Number(rawScore);
+      if (
+        !criterion ||
+        !Number.isInteger(score) ||
+        score < criterion.min ||
+        score > criterion.max
+      )
+        return undefined;
+      scores[criterionId] = score;
+    }
+    items.push({ sourceItemId: item.sourceItemId, scores });
+  }
+  if (!items.length) return undefined;
+  const selectedItemId =
+    typeof value.selectedItemId === "string" &&
+    sourceIds.has(value.selectedItemId)
+      ? value.selectedItemId
+      : undefined;
+  const selectionReason =
+    typeof value.selectionReason === "string" && value.selectionReason.trim()
+      ? value.selectionReason.trim().slice(0, 10_000)
+      : undefined;
+  const finalized = Boolean(value.finalized);
+  if (finalized) {
+    const complete = sourceValue.items.every((sourceItem) => {
+      const scored = items.find((item) => item.sourceItemId === sourceItem.id);
+      return activity.scoreCriteria?.every(
+        (criterion) => scored?.scores[criterion.id] !== undefined,
+      );
+    });
+    if (!selectedItemId || !selectionReason || !complete) return undefined;
+  }
+  return { items, selectedItemId, selectionReason, finalized };
 }
 
 export function isWorksheetResponse(
@@ -141,7 +314,13 @@ export function isPrioritizationResponse(
     value &&
       typeof value === "object" &&
       !Array.isArray(value) &&
-      Array.isArray((value as { items?: unknown }).items),
+      Array.isArray((value as { items?: unknown }).items) &&
+      (value as { items: unknown[] }).items.every(
+        (item) =>
+          item &&
+          typeof item === "object" &&
+          typeof (item as { text?: unknown }).text === "string",
+      ),
   );
 }
 

--- a/apps/commons-courses/lib/live-session-data.ts
+++ b/apps/commons-courses/lib/live-session-data.ts
@@ -15,6 +15,8 @@ import type {
 } from "@/types/live-session";
 import {
   decodeOtherResponse,
+  normalizeCardCollectionResponse,
+  normalizeLinkedScorecardResponse,
   normalizePrioritizationResponse,
   normalizeWorksheetResponse,
 } from "@/lib/live-response-policy";
@@ -88,6 +90,14 @@ export async function getSessionResults(
         participantId?: { displayName?: string };
       }>,
       revealNames,
+      session.activities.find((item) => item.id === activity.sourceActivityId),
+      responses.filter(
+        (response) => response.activityId === activity.sourceActivityId,
+      ) as unknown as Array<{
+        _id: Types.ObjectId;
+        value: LiveResponseValue;
+        participantId?: { _id?: Types.ObjectId; displayName?: string };
+      }>,
     );
   }
   return results;
@@ -175,9 +185,15 @@ function buildActivityResults(
     _id: Types.ObjectId;
     value: LiveResponseValue;
     correct?: boolean;
-    participantId?: { displayName?: string };
+    participantId?: { _id?: Types.ObjectId; displayName?: string };
   }>,
   revealNames: boolean,
+  sourceActivity?: LiveActivity,
+  sourceResponses: Array<{
+    _id: Types.ObjectId;
+    value: LiveResponseValue;
+    participantId?: { _id?: Types.ObjectId; displayName?: string };
+  }> = [],
 ): LiveActivityResults {
   if (activity.type === "prioritization") {
     return {
@@ -207,19 +223,116 @@ function buildActivityResults(
       worksheets: responses.flatMap((response) => {
         const value = normalizeWorksheetResponse(activity, response.value);
         if (!value) return [];
-        return [{
-          id: String(response._id),
-          participantName: revealNames
-            ? response.participantId?.displayName || "Learner"
-            : undefined,
-          values: (activity.worksheetFields || []).flatMap((field) => {
-            const answer = value.values[field.id];
-            return answer === undefined
-              ? []
-              : [{ fieldId: field.id, label: field.label, value: String(answer) }];
-          }),
-          finalized: value.finalized,
-        }];
+        return [
+          {
+            id: String(response._id),
+            participantName: revealNames
+              ? response.participantId?.displayName || "Learner"
+              : undefined,
+            values: (activity.worksheetFields || []).flatMap((field) => {
+              const answer = value.values[field.id];
+              return answer === undefined
+                ? []
+                : [
+                    {
+                      fieldId: field.id,
+                      label: field.label,
+                      value: String(answer),
+                    },
+                  ];
+            }),
+            finalized: value.finalized,
+          },
+        ];
+      }),
+    };
+  }
+  if (activity.type === "card_collection") {
+    return {
+      total: responses.length,
+      cardCollections: responses.flatMap((response) => {
+        const value = normalizeCardCollectionResponse(activity, response.value);
+        if (!value) return [];
+        return [
+          {
+            id: String(response._id),
+            participantName: revealNames
+              ? response.participantId?.displayName || "Learner"
+              : undefined,
+            items: value.items.map((item) => ({
+              id: item.id,
+              title: String(
+                item.values[activity.itemTitleFieldId || ""] || "Untitled card",
+              ),
+              values: (activity.worksheetFields || []).flatMap((field) => {
+                const answer = item.values[field.id];
+                return answer === undefined
+                  ? []
+                  : [
+                      {
+                        fieldId: field.id,
+                        label: field.label,
+                        value: String(answer),
+                      },
+                    ];
+              }),
+            })),
+            finalized: value.finalized,
+          },
+        ];
+      }),
+    };
+  }
+  if (activity.type === "linked_scorecard" && sourceActivity) {
+    return {
+      total: responses.length,
+      scorecards: responses.flatMap((response) => {
+        const participantId = String(response.participantId?._id || "");
+        const sourceRecord = sourceResponses.find(
+          (candidate) =>
+            String(candidate.participantId?._id || "") === participantId,
+        );
+        const source = normalizeCardCollectionResponse(
+          sourceActivity,
+          sourceRecord?.value,
+        );
+        const value = normalizeLinkedScorecardResponse(
+          activity,
+          response.value,
+          sourceRecord?.value,
+        );
+        if (!source || !value) return [];
+        const titleFieldId =
+          sourceActivity.itemTitleFieldId ||
+          sourceActivity.worksheetFields?.[0]?.id ||
+          "";
+        const titleFor = (id: string) =>
+          String(
+            source.items.find((item) => item.id === id)?.values[titleFieldId] ||
+              "Untitled card",
+          );
+        return [
+          {
+            id: String(response._id),
+            participantName: revealNames
+              ? response.participantId?.displayName || "Learner"
+              : undefined,
+            selectedItemId: value.selectedItemId,
+            selectedTitle: value.selectedItemId
+              ? titleFor(value.selectedItemId)
+              : undefined,
+            selectionReason: value.selectionReason,
+            items: value.items.map((item) => ({
+              sourceItemId: item.sourceItemId,
+              title: titleFor(item.sourceItemId),
+              total: Object.values(item.scores).reduce(
+                (sum, score) => sum + score,
+                0,
+              ),
+            })),
+            finalized: value.finalized,
+          },
+        ];
       }),
     };
   }

--- a/apps/commons-courses/lib/live-session-input.ts
+++ b/apps/commons-courses/lib/live-session-input.ts
@@ -4,6 +4,7 @@ import type {
   LiveActivityOption,
   LiveActivityType,
   LiveWorksheetField,
+  LiveScoreCriterion,
   LiveSessionAccess,
   LiveSessionPace,
 } from "@/types/live-session";
@@ -19,6 +20,8 @@ const activityTypes: LiveActivityType[] = [
   "quiz",
   "prioritization",
   "worksheet",
+  "card_collection",
+  "linked_scorecard",
   "reflection",
   "task",
   "break",
@@ -59,9 +62,39 @@ export function createActivity(
     minItems: clampNumber(input.minItems, 1, 50),
     maxSelections: clampNumber(input.maxSelections, 1, 10),
     worksheetFields: normalizeWorksheetFields(input.worksheetFields),
+    itemTitleFieldId: clean(input.itemTitleFieldId),
+    sourceActivityId: clean(input.sourceActivityId),
+    scoreCriteria: normalizeScoreCriteria(input.scoreCriteria),
     points: clampNumber(input.points, 0, 10_000) || 0,
     options: normalizeOptions(input.options),
   };
+}
+
+function normalizeScoreCriteria(input: unknown): LiveScoreCriterion[] {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set<string>();
+  return input.slice(0, 20).flatMap((value, index) => {
+    if (!value || typeof value !== "object") return [];
+    const source = value as Partial<LiveScoreCriterion>;
+    const sourceId = clean(source.id) || `criterion-${index + 1}`;
+    const id = sourceId.replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 80);
+    const label = clean(source.label);
+    if (!id || !label || seen.has(id)) return [];
+    seen.add(id);
+    const min = clampNumber(source.min, 0, 20) ?? 1;
+    const max = clampNumber(source.max, min, 20) ?? 5;
+    return [
+      {
+        id,
+        label,
+        description: clean(source.description),
+        min,
+        max,
+        lowLabel: clean(source.lowLabel),
+        highLabel: clean(source.highLabel),
+      },
+    ];
+  });
 }
 
 function normalizeWorksheetFields(input: unknown): LiveWorksheetField[] {
@@ -79,21 +112,27 @@ function normalizeWorksheetFields(input: unknown): LiveWorksheetField[] {
     const type = allowedTypes.has(String(source.type))
       ? (source.type as LiveWorksheetField["type"])
       : "short_text";
-    const min = type === "scale" ? clampNumber(source.min, 0, 20) ?? 1 : undefined;
-    const max = type === "scale" ? clampNumber(source.max, min || 1, 20) ?? 5 : undefined;
-    return [{
-      id,
-      label,
-      type,
-      section: clean(source.section),
-      description: clean(source.description),
-      placeholder: clean(source.placeholder),
-      required: Boolean(source.required),
-      min,
-      max,
-      lowLabel: clean(source.lowLabel),
-      highLabel: clean(source.highLabel),
-    }];
+    const min =
+      type === "scale" ? (clampNumber(source.min, 0, 20) ?? 1) : undefined;
+    const max =
+      type === "scale"
+        ? (clampNumber(source.max, min || 1, 20) ?? 5)
+        : undefined;
+    return [
+      {
+        id,
+        label,
+        type,
+        section: clean(source.section),
+        description: clean(source.description),
+        placeholder: clean(source.placeholder),
+        required: Boolean(source.required),
+        min,
+        max,
+        lowLabel: clean(source.lowLabel),
+        highLabel: clean(source.highLabel),
+      },
+    ];
   });
 }
 

--- a/apps/commons-courses/models/LiveSession.ts
+++ b/apps/commons-courses/models/LiveSession.ts
@@ -57,6 +57,19 @@ const LiveWorksheetFieldSchema = new Schema(
   { _id: false },
 );
 
+const LiveScoreCriterionSchema = new Schema(
+  {
+    id: { type: String, required: true, trim: true },
+    label: { type: String, required: true, trim: true },
+    description: { type: String, trim: true },
+    min: { type: Number, required: true, min: 0, max: 20 },
+    max: { type: Number, required: true, min: 1, max: 20 },
+    lowLabel: { type: String, trim: true },
+    highLabel: { type: String, trim: true },
+  },
+  { _id: false },
+);
+
 const LiveActivitySchema = new Schema<LiveActivity>(
   {
     id: { type: String, required: true, trim: true },
@@ -69,6 +82,8 @@ const LiveActivitySchema = new Schema<LiveActivity>(
         "quiz",
         "prioritization",
         "worksheet",
+        "card_collection",
+        "linked_scorecard",
         "reflection",
         "task",
         "break",
@@ -105,6 +120,9 @@ const LiveActivitySchema = new Schema<LiveActivity>(
     minItems: { type: Number, min: 1, max: 50 },
     maxSelections: { type: Number, min: 1, max: 10 },
     worksheetFields: { type: [LiveWorksheetFieldSchema], default: [] },
+    itemTitleFieldId: { type: String, trim: true },
+    sourceActivityId: { type: String, trim: true },
+    scoreCriteria: { type: [LiveScoreCriterionSchema], default: [] },
     points: { type: Number, default: 0, min: 0 },
     options: { type: [LiveActivityOptionSchema], default: [] },
   },

--- a/apps/commons-courses/scripts/migrate-ai-quick-wins-linked-tasks.mjs
+++ b/apps/commons-courses/scripts/migrate-ai-quick-wins-linked-tasks.mjs
@@ -1,0 +1,283 @@
+import mongoose from "mongoose";
+
+const sessionId = "6a8490f63085a3ad64e0da34";
+const oldActivityIds = [1, 2, 3, 4].map(
+  (card) => `discover-task-anatomy-${card}`,
+);
+const collectionId = "discover-task-anatomies";
+const scorecardId = "discover-final-choice";
+const criteria = [
+  ["frequency", "Frequency"],
+  ["time", "Time cost"],
+  ["repeatability", "Repeatability"],
+  ["verifiability", "Verifiability"],
+  ["reversibility", "Reversibility"],
+  ["access", "Data access"],
+  ["judgment", "Low judgment density"],
+].map(([id, label]) => ({
+  id,
+  label,
+  min: 1,
+  max: 5,
+  lowLabel: "Low",
+  highLabel: "High",
+}));
+const fields = [
+  field("task-name", "1. Task name", "short_text", true, "Six words or fewer"),
+  field("task-trigger", "2. What triggers it?", "long_text", true),
+  field("task-frequency", "3. How often, and how long does it take?"),
+  field("task-tools", "4. Which tools or apps are involved?"),
+  field("task-inputs", "5. What inputs are needed, and where do they live?"),
+  field("task-steps", "6. What are the steps?", "long_text", true),
+  field("task-judgment", "7. Where do you pause and think?"),
+  field("task-exceptions", "8. What exceptions change the process?"),
+  field(
+    "task-quality",
+    "9. What separates a good result from a bad one?",
+    "long_text",
+    true,
+  ),
+  field("task-tacit", "10. What part do you ‘just know’?"),
+  field("task-loss", "11. What would be lost if this were delegated?"),
+  field("task-never", "12. What should AI never give up?"),
+];
+
+if (!process.env.MONGODB_URI) throw new Error("MONGODB_URI is required.");
+await mongoose.connect(process.env.MONGODB_URI);
+try {
+  const db = mongoose.connection.db;
+  if (!db) throw new Error("MongoDB connection is unavailable.");
+  const sessions = db.collection("livesessions");
+  const responses = db.collection("liveresponses");
+  const session = await sessions.findOne({
+    _id: new mongoose.Types.ObjectId(sessionId),
+  });
+  if (!session) throw new Error(`Live session not found: ${sessionId}`);
+  const activities = Array.isArray(session.activities)
+    ? session.activities
+    : [];
+  const oldActivities = activities.filter((activity) =>
+    oldActivityIds.includes(activity.id),
+  );
+  const existingCollection = activities.find(
+    (activity) => activity.id === collectionId,
+  );
+  const firstIndex = Math.min(
+    ...oldActivities.map((activity) =>
+      activities.findIndex((candidate) => candidate.id === activity.id),
+    ),
+  );
+  const source = existingCollection || oldActivities[0];
+  if (!source) throw new Error("Task anatomy activities were not found.");
+  const status =
+    session.pace === "learner" ||
+    oldActivities.some((activity) => activity.status === "open")
+      ? "open"
+      : oldActivities.every((activity) => activity.status === "closed")
+        ? "closed"
+        : "draft";
+  const collectionActivity = {
+    ...source,
+    id: collectionId,
+    type: "card_collection",
+    title: "Task anatomy cards",
+    prompt:
+      "Unpack each shortlisted routine and surface the judgment hidden inside it.",
+    instructions:
+      "Add one card for every task you want to examine. Work from the real task, not the ideal process. You can create as many cards as you need, save progress, and return to any card.",
+    successCriteria:
+      "Each card names the steps, at least one decision point, an exception, and what good looks like.",
+    estimatedMinutes: 20,
+    status,
+    minItems: 1,
+    itemTitleFieldId: "task-name",
+    worksheetFields: fields,
+    scoreCriteria: [],
+    options: [],
+  };
+  const oldScorecard = activities.find(
+    (activity) => activity.id === scorecardId,
+  );
+  if (!oldScorecard) throw new Error("Final-choice activity was not found.");
+  const scorecardActivity = {
+    ...oldScorecard,
+    type: "linked_scorecard",
+    prompt:
+      "Score the tasks you just unpacked and choose the first one you will carry through all four sessions.",
+    instructions:
+      "Your task cards are already here. Score each one for frequency, time cost, repeatability, verifiability, reversibility, data access, and judgment density—then choose your first build.",
+    successCriteria:
+      "Choose one task and explain why it is a safe, useful first build.",
+    sourceActivityId: collectionId,
+    selectionPrompt: "Choose the first task you will offload.",
+    scoreCriteria: criteria,
+    worksheetFields: [],
+    options: [],
+    status: session.pace === "learner" ? "open" : oldScorecard.status,
+  };
+
+  const oldResponses = await responses
+    .find({ sessionId: session._id, activityId: { $in: oldActivityIds } })
+    .toArray();
+  const byParticipant = Map.groupBy(oldResponses, (response) =>
+    String(response.participantId),
+  );
+  let migratedCollections = 0;
+  for (const participantResponses of byParticipant.values()) {
+    const ordered = oldActivityIds.flatMap((activityId) =>
+      participantResponses.filter(
+        (response) => response.activityId === activityId,
+      ),
+    );
+    const items = ordered.flatMap((response, index) => {
+      const values = response.value?.values;
+      if (!values || typeof values !== "object") return [];
+      const normalized = Object.fromEntries(
+        Object.entries(values).map(([key, value]) => [
+          key.replace(/^task-\d+-/, "task-"),
+          value,
+        ]),
+      );
+      return Object.keys(normalized).length
+        ? [{ id: `migrated-${index + 1}`, values: normalized }]
+        : [];
+    });
+    if (!items.length) continue;
+    const base = ordered.at(-1);
+    await responses.updateOne(
+      {
+        sessionId: session._id,
+        activityId: collectionId,
+        participantId: base.participantId,
+      },
+      {
+        $set: {
+          courseId: base.courseId,
+          userId: base.userId,
+          value: {
+            items,
+            finalized: ordered.every((response) => response.value?.finalized),
+          },
+          submittedAt: base.submittedAt || new Date(),
+          updatedAt: new Date(),
+        },
+        $setOnInsert: { createdAt: new Date(), pointsAwarded: 0 },
+      },
+      { upsert: true },
+    );
+    migratedCollections += 1;
+  }
+  const [scorecardResponses, collectionResponses] = await Promise.all([
+    responses
+      .find({ sessionId: session._id, activityId: scorecardId })
+      .toArray(),
+    responses
+      .find({ sessionId: session._id, activityId: collectionId })
+      .toArray(),
+  ]);
+  let migratedScorecards = 0;
+  for (const response of scorecardResponses) {
+    const oldValues = response.value?.values;
+    if (!oldValues || typeof oldValues !== "object") continue;
+    const collectionResponse = collectionResponses.find(
+      (candidate) =>
+        String(candidate.participantId) === String(response.participantId),
+    );
+    const sourceItems = collectionResponse?.value?.items;
+    if (!Array.isArray(sourceItems) || !sourceItems.length) continue;
+    const items = sourceItems.map((sourceItem, index) => ({
+      sourceItemId: sourceItem.id,
+      scores: Object.fromEntries(
+        criteria.flatMap((criterion) => {
+          const value = Number(
+            oldValues[`score-task-${index + 1}-${criterion.id}`],
+          );
+          return Number.isInteger(value) &&
+            value >= criterion.min &&
+            value <= criterion.max
+            ? [[criterion.id, value]]
+            : [];
+        }),
+      ),
+    }));
+    const selectedText = String(oldValues["selected-task"] || "")
+      .trim()
+      .toLocaleLowerCase();
+    const selected = selectedText
+      ? sourceItems.find((item) =>
+          String(item.values?.["task-name"] || "")
+            .trim()
+            .toLocaleLowerCase()
+            .includes(selectedText),
+        )
+      : undefined;
+    const finalized = Boolean(
+      selected &&
+        items.every((item) =>
+          criteria.every(
+            (criterion) => item.scores[criterion.id] !== undefined,
+          ),
+        ),
+    );
+    await responses.updateOne(
+      { _id: response._id },
+      {
+        $set: {
+          value: {
+            items,
+            selectedItemId: selected?.id,
+            selectionReason: oldValues["selection-reason"],
+            finalized,
+          },
+          updatedAt: new Date(),
+        },
+      },
+    );
+    migratedScorecards += 1;
+  }
+
+  const withoutOld = activities.filter(
+    (activity) => !oldActivityIds.includes(activity.id),
+  );
+  const collectionIndex = withoutOld.findIndex(
+    (activity) => activity.id === collectionId,
+  );
+  if (collectionIndex >= 0) withoutOld[collectionIndex] = collectionActivity;
+  else
+    withoutOld.splice(
+      Number.isFinite(firstIndex) && firstIndex >= 0 ? firstIndex : 9,
+      0,
+      collectionActivity,
+    );
+  const scorecardIndex = withoutOld.findIndex(
+    (activity) => activity.id === scorecardId,
+  );
+  withoutOld[scorecardIndex] = scorecardActivity;
+  await sessions.updateOne(
+    { _id: session._id },
+    {
+      $set: {
+        activities: withoutOld,
+        currentActivityId: oldActivityIds.includes(session.currentActivityId)
+          ? collectionId
+          : session.currentActivityId,
+        updatedAt: new Date(),
+      },
+      $inc: { stateVersion: 1 },
+    },
+  );
+  console.log(
+    JSON.stringify({
+      sessionId,
+      activities: withoutOld.length,
+      migratedCollections,
+      migratedScorecards,
+    }),
+  );
+} finally {
+  await mongoose.disconnect();
+}
+
+function field(id, label, type = "long_text", required = false, placeholder) {
+  return { id, label, type, required, placeholder };
+}

--- a/apps/commons-courses/scripts/seed-ai-quick-wins-workshop.mjs
+++ b/apps/commons-courses/scripts/seed-ai-quick-wins-workshop.mjs
@@ -33,166 +33,166 @@ if (!dryRun && !process.env.MONGODB_URI) {
 await main();
 
 async function main() {
-const workDir = await mkdtemp(path.join(os.tmpdir(), "quick-wins-workshop-"));
-try {
-  const assets = await prepareAssets(inputs, workDir);
-  if (previewDir) await writePreviews(assets.deck.pages, previewDir);
-  if (dryRun) {
-    console.log(
-      JSON.stringify(
-        {
-          dryRun,
-          files: Object.values(assets).map((asset) => ({
-            name: asset.name,
-            bytes: asset.bytes.length,
-            pages: asset.pages.length,
-            visibility: asset.visibility,
-          })),
-        },
-        null,
-        2,
-      ),
-    );
-    return;
-  }
-
-  await mongoose.connect(process.env.MONGODB_URI);
+  const workDir = await mkdtemp(path.join(os.tmpdir(), "quick-wins-workshop-"));
   try {
-    const db = mongoose.connection.db;
-    if (!db) throw new Error("MongoDB connection is unavailable.");
-    const owner = await db.collection("users").findOne({ email: ownerEmail });
-    if (!owner) throw new Error(`Owner not found: ${ownerEmail}`);
-    const principalId = owner.identityUserId;
-    if (!principalId) {
-      throw new Error(`${ownerEmail} is not connected to Commons Identity.`);
-    }
-    const profile = await db
-      .collection("educatorprofiles")
-      .findOne({ userId: owner._id });
-    const sourceCourse = await db.collection("courses").findOne({
-      slug: "claude-skills-for-everyday-work-moringa",
-    });
-    const now = new Date();
-    const course = await upsertCourse(db, {
-      owner,
-      profile,
-      agents: sourceCourse?.agents || [],
-      now,
-    });
-
-    const existingSession = await db.collection("livesessions").findOne({
-      courseId: course._id,
-      title: "Day 1 · Discover — AI Quick Wins for Leaders",
-    });
-    if (existingSession && existingSession.status !== "draft" && !force) {
-      throw new Error(
-        "The Day 1 session has already been opened. Re-run with --force only if replacing its plan is intentional.",
+    const assets = await prepareAssets(inputs, workDir);
+    if (previewDir) await writePreviews(assets.deck.pages, previewDir);
+    if (dryRun) {
+      console.log(
+        JSON.stringify(
+          {
+            dryRun,
+            files: Object.values(assets).map((asset) => ({
+              name: asset.name,
+              bytes: asset.bytes.length,
+              pages: asset.pages.length,
+              visibility: asset.visibility,
+            })),
+          },
+          null,
+          2,
+        ),
       );
+      return;
     }
 
-    const commonsFiles = await uploadToCommonsLibrary(
-      Object.values(assets),
-      principalId,
-      owner.identityWorkspaceId,
-    );
-    const bucket = new mongo.GridFSBucket(db, {
-      bucketName: "courseMaterials",
-    });
-    const materialByKey = {};
-    for (const asset of Object.values(assets)) {
-      materialByKey[asset.key] = await syncMaterial({
-        db,
-        bucket,
-        course,
+    await mongoose.connect(process.env.MONGODB_URI);
+    try {
+      const db = mongoose.connection.db;
+      if (!db) throw new Error("MongoDB connection is unavailable.");
+      const owner = await db.collection("users").findOne({ email: ownerEmail });
+      if (!owner) throw new Error(`Owner not found: ${ownerEmail}`);
+      const principalId = owner.identityUserId;
+      if (!principalId) {
+        throw new Error(`${ownerEmail} is not connected to Commons Identity.`);
+      }
+      const profile = await db
+        .collection("educatorprofiles")
+        .findOne({ userId: owner._id });
+      const sourceCourse = await db.collection("courses").findOne({
+        slug: "claude-skills-for-everyday-work-moringa",
+      });
+      const now = new Date();
+      const course = await upsertCourse(db, {
         owner,
-        principalId,
-        asset,
-        commonsFile: commonsFiles.get(asset.key),
+        profile,
+        agents: sourceCourse?.agents || [],
         now,
       });
-    }
 
-    const joinCode =
-      existingSession?.joinCode || (await createUniqueJoinCode(db));
-    const activities = createDiscoverActivities(
-      String(materialByKey.deck._id),
-    );
-    const session = await db.collection("livesessions").findOneAndUpdate(
-      {
+      const existingSession = await db.collection("livesessions").findOne({
         courseId: course._id,
         title: "Day 1 · Discover — AI Quick Wins for Leaders",
-      },
-      {
-        $set: {
-          courseSlug: slug,
-          description:
-            "Discover the AI landscape, map the organisation, capture recurring routines, and choose the first safe task to offload.",
-          joinCode,
-          status: "draft",
-          pace: "facilitator",
-          access: "open",
-          invitedEmails: [],
-          activities,
-          settings: {
-            allowLateJoin: true,
-            showParticipantNames: true,
-            showLeaderboard: false,
-            learnerCopilot: {
-              enabled: false,
-              explainCurrentActivity: true,
-              coachResponses: true,
-              useCourseMaterials: true,
-              giveDirectExplanations: false,
-            },
-          },
-          createdBy: owner._id,
-          updatedAt: now,
-        },
-        $unset: { currentActivityId: "" },
-        $setOnInsert: { createdAt: now },
-        $inc: { stateVersion: 1 },
-      },
-      { upsert: true, returnDocument: "after" },
-    );
-    if (!session) throw new Error("Live session could not be created.");
+      });
+      if (existingSession && existingSession.status !== "draft" && !force) {
+        throw new Error(
+          "The Day 1 session has already been opened. Re-run with --force only if replacing its plan is intentional.",
+        );
+      }
 
-    console.log(
-      JSON.stringify(
+      const commonsFiles = await uploadToCommonsLibrary(
+        Object.values(assets),
+        principalId,
+        owner.identityWorkspaceId,
+      );
+      const bucket = new mongo.GridFSBucket(db, {
+        bucketName: "courseMaterials",
+      });
+      const materialByKey = {};
+      for (const asset of Object.values(assets)) {
+        materialByKey[asset.key] = await syncMaterial({
+          db,
+          bucket,
+          course,
+          owner,
+          principalId,
+          asset,
+          commonsFile: commonsFiles.get(asset.key),
+          now,
+        });
+      }
+
+      const joinCode =
+        existingSession?.joinCode || (await createUniqueJoinCode(db));
+      const activities = createDiscoverActivities(
+        String(materialByKey.deck._id),
+      );
+      const session = await db.collection("livesessions").findOneAndUpdate(
         {
-          owner: owner.email,
-          course: {
-            id: String(course._id),
-            slug: course.slug,
-            visibility: course.catalogVisibility,
-          },
-          liveSession: {
-            id: String(session._id),
-            joinCode: session.joinCode,
-            activities: session.activities.length,
-            access: session.access,
-          },
-          materials: Object.fromEntries(
-            Object.entries(materialByKey).map(([key, value]) => [
-              key,
-              {
-                id: String(value._id),
-                name: value.name,
-                visibility: value.visibility,
-                fileId: value.fileId,
-              },
-            ]),
-          ),
+          courseId: course._id,
+          title: "Day 1 · Discover — AI Quick Wins for Leaders",
         },
-        null,
-        2,
-      ),
-    );
+        {
+          $set: {
+            courseSlug: slug,
+            description:
+              "Discover the AI landscape, map the organisation, capture recurring routines, and choose the first safe task to offload.",
+            joinCode,
+            status: "draft",
+            pace: "facilitator",
+            access: "open",
+            invitedEmails: [],
+            activities,
+            settings: {
+              allowLateJoin: true,
+              showParticipantNames: true,
+              showLeaderboard: false,
+              learnerCopilot: {
+                enabled: false,
+                explainCurrentActivity: true,
+                coachResponses: true,
+                useCourseMaterials: true,
+                giveDirectExplanations: false,
+              },
+            },
+            createdBy: owner._id,
+            updatedAt: now,
+          },
+          $unset: { currentActivityId: "" },
+          $setOnInsert: { createdAt: now },
+          $inc: { stateVersion: 1 },
+        },
+        { upsert: true, returnDocument: "after" },
+      );
+      if (!session) throw new Error("Live session could not be created.");
+
+      console.log(
+        JSON.stringify(
+          {
+            owner: owner.email,
+            course: {
+              id: String(course._id),
+              slug: course.slug,
+              visibility: course.catalogVisibility,
+            },
+            liveSession: {
+              id: String(session._id),
+              joinCode: session.joinCode,
+              activities: session.activities.length,
+              access: session.access,
+            },
+            materials: Object.fromEntries(
+              Object.entries(materialByKey).map(([key, value]) => [
+                key,
+                {
+                  id: String(value._id),
+                  name: value.name,
+                  visibility: value.visibility,
+                  fileId: value.fileId,
+                },
+              ]),
+            ),
+          },
+          null,
+          2,
+        ),
+      );
+    } finally {
+      await mongoose.disconnect();
+    }
   } finally {
-    await mongoose.disconnect();
+    await rm(workDir, { recursive: true, force: true });
   }
-} finally {
-  await rm(workDir, { recursive: true, force: true });
-}
 }
 
 async function upsertCourse(db, { owner, profile, agents, now }) {
@@ -357,26 +357,47 @@ function createDiscoverActivities(materialId) {
     worksheetFields,
     ...extra,
   });
-  const taskCardFields = (card) => [
-    field(`task-${card}-name`, "1. Task name", "short_text", {
+  const taskCardFields = () => [
+    field("task-name", "1. Task name", "short_text", {
       required: true,
       placeholder: "Six words or fewer",
-      section: `Task ${card}`,
     }),
-    field(`task-${card}-trigger`, "2. What triggers it?", "long_text", {
+    field("task-trigger", "2. What triggers it?", "long_text", {
       required: true,
-      section: `Task ${card}`,
     }),
-    field(`task-${card}-frequency`, "3. How often, and how long does it take?", "long_text", { section: `Task ${card}` }),
-    field(`task-${card}-tools`, "4. Which tools or apps are involved?", "long_text", { section: `Task ${card}` }),
-    field(`task-${card}-inputs`, "5. What inputs are needed, and where do they live?", "long_text", { section: `Task ${card}` }),
-    field(`task-${card}-steps`, "6. What are the steps?", "long_text", { required: true, section: `Task ${card}` }),
-    field(`task-${card}-judgment`, "7. Where do you pause and think?", "long_text", { section: `Task ${card}` }),
-    field(`task-${card}-exceptions`, "8. What exceptions change the process?", "long_text", { section: `Task ${card}` }),
-    field(`task-${card}-quality`, "9. What separates a good result from a bad one?", "long_text", { required: true, section: `Task ${card}` }),
-    field(`task-${card}-tacit`, "10. What part do you ‘just know’?", "long_text", { section: `Task ${card}` }),
-    field(`task-${card}-loss`, "11. What would be lost if this were delegated?", "long_text", { section: `Task ${card}` }),
-    field(`task-${card}-never`, "12. What should AI never give up?", "long_text", { section: `Task ${card}` }),
+    field(
+      "task-frequency",
+      "3. How often, and how long does it take?",
+      "long_text",
+    ),
+    field("task-tools", "4. Which tools or apps are involved?", "long_text"),
+    field(
+      "task-inputs",
+      "5. What inputs are needed, and where do they live?",
+      "long_text",
+    ),
+    field("task-steps", "6. What are the steps?", "long_text", {
+      required: true,
+    }),
+    field("task-judgment", "7. Where do you pause and think?", "long_text"),
+    field(
+      "task-exceptions",
+      "8. What exceptions change the process?",
+      "long_text",
+    ),
+    field(
+      "task-quality",
+      "9. What separates a good result from a bad one?",
+      "long_text",
+      { required: true },
+    ),
+    field("task-tacit", "10. What part do you ‘just know’?", "long_text"),
+    field(
+      "task-loss",
+      "11. What would be lost if this were delegated?",
+      "long_text",
+    ),
+    field("task-never", "12. What should AI never give up?", "long_text"),
   ];
   const scoreCriteria = [
     ["frequency", "Frequency"],
@@ -387,22 +408,6 @@ function createDiscoverActivities(materialId) {
     ["access", "Data access"],
     ["judgment", "Low judgment density"],
   ];
-  const scorecardFields = [1, 2, 3, 4].flatMap((task) => [
-    field(`score-task-${task}-name`, `Task ${task} name`, "short_text", {
-      required: true,
-      section: `Candidate ${task}`,
-      placeholder: "Copy one of your shortlisted routines",
-    }),
-    ...scoreCriteria.map(([id, label]) =>
-      field(`score-task-${task}-${id}`, label, "scale", {
-        section: `Candidate ${task}`,
-        min: 1,
-        max: 5,
-        lowLabel: "Low",
-        highLabel: "High",
-      }),
-    ),
-  ]);
 
   return [
     content(
@@ -423,9 +428,19 @@ function createDiscoverActivities(materialId) {
       7,
       7,
       [
-        field("outcome", "By the end of session four, I will be able to…", "long_text", { required: true, section: "Outcome contract" }),
-        field("evidence", "The evidence that it worked will be…", "long_text", { required: true, section: "Outcome contract" }),
-        field("signature", "Name or signature", "short_text", { section: "Outcome contract" }),
+        field(
+          "outcome",
+          "By the end of session four, I will be able to…",
+          "long_text",
+          { required: true, section: "Outcome contract" },
+        ),
+        field("evidence", "The evidence that it worked will be…", "long_text", {
+          required: true,
+          section: "Outcome contract",
+        }),
+        field("signature", "Name or signature", "short_text", {
+          section: "Outcome contract",
+        }),
       ],
       {
         instructions:
@@ -492,10 +507,30 @@ function createDiscoverActivities(materialId) {
       24,
       15,
       [
-        field("knowledge", "Knowledge: what does the organisation need to know, and where does it live?", "long_text", { required: true, section: "Organisational foundations" }),
-        field("tools", "Tools: which systems does the organisation actually use?", "long_text", { required: true, section: "Organisational foundations" }),
-        field("procedures", "Procedures: where are repeatable processes written down—or only held in people’s heads?", "long_text", { required: true, section: "Organisational foundations" }),
-        field("rules", "Rules: what policies, boundaries, approvals, and risks must an AI system respect?", "long_text", { required: true, section: "Organisational foundations" }),
+        field(
+          "knowledge",
+          "Knowledge: what does the organisation need to know, and where does it live?",
+          "long_text",
+          { required: true, section: "Organisational foundations" },
+        ),
+        field(
+          "tools",
+          "Tools: which systems does the organisation actually use?",
+          "long_text",
+          { required: true, section: "Organisational foundations" },
+        ),
+        field(
+          "procedures",
+          "Procedures: where are repeatable processes written down—or only held in people’s heads?",
+          "long_text",
+          { required: true, section: "Organisational foundations" },
+        ),
+        field(
+          "rules",
+          "Rules: what policies, boundaries, approvals, and risks must an AI system respect?",
+          "long_text",
+          { required: true, section: "Organisational foundations" },
+        ),
       ],
       {
         instructions:
@@ -510,13 +545,35 @@ function createDiscoverActivities(materialId) {
       8,
       [
         ...[1, 2, 3, 4].flatMap((row) => [
-          field(`tool-${row}`, "Tool", "short_text", { section: `Tool ${row}` }),
-          field(`tool-${row}-frequency`, "How often do you use it?", "short_text", { section: `Tool ${row}` }),
-          field(`tool-${row}-use`, "What do you use it for?", "long_text", { section: `Tool ${row}` }),
-          field(`tool-${row}-trust`, "Where did you stop trusting it?", "long_text", { section: `Tool ${row}` }),
+          field(`tool-${row}`, "Tool", "short_text", {
+            section: `Tool ${row}`,
+          }),
+          field(
+            `tool-${row}-frequency`,
+            "How often do you use it?",
+            "short_text",
+            { section: `Tool ${row}` },
+          ),
+          field(`tool-${row}-use`, "What do you use it for?", "long_text", {
+            section: `Tool ${row}`,
+          }),
+          field(
+            `tool-${row}-trust`,
+            "Where did you stop trusting it?",
+            "long_text",
+            { section: `Tool ${row}` },
+          ),
         ]),
-        field("gave-up", "What have you tried and given up on?", "long_text", { required: true, section: "Patterns" }),
-        field("repeated-context", "Where do you paste the same context again and again?", "long_text", { required: true, section: "Patterns" }),
+        field("gave-up", "What have you tried and given up on?", "long_text", {
+          required: true,
+          section: "Patterns",
+        }),
+        field(
+          "repeated-context",
+          "Where do you paste the same context again and again?",
+          "long_text",
+          { required: true, section: "Patterns" },
+        ),
       ],
       {
         instructions:
@@ -550,40 +607,49 @@ function createDiscoverActivities(materialId) {
       points: 0,
       options: [],
     },
-    ...[1, 2, 3, 4].map((card) =>
-      worksheet(
-        `discover-task-anatomy-${card}`,
-        `Task anatomy card ${card}`,
-        "Unpack one shortlisted routine and surface the judgment hidden inside it.",
+    {
+      ...content(
+        "discover-task-anatomies",
+        "Task anatomy cards",
+        "Unpack each shortlisted routine and surface the judgment hidden inside it.",
         35,
-        8,
-        taskCardFields(card),
-        {
-          instructions:
-            "Work from the real task, not the ideal process. Capture decisions, exceptions, the quality bar, and anything you describe as ‘I just know’. Save progress if you need to return to it.",
-          successCriteria:
-            "You can name the steps, at least one decision point, one exception, and what good looks like.",
-        },
+        20,
       ),
-    ),
-    worksheet(
-      "discover-final-choice",
-      "Choose the first task to offload",
-      "Score your four candidates and choose the first one you will carry through all four sessions.",
-      36,
-      12,
-      [
-        ...scorecardFields,
-        field("selected-task", "The first task I will offload is…", "short_text", { required: true, section: "Decision", placeholder: "Six words or fewer" }),
-        field("selection-reason", "Why is this a safe, useful first build?", "long_text", { required: true, section: "Decision" }),
-      ],
-      {
-        instructions:
-          "Consider frequency, time cost, repeatability, verifiability, reversibility, data access, and judgment density. For a first build, favour something easy to verify and easy to reverse.",
-        successCriteria:
-          "Name one task in six words or fewer and explain why it is a safe, useful first build.",
-      },
-    ),
+      type: "card_collection",
+      required: true,
+      minItems: 1,
+      itemTitleFieldId: "task-name",
+      worksheetFields: taskCardFields(),
+      instructions:
+        "Add one card for every task you want to examine. Work from the real task, not the ideal process. You can create as many cards as you need, save progress, and return to any card.",
+      successCriteria:
+        "Each card names the steps, at least one decision point, an exception, and what good looks like.",
+    },
+    {
+      ...content(
+        "discover-final-choice",
+        "Choose the first task to offload",
+        "Score the tasks you just unpacked and choose the first one you will carry through all four sessions.",
+        36,
+        12,
+      ),
+      type: "linked_scorecard",
+      required: true,
+      sourceActivityId: "discover-task-anatomies",
+      selectionPrompt: "Choose the first task you will offload.",
+      scoreCriteria: scoreCriteria.map(([id, label]) => ({
+        id,
+        label,
+        min: 1,
+        max: 5,
+        lowLabel: "Low",
+        highLabel: "High",
+      })),
+      instructions:
+        "Your task cards are already here. Score each one for frequency, time cost, repeatability, verifiability, reversibility, data access, and judgment density—then choose your first build.",
+      successCriteria:
+        "Choose one task and explain why it is a safe, useful first build.",
+    },
     worksheet(
       "discover-recording-commitment",
       "Your recording commitment",
@@ -591,10 +657,30 @@ function createDiscoverActivities(materialId) {
       37,
       8,
       [
-        field("recorded-task", "The task I will record", "short_text", { required: true, section: "Assignment" }),
-        field("recording-date", "I will record it by", "date", { required: true, section: "Assignment" }),
-        field("support-needed", "What help, access, or support do you need?", "long_text", { section: "Assignment" }),
-        field("commitment", "Write your commitment in one sentence", "long_text", { required: true, section: "Commitment", placeholder: "I am recording ___ by ___." }),
+        field("recorded-task", "The task I will record", "short_text", {
+          required: true,
+          section: "Assignment",
+        }),
+        field("recording-date", "I will record it by", "date", {
+          required: true,
+          section: "Assignment",
+        }),
+        field(
+          "support-needed",
+          "What help, access, or support do you need?",
+          "long_text",
+          { section: "Assignment" },
+        ),
+        field(
+          "commitment",
+          "Write your commitment in one sentence",
+          "long_text",
+          {
+            required: true,
+            section: "Commitment",
+            placeholder: "I am recording ___ by ___.",
+          },
+        ),
       ],
       {
         instructions:
@@ -619,7 +705,12 @@ async function prepareAssets(source, workDir) {
   const deckPages = await renderPdfPages(deckPdf);
   const deckText = await extractPresentationText(deckBytes);
   const documentDefinitions = [
-    ["workbook", source.workbook, "Session 1 Participant Workbook.pdf", "course"],
+    [
+      "workbook",
+      source.workbook,
+      "Session 1 Participant Workbook.pdf",
+      "course",
+    ],
     ["cards", source.cards, "Session 1 Reference Cards.pdf", "course"],
     ["guide", source.guide, "Session 1 Facilitator Guide.pdf", "educator"],
   ].filter(([, sourcePath]) => Boolean(sourcePath));
@@ -946,7 +1037,8 @@ async function syncMaterial({
     await Promise.allSettled(oldIds.map((id) => bucket.delete(id)));
     return material;
   } finally {
-    if (!committed) await Promise.allSettled(newIds.map((id) => bucket.delete(id)));
+    if (!committed)
+      await Promise.allSettled(newIds.map((id) => bucket.delete(id)));
   }
 }
 
@@ -956,10 +1048,7 @@ async function upload(bucket, bytes, filename, contentType) {
     metadata: { private: true },
   });
   await new Promise((resolve, reject) =>
-    Readable.from(bytes)
-      .pipe(stream)
-      .on("finish", resolve)
-      .on("error", reject),
+    Readable.from(bytes).pipe(stream).on("finish", resolve).on("error", reject),
   );
   return stream.id;
 }
@@ -967,7 +1056,9 @@ async function upload(bucket, bytes, filename, contentType) {
 async function createUniqueJoinCode(db) {
   for (let attempt = 0; attempt < 20; attempt += 1) {
     const code = String(Math.floor(100_000 + Math.random() * 900_000));
-    const exists = await db.collection("livesessions").findOne({ joinCode: code });
+    const exists = await db
+      .collection("livesessions")
+      .findOne({ joinCode: code });
     if (!exists) return code;
   }
   throw new Error("A unique live-session join code could not be generated.");
@@ -975,7 +1066,22 @@ async function createUniqueJoinCode(db) {
 
 async function writePreviews(pages, targetDir) {
   await mkdir(targetDir, { recursive: true });
-  const indexes = [0, 6, 7, 17, 20, 23, 30, 31, 33, 34, 35, 36, 37, pages.length - 1].filter(
+  const indexes = [
+    0,
+    6,
+    7,
+    17,
+    20,
+    23,
+    30,
+    31,
+    33,
+    34,
+    35,
+    36,
+    37,
+    pages.length - 1,
+  ].filter(
     (value, index, values) =>
       value >= 0 && value < pages.length && values.indexOf(value) === index,
   );

--- a/apps/commons-courses/types/live-session.ts
+++ b/apps/commons-courses/types/live-session.ts
@@ -11,6 +11,8 @@ export type LiveActivityType =
   | "quiz"
   | "prioritization"
   | "worksheet"
+  | "card_collection"
+  | "linked_scorecard"
   | "reflection"
   | "task"
   | "break";
@@ -35,6 +37,16 @@ export type LiveWorksheetField = {
   required: boolean;
   min?: number;
   max?: number;
+  lowLabel?: string;
+  highLabel?: string;
+};
+
+export type LiveScoreCriterion = {
+  id: string;
+  label: string;
+  description?: string;
+  min: number;
+  max: number;
   lowLabel?: string;
   highLabel?: string;
 };
@@ -71,6 +83,11 @@ export type LiveActivity = {
   minItems?: number;
   maxSelections?: number;
   worksheetFields?: LiveWorksheetField[];
+  /** Field used as the visible title for each repeatable card. */
+  itemTitleFieldId?: string;
+  /** Activity whose card collection supplies the scorecard candidates. */
+  sourceActivityId?: string;
+  scoreCriteria?: LiveScoreCriterion[];
   points: number;
   options: LiveActivityOption[];
 };
@@ -91,11 +108,35 @@ export type LiveWorksheetResponse = {
   finalized: boolean;
 };
 
+export type LiveCardCollectionItem = {
+  id: string;
+  values: Record<string, string | number>;
+};
+
+export type LiveCardCollectionResponse = {
+  items: LiveCardCollectionItem[];
+  finalized: boolean;
+};
+
+export type LiveScorecardItem = {
+  sourceItemId: string;
+  scores: Record<string, number>;
+};
+
+export type LiveLinkedScorecardResponse = {
+  items: LiveScorecardItem[];
+  selectedItemId?: string;
+  selectionReason?: string;
+  finalized: boolean;
+};
+
 export type LiveResponseValue =
   | string
   | string[]
   | LivePrioritizationResponse
-  | LiveWorksheetResponse;
+  | LiveWorksheetResponse
+  | LiveCardCollectionResponse
+  | LiveLinkedScorecardResponse;
 
 export type LiveSessionSettings = {
   allowLateJoin: boolean;
@@ -183,6 +224,25 @@ export type LiveActivityResults = {
     id: string;
     participantName?: string;
     values: Array<{ fieldId: string; label: string; value: string }>;
+    finalized: boolean;
+  }>;
+  cardCollections?: Array<{
+    id: string;
+    participantName?: string;
+    items: Array<{
+      id: string;
+      title: string;
+      values: Array<{ fieldId: string; label: string; value: string }>;
+    }>;
+    finalized: boolean;
+  }>;
+  scorecards?: Array<{
+    id: string;
+    participantName?: string;
+    selectedItemId?: string;
+    selectedTitle?: string;
+    selectionReason?: string;
+    items: Array<{ sourceItemId: string; title: string; total: number }>;
     finalized: boolean;
   }>;
 };


### PR DESCRIPTION
## Summary
- add reusable repeatable-card and linked-scorecard live activity types
- let learners create, edit, save, and finish any number of structured task cards
- carry those task cards into a scored first-task selection without retyping
- expose linked results to facilitators and support authoring in the live-session editor and educator copilot
- migrate the AI Quick Wins Day 1 run of show from four separate task forms to one linked workflow while preserving existing responses

## Validation
- pnpm test (40 passing)
- pnpm exec tsc --noEmit
- targeted ESLint
- node syntax checks for seed and migration scripts