### PR TITLE
fix: use portable UUID default for UI plugins

### DIFF
--- a/apps/commons-api/migrations/versioned/021_ui_plugins.sql
+++ b/apps/commons-api/migrations/versioned/021_ui_plugins.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS "ui_plugin" (
-  "plugin_id" uuid PRIMARY KEY DEFAULT uuid_generate_v4() NOT NULL,
+  "plugin_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
   "owner_user_id" text NOT NULL,
   "workspace_id" text,
   "created_by_agent_id" text REFERENCES "agent"("agent_id") ON DELETE SET NULL,


### PR DESCRIPTION
Fixes the staging migration failure by using PostgreSQL gen_random_uuid(), consistent with the other versioned migrations, instead of relying on uuid_generate_v4() being present on search_path.