### PR TITLE
ci: allow manual package release retries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Adds workflow_dispatch to the package Release workflow so checkout/publish failures can be retried deterministically after fixing credentials.