### PR TITLE
Add multi-session live programmes and AI Quick Wins Capture

### DIFF
--- a/apps/commons-courses/app/api/educator/live-sessions/[id]/route.ts
+++ b/apps/commons-courses/app/api/educator/live-sessions/[id]/route.ts
@@ -9,12 +9,26 @@ import {
   serializeEducatorLiveSession,
 } from "@/lib/live-session-data";
 import LiveSession, { type ILiveSession } from "@/models/LiveSession";
-import type { LiveActivity } from "@/types/live-session";
+import type { LiveActivity, LiveSessionPart } from "@/types/live-session";
 import { activityStatusesForLivePace } from "@/lib/live-session-pacing";
+import {
+  activityStatusesForParts,
+  firstActivityIdForPart,
+  partForActivity,
+} from "@/lib/live-session-parts";
 
-function syncActivityStatusesForPace(
-  session: ILiveSession,
-) {
+function syncActivityStatusesForPace(session: ILiveSession) {
+  if (session.parts?.length) {
+    const statuses = activityStatusesForParts({
+      activities: session.activities,
+      parts: session.parts,
+      currentActivityId: session.currentActivityId,
+    });
+    for (const activity of session.activities) {
+      activity.status = statuses[activity.id];
+    }
+    return;
+  }
   const next = activityStatusesForLivePace({
     activities: session.activities,
     currentActivityId: session.currentActivityId,
@@ -71,7 +85,7 @@ export async function PATCH(
   const body = await req.json().catch(() => ({}));
   const record =
     body && typeof body === "object" ? (body as Record<string, unknown>) : {};
-  const patch = normalizeSessionPatch(body);
+  const patch = normalizeSessionPatch(body, session.activities);
 
   if (record.command === "open_lobby") {
     session.status = "lobby";
@@ -96,9 +110,64 @@ export async function PATCH(
         { status: 404 },
       );
     }
+    const part = partForActivity(session, activityId);
+    if (part && part.status !== "open") {
+      return NextResponse.json(
+        { error: `Open ${part.title} before presenting its activities.` },
+        { status: 409 },
+      );
+    }
     session.status = "live";
     session.currentActivityId = activityId;
+    if (part) {
+      session.currentPartId = part.id;
+      session.pace = part.pace;
+    }
     syncActivityStatusesForPace(session);
+  } else if (record.command === "open_part") {
+    const partId = typeof record.partId === "string" ? record.partId : "";
+    const part = session.parts.find(
+      (item: LiveSessionPart) => item.id === partId,
+    );
+    if (!part) {
+      return NextResponse.json(
+        { error: "Programme session not found." },
+        { status: 404 },
+      );
+    }
+    for (const item of session.parts)
+      item.status = item.id === partId ? "open" : "closed";
+    session.currentPartId = part.id;
+    session.pace = part.pace;
+    session.currentActivityId = firstActivityIdForPart(
+      session.activities,
+      part,
+    );
+    session.status = "live";
+    syncActivityStatusesForPace(session);
+  } else if (record.command === "set_part_pace") {
+    const partId = typeof record.partId === "string" ? record.partId : "";
+    const pace = record.pace === "learner" ? "learner" : "facilitator";
+    const part = session.parts.find(
+      (item: LiveSessionPart) => item.id === partId,
+    );
+    if (!part) {
+      return NextResponse.json(
+        { error: "Programme session not found." },
+        { status: 404 },
+      );
+    }
+    part.pace = pace;
+    if (part.status === "open") {
+      session.currentPartId = part.id;
+      session.pace = pace;
+      session.currentActivityId = part.activityIds.includes(
+        session.currentActivityId || "",
+      )
+        ? session.currentActivityId
+        : firstActivityIdForPart(session.activities, part);
+      syncActivityStatusesForPace(session);
+    }
   } else if (record.command === "close_activity") {
     const activityId =
       typeof record.activityId === "string" ? record.activityId : "";
@@ -120,6 +189,7 @@ export async function PATCH(
 
   session.stateVersion = (session.stateVersion || 0) + 1;
   session.markModified("activities");
+  session.markModified("parts");
   await session.save();
   return NextResponse.json({
     session: await serializeEducatorLiveSession(

--- a/apps/commons-courses/app/api/live-sessions/[id]/responses/route.ts
+++ b/apps/commons-courses/app/api/live-sessions/[id]/responses/route.ts
@@ -13,6 +13,10 @@ import {
   normalizePrioritizationResponse,
   normalizeWorksheetResponse,
 } from "@/lib/live-response-policy";
+import {
+  effectiveActivityPace,
+  isActivityPartOpen,
+} from "@/lib/live-session-parts";
 
 export async function POST(
   req: NextRequest,
@@ -54,6 +58,12 @@ export async function POST(
   if (!session || !activity) {
     return NextResponse.json({ error: "Activity not found." }, { status: 404 });
   }
+  if (!isActivityPartOpen(session, activity.id)) {
+    return NextResponse.json(
+      { error: "This programme session is not open yet." },
+      { status: 409 },
+    );
+  }
   if (activity.status !== "open") {
     return NextResponse.json(
       { error: "This activity is not open." },
@@ -61,7 +71,7 @@ export async function POST(
     );
   }
   if (
-    session.pace === "facilitator" &&
+    effectiveActivityPace(session, activity.id) === "facilitator" &&
     session.currentActivityId !== activity.id
   ) {
     return NextResponse.json(

--- a/apps/commons-courses/app/api/live-sessions/[id]/state/route.ts
+++ b/apps/commons-courses/app/api/live-sessions/[id]/state/route.ts
@@ -37,7 +37,7 @@ export async function GET(
 
   await connectDB();
   const session = await LiveSession.findById(id).select(
-    "courseId status pace access invitedEmails currentActivityId stateVersion activities settings",
+    "courseId status pace access invitedEmails currentActivityId currentPartId stateVersion activities parts settings",
   );
   if (!session || session.status === "draft") {
     return NextResponse.json(
@@ -120,12 +120,14 @@ export async function GET(
         status: session.status,
         pace: session.pace,
         currentActivityId,
+        currentPartId: session.currentPartId,
         currentActivity: currentActivity
           ? learnerSafeActivities([currentActivity])[0]
           : undefined,
         learnerCopilot: normalizeLiveLearnerCopilotPolicy(
           session.settings?.learnerCopilot,
         ),
+        parts: session.parts || [],
         stateVersion: session.stateVersion || 0,
         activityStatuses: Object.fromEntries(
           session.activities.map((activity: LiveActivity) => [

--- a/apps/commons-courses/components/educator/live-facilitator-studio.tsx
+++ b/apps/commons-courses/components/educator/live-facilitator-studio.tsx
@@ -37,6 +37,7 @@ import type {
   LiveActivityType,
   LiveParticipantRecord,
   LiveSessionRecord,
+  LiveSessionPart,
   LiveWorksheetField,
 } from "@/types/live-session";
 import type { CourseMaterialRecord } from "@/types/course-material";
@@ -162,12 +163,23 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
   const current = data?.session.activities.find(
     (activity) => activity.id === data.session.currentActivityId,
   );
-  const currentIndex = current
-    ? data!.session.activities.findIndex(
-        (activity) => activity.id === current.id,
-      )
-    : -1;
-  const nextActivity = data?.session.activities[currentIndex + 1];
+  const currentPart = data?.session.parts.find(
+    (part) =>
+      part.id === data.session.currentPartId ||
+      part.activityIds.includes(current?.id || ""),
+  );
+  const currentPartActivities = currentPart
+    ? currentPart.activityIds.flatMap((activityId) => {
+        const activity = data?.session.activities.find(
+          (candidate) => candidate.id === activityId,
+        );
+        return activity ? [activity] : [];
+      })
+    : data?.session.activities || [];
+  const currentPartIndex = currentPartActivities.findIndex(
+    (activity) => activity.id === current?.id,
+  );
+  const nextActivity = currentPartActivities[currentPartIndex + 1];
 
   function updateSession(patch: Partial<LiveSessionRecord>) {
     setData((currentData) =>
@@ -202,6 +214,7 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
         scheduledStart: data.session.scheduledStart,
         settings: data.session.settings,
         activities: data.session.activities,
+        parts: data.session.parts,
       }),
     });
     const next = await res.json().catch(() => ({}));
@@ -212,14 +225,19 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
     setSaving(false);
   }
 
-  async function command(commandName: string, activityId?: string) {
+  async function command(
+    commandName: string,
+    activityId?: string,
+    partId?: string,
+    pace?: LiveSessionPart["pace"],
+  ) {
     if (running) return;
     setRunning(true);
     setNotice("");
     const res = await fetch(`/api/educator/live-sessions/${sessionId}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ command: commandName, activityId }),
+      body: JSON.stringify({ command: commandName, activityId, partId, pace }),
     });
     const next = await res.json().catch(() => ({}));
     if (res.ok) {
@@ -453,6 +471,17 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
         </div>
       ) : null}
 
+      {data.session.parts.length ? (
+        <ProgrammeSessionControls
+          parts={data.session.parts}
+          running={running}
+          onOpen={(partId) => command("open_part", undefined, partId)}
+          onPaceChange={(partId, pace) =>
+            command("set_part_pace", undefined, partId, pace)
+          }
+        />
+      ) : null}
+
       {tab === "plan" ? (
         <div className="grid gap-5 xl:grid-cols-[340px_minmax(0,1fr)]">
           <aside className="rounded-2xl border border-slate-200 bg-white p-3">
@@ -547,24 +576,32 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
                     className={inputClass}
                   />
                 </Field>
-                <Field label="Delivery pace">
-                  <select
-                    value={data.session.pace}
-                    onChange={(event) =>
-                      updateSession({
-                        pace: event.target.value as LiveSessionRecord["pace"],
-                      })
-                    }
-                    className={inputClass}
-                  >
-                    <option value="facilitator">
-                      Facilitator controls each step
-                    </option>
-                    <option value="learner">
-                      Learners move at their own pace
-                    </option>
-                  </select>
-                </Field>
+                {data.session.parts.length ? (
+                  <Field label="Programme delivery">
+                    <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm text-slate-500">
+                      Pace is set for each programme session above.
+                    </div>
+                  </Field>
+                ) : (
+                  <Field label="Delivery pace">
+                    <select
+                      value={data.session.pace}
+                      onChange={(event) =>
+                        updateSession({
+                          pace: event.target.value as LiveSessionRecord["pace"],
+                        })
+                      }
+                      className={inputClass}
+                    >
+                      <option value="facilitator">
+                        Facilitator controls each step
+                      </option>
+                      <option value="learner">
+                        Learners move at their own pace
+                      </option>
+                    </select>
+                  </Field>
+                )}
                 <Field label="Who can join">
                   <select
                     value={data.session.access}
@@ -982,7 +1019,14 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
                   <button
                     key={activity.id}
                     onClick={() => command("activate", activity.id)}
-                    disabled={data.session.status === "ended"}
+                    disabled={
+                      data.session.status === "ended" ||
+                      Boolean(
+                        data.session.parts.find((part) =>
+                          part.activityIds.includes(activity.id),
+                        )?.status === "closed",
+                      )
+                    }
                     className={cn(
                       "flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left",
                       activity.id === current?.id
@@ -1100,7 +1144,9 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
                 <ShareRow
                   label="Pace"
                   value={
-                    data.session.pace === "facilitator"
+                    data.session.parts.length
+                      ? "Set per programme session"
+                      : data.session.pace === "facilitator"
                       ? "You control it"
                       : "Learners control it"
                   }
@@ -1127,6 +1173,116 @@ export function LiveFacilitatorStudio({ sessionId }: { sessionId: string }) {
         </div>
       ) : null}
     </div>
+  );
+}
+
+function ProgrammeSessionControls({
+  parts,
+  running,
+  onOpen,
+  onPaceChange,
+}: {
+  parts: LiveSessionPart[];
+  running: boolean;
+  onOpen: (partId: string) => void;
+  onPaceChange: (partId: string, pace: LiveSessionPart["pace"]) => void;
+}) {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-4 sm:p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-bold text-slate-950">
+            Programme sessions
+          </h3>
+          <p className="mt-1 text-xs leading-5 text-slate-500">
+            Keep one learner link. Choose which session is open and how learners
+            move through it.
+          </p>
+        </div>
+        <BookOpen className="h-4 w-4 shrink-0 text-slate-300" />
+      </div>
+      <div className="mt-4 grid gap-3 lg:grid-cols-2">
+        {parts.map((part, index) => {
+          const open = part.status === "open";
+          return (
+            <article
+              key={part.id}
+              className={cn(
+                "rounded-xl border p-4",
+                open
+                  ? "border-emerald-200 bg-emerald-50/40"
+                  : "border-slate-200 bg-slate-50/50",
+              )}
+            >
+              <div className="flex items-start gap-3">
+                <span
+                  className={cn(
+                    "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-xs font-bold",
+                    open
+                      ? "bg-emerald-600 text-white"
+                      : "bg-white text-slate-500 shadow-sm",
+                  )}
+                >
+                  {index + 1}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h4 className="truncate text-sm font-bold text-slate-950">
+                      {part.title}
+                    </h4>
+                    <span
+                      className={cn(
+                        "rounded-full px-2 py-0.5 text-[9px] font-bold uppercase tracking-wide",
+                        open
+                          ? "bg-emerald-100 text-emerald-700"
+                          : "bg-slate-200 text-slate-500",
+                      )}
+                    >
+                      {open ? "Open" : "Closed"}
+                    </span>
+                  </div>
+                  {part.description ? (
+                    <p className="mt-1 line-clamp-2 text-xs leading-5 text-slate-500">
+                      {part.description}
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+              <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+                <select
+                  value={part.pace}
+                  disabled={running}
+                  onChange={(event) =>
+                    onPaceChange(
+                      part.id,
+                      event.target.value as LiveSessionPart["pace"],
+                    )
+                  }
+                  className="min-w-0 flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-bold text-slate-700"
+                  aria-label={`${part.title} delivery pace`}
+                >
+                  <option value="learner">Learner self-guided</option>
+                  <option value="facilitator">Educator guided</option>
+                </select>
+                <button
+                  type="button"
+                  disabled={running || open}
+                  onClick={() => onOpen(part.id)}
+                  className={cn(
+                    "rounded-lg px-3 py-2 text-xs font-bold",
+                    open
+                      ? "cursor-default bg-emerald-100 text-emerald-700"
+                      : "bg-slate-950 text-white disabled:opacity-50",
+                  )}
+                >
+                  {open ? "Open to learners" : "Open this session"}
+                </button>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
   );
 }
 

--- a/apps/commons-courses/components/live/live-learner-room.tsx
+++ b/apps/commons-courses/components/live/live-learner-room.tsx
@@ -51,6 +51,7 @@ import {
   learnerAvailableActivities,
   resolveLearnerActivitySelection,
 } from "@/lib/live-learner-selection";
+import { effectiveActivityPace } from "@/lib/live-session-parts";
 import type {
   LearnerLiveSession,
   LiveActivity,
@@ -93,12 +94,20 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
 
   const applySelection = useCallback((next: LearnerLiveSession) => {
     const lastPresentedActivityId = presentedActivityRef.current;
+    const activePart =
+      next.parts.find((part) => part.id === next.currentPartId) ||
+      next.parts.find((part) => part.status === "open");
+    const activities = activePart
+      ? next.activities.filter((activity) =>
+          activePart.activityIds.includes(activity.id),
+        )
+      : next.activities;
     setSelectedId((selectedActivityId) =>
       resolveLearnerActivitySelection({
-        activities: next.activities,
+        activities,
         currentActivityId: next.currentActivityId,
         lastPresentedActivityId,
-        pace: next.pace,
+        pace: activePart?.pace || next.pace,
         responses: next.responses,
         selectedActivityId,
       }),
@@ -200,6 +209,8 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
         status: state.status,
         pace: state.pace,
         currentActivityId: state.currentActivityId,
+        currentPartId: state.currentPartId,
+        parts: state.parts,
         settings: {
           ...current.settings,
           learnerCopilot: state.learnerCopilot,
@@ -281,19 +292,36 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
   }, [workbookOpen]);
 
   const activity = session?.activities.find((item) => item.id === selectedId);
-  const activityIndex =
-    session?.activities.findIndex((item) => item.id === selectedId) ?? -1;
+  const { activePart, activeActivities } = useMemo(() => {
+    const part = session
+      ? session.parts.find((item) => item.id === session.currentPartId) ||
+        session.parts.find((item) => item.status === "open")
+      : undefined;
+    return {
+      activePart: part,
+      activeActivities: session
+        ? part
+          ? session.activities.filter((item) =>
+              part.activityIds.includes(item.id),
+            )
+          : session.activities
+        : [],
+    };
+  }, [session]);
+  const activityIndex = activeActivities.findIndex(
+    (item) => item.id === selectedId,
+  );
   const response = activity ? session?.responses[activity.id] : undefined;
   const availableActivities = useMemo(
     () =>
       session
         ? learnerAvailableActivities(
-            session.activities,
+            activeActivities,
             session.currentActivityId,
             session.responses,
           )
         : [],
-    [session],
+    [activeActivities, session],
   );
   const activityPosition = activityIndex >= 0 ? activityIndex + 1 : null;
   const availableActivityIndex = availableActivities.findIndex(
@@ -333,7 +361,12 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
         "finalized" in value
           ? Boolean(value.finalized)
           : true;
-      if (session?.pace === "learner" && finalized) goNext();
+      if (
+        session &&
+        effectiveActivityPace(session, activity.id) === "learner" &&
+        finalized
+      )
+        goNext();
     } else setNotice(data.error || "Could not save your response.");
     setSubmitting(false);
   }
@@ -475,18 +508,21 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
             <BookOpen className="h-4 w-4" />
             <span className="hidden sm:inline">Activities</span>
             <span className="rounded bg-[var(--course-background)] px-1.5 py-0.5 text-[10px]">
-              {activityPosition || "–"}/{session.activities.length}
+              {activityPosition || "–"}/{activeActivities.length}
             </span>
             <ChevronDown className="hidden h-3.5 w-3.5 opacity-50 sm:block" />
           </button>
         </div>
       </header>
       <div className="mx-auto w-full max-w-[1600px] px-3 py-4 sm:px-6 sm:py-6 lg:px-10 lg:py-8">
+        {session.parts.length ? (
+          <ProgrammePartStrip session={session} activePartId={activePart?.id} />
+        ) : null}
         <section className="min-w-0">
           <div className="mb-3 flex items-center justify-between text-xs opacity-50 sm:mb-4">
             <span>
               {activityPosition
-                ? `Activity ${activityPosition} of ${session.activities.length}`
+                ? `Activity ${activityPosition} of ${activeActivities.length}`
                 : "Waiting for the current activity"}
             </span>
             {activity?.estimatedMinutes ? (
@@ -605,6 +641,66 @@ export function LiveLearnerRoom({ sessionId }: { sessionId: string }) {
   );
 }
 
+function ProgrammePartStrip({
+  session,
+  activePartId,
+}: {
+  session: LearnerLiveSession;
+  activePartId?: string;
+}) {
+  return (
+    <section className="mb-5" aria-label="Programme sessions">
+      <p className="mb-2 text-[10px] font-bold uppercase tracking-[0.18em] opacity-45">
+        Programme sessions
+      </p>
+      <div className="grid gap-2 sm:grid-cols-2 lg:flex">
+        {session.parts.map((part, index) => {
+          const active = part.id === activePartId && part.status === "open";
+          return (
+            <div
+              key={part.id}
+              className={cn(
+                "flex min-w-0 items-center gap-3 rounded-xl border px-3.5 py-3 lg:min-w-64",
+                active
+                  ? "border-[var(--course-primary)] bg-[var(--course-surface)] shadow-sm"
+                  : "border-slate-200 bg-[var(--course-surface)]/60 opacity-70",
+              )}
+            >
+              <span
+                className={cn(
+                  "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-xs font-bold",
+                  active
+                    ? "bg-[var(--course-primary)] text-[var(--course-on-primary)]"
+                    : "bg-slate-100 text-slate-500",
+                )}
+              >
+                {index + 1}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-bold">
+                  {part.title}
+                </span>
+                <span className="mt-0.5 block text-[10px] font-medium opacity-55">
+                  {part.status === "closed"
+                    ? "Not open yet"
+                    : part.pace === "learner"
+                      ? "Move at your own pace"
+                      : "Facilitator guided"}
+                </span>
+              </span>
+              {part.status === "closed" ? (
+                <LockKeyhole className="h-3.5 w-3.5 shrink-0 opacity-50" />
+              ) : (
+                <span className="h-2 w-2 shrink-0 rounded-full bg-emerald-500" />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
 function EnrollmentRequired({
   gate,
   notice,
@@ -719,7 +815,8 @@ function WorkbookDrawer({
               Activities
             </h2>
             <p className="mt-1 text-xs opacity-55">
-              {session.pace === "facilitator"
+              {(session.parts.find((part) => part.status === "open")?.pace ||
+                session.pace) === "facilitator"
                 ? "Your facilitator controls what appears next."
                 : "Move through the available workbook activities."}
             </p>
@@ -734,57 +831,111 @@ function WorkbookDrawer({
           </button>
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3 sm:p-4">
-          <div className="space-y-1.5">
-            {session.activities.map((item, index) => {
-              const locked = item.status === "draft";
-              const selected = item.id === selectedId;
-              const done = Boolean(session.responses[item.id]);
-              const canSelect =
-                selected ||
-                (session.pace === "learner" &&
-                  !locked &&
-                  (item.status === "open" || done));
-              return (
-                <button
-                  key={item.id}
-                  type="button"
-                  disabled={!canSelect}
-                  onClick={() => onSelect(item.id)}
-                  className={cn(
-                    "flex w-full items-center gap-3 rounded-xl border px-3 py-3 text-left transition",
-                    selected
-                      ? "border-transparent bg-[var(--course-primary)] text-[var(--course-on-primary)]"
-                      : "border-transparent hover:border-slate-200 hover:bg-[var(--course-background)]",
-                    !canSelect && !selected && "cursor-default opacity-45",
-                  )}
-                >
-                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-current/10 text-[10px] font-bold">
-                    {String(index + 1).padStart(2, "0")}
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="block text-sm font-bold leading-5">
-                      {item.title || `Activity ${index + 1}`}
+          <div className="space-y-4">
+            {(session.parts.length
+              ? session.parts
+              : [
+                  {
+                    id: "all-activities",
+                    title: "Activities",
+                    status: "open" as const,
+                    pace: session.pace,
+                    activityIds: session.activities.map((item) => item.id),
+                  },
+                ]
+            ).map((part) => (
+              <section key={part.id}>
+                {session.parts.length ? (
+                  <div className="mb-2 flex items-center gap-2 px-2">
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-xs font-bold">
+                        {part.title}
+                      </span>
+                      <span className="text-[10px] opacity-50">
+                        {part.status === "closed"
+                          ? "Not open yet"
+                          : part.pace === "learner"
+                            ? "Self-guided"
+                            : "Facilitator guided"}
+                      </span>
                     </span>
-                    <span className="mt-0.5 block text-[10px] font-bold uppercase tracking-wide opacity-50">
-                      {selected
-                        ? "Showing now"
-                        : done
-                          ? "Completed"
-                          : locked
-                            ? "Upcoming"
-                            : item.status === "closed"
-                              ? "Closed"
-                              : labelFor(item.type)}
-                    </span>
-                  </span>
-                  {locked ? (
-                    <LockKeyhole className="h-3.5 w-3.5 shrink-0" />
-                  ) : done ? (
-                    <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-500" />
-                  ) : null}
-                </button>
-              );
-            })}
+                    {part.status === "closed" ? (
+                      <LockKeyhole className="h-3.5 w-3.5 opacity-40" />
+                    ) : (
+                      <span className="h-2 w-2 rounded-full bg-emerald-500" />
+                    )}
+                  </div>
+                ) : null}
+                {part.status === "open" ? (
+                  <div className="space-y-1.5">
+                    {part.activityIds.flatMap((activityId) => {
+                      const item = session.activities.find(
+                        (activity) => activity.id === activityId,
+                      );
+                      if (!item) return [];
+                      const index = session.activities.findIndex(
+                        (activity) => activity.id === item.id,
+                      );
+                      const locked = item.status === "draft";
+                      const selected = item.id === selectedId;
+                      const done = Boolean(session.responses[item.id]);
+                      const canSelect =
+                        selected ||
+                        (part.pace === "learner" &&
+                          !locked &&
+                          (item.status === "open" || done));
+                      return [
+                        <button
+                          key={item.id}
+                          type="button"
+                          disabled={!canSelect}
+                          onClick={() => onSelect(item.id)}
+                          className={cn(
+                            "flex w-full items-center gap-3 rounded-xl border px-3 py-3 text-left transition",
+                            selected
+                              ? "border-transparent bg-[var(--course-primary)] text-[var(--course-on-primary)]"
+                              : "border-transparent hover:border-slate-200 hover:bg-[var(--course-background)]",
+                            !canSelect &&
+                              !selected &&
+                              "cursor-default opacity-45",
+                          )}
+                        >
+                          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-current/10 text-[10px] font-bold">
+                            {String(index + 1).padStart(2, "0")}
+                          </span>
+                          <span className="min-w-0 flex-1">
+                            <span className="block text-sm font-bold leading-5">
+                              {item.title || `Activity ${index + 1}`}
+                            </span>
+                            <span className="mt-0.5 block text-[10px] font-bold uppercase tracking-wide opacity-50">
+                              {selected
+                                ? "Showing now"
+                                : done
+                                  ? "Completed"
+                                  : locked
+                                    ? "Upcoming"
+                                    : item.status === "closed"
+                                      ? "Closed"
+                                      : labelFor(item.type)}
+                            </span>
+                          </span>
+                          {locked ? (
+                            <LockKeyhole className="h-3.5 w-3.5 shrink-0" />
+                          ) : done ? (
+                            <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-500" />
+                          ) : null}
+                        </button>,
+                      ];
+                    })}
+                  </div>
+                ) : (
+                  <div className="rounded-xl border border-dashed border-slate-200 px-4 py-4 text-xs leading-5 opacity-55">
+                    This session is visible in your programme and will unlock
+                    when your educator opens it.
+                  </div>
+                )}
+              </section>
+            ))}
           </div>
         </div>
       </section>

--- a/apps/commons-courses/lib/live-session-data.ts
+++ b/apps/commons-courses/lib/live-session-data.ts
@@ -148,8 +148,10 @@ function serializeBase(
     invitedEmails: session.invitedEmails || [],
     scheduledStart: session.scheduledStart?.toISOString(),
     currentActivityId,
+    currentPartId: session.currentPartId,
     stateVersion: session.stateVersion || 0,
     activities: session.activities || [],
+    parts: session.parts || [],
     settings: {
       allowLateJoin: session.settings?.allowLateJoin !== false,
       showParticipantNames: Boolean(session.settings?.showParticipantNames),

--- a/apps/commons-courses/lib/live-session-input.ts
+++ b/apps/commons-courses/lib/live-session-input.ts
@@ -7,6 +7,7 @@ import type {
   LiveScoreCriterion,
   LiveSessionAccess,
   LiveSessionPace,
+  LiveSessionPart,
 } from "@/types/live-session";
 import {
   defaultLiveLearnerCopilotPolicy,
@@ -169,6 +170,49 @@ export function normalizeActivities(input: unknown): LiveActivity[] {
     .filter((activity): activity is LiveActivity => Boolean(activity));
 }
 
+export function normalizeSessionParts(
+  input: unknown,
+  activities: LiveActivity[],
+): LiveSessionPart[] {
+  if (!Array.isArray(input)) return [];
+  const validActivityIds = new Set(activities.map((activity) => activity.id));
+  const assignedActivityIds = new Set<string>();
+  const partIds = new Set<string>();
+  return input.slice(0, 24).flatMap((value, index) => {
+    if (!value || typeof value !== "object") return [];
+    const source = value as Partial<LiveSessionPart>;
+    const sourceId = clean(source.id) || `part-${index + 1}`;
+    const id = sourceId.replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 80);
+    const title = clean(source.title);
+    if (!id || !title || partIds.has(id)) return [];
+    partIds.add(id);
+    const activityIds = Array.isArray(source.activityIds)
+      ? source.activityIds.flatMap((activityId) => {
+          const normalized = clean(activityId);
+          if (
+            !normalized ||
+            !validActivityIds.has(normalized) ||
+            assignedActivityIds.has(normalized)
+          ) {
+            return [];
+          }
+          assignedActivityIds.add(normalized);
+          return [normalized];
+        })
+      : [];
+    return [
+      {
+        id,
+        title,
+        description: clean(source.description),
+        status: source.status === "open" ? "open" : "closed",
+        pace: source.pace === "learner" ? "learner" : "facilitator",
+        activityIds,
+      },
+    ];
+  });
+}
+
 export function normalizeSessionCreate(input: unknown) {
   const body =
     input && typeof input === "object"
@@ -199,7 +243,10 @@ export function normalizeSessionCreate(input: unknown) {
   };
 }
 
-export function normalizeSessionPatch(input: unknown) {
+export function normalizeSessionPatch(
+  input: unknown,
+  existingActivities: LiveActivity[] = [],
+) {
   const body =
     input && typeof input === "object"
       ? (input as Record<string, unknown>)
@@ -221,8 +268,15 @@ export function normalizeSessionPatch(input: unknown) {
     patch.invitedEmails = normalizeEmails(body.invitedEmails);
   if ("scheduledStart" in body)
     patch.scheduledStart = normalizeDate(body.scheduledStart);
-  if ("activities" in body)
-    patch.activities = normalizeActivities(body.activities);
+  const activities =
+    "activities" in body ? normalizeActivities(body.activities) : undefined;
+  if (activities) patch.activities = activities;
+  if ("parts" in body) {
+    patch.parts = normalizeSessionParts(
+      body.parts,
+      activities || existingActivities,
+    );
+  }
   if (body.settings && typeof body.settings === "object") {
     const settings = body.settings as Record<string, unknown>;
     patch.settings = {

--- a/apps/commons-courses/lib/live-session-parts.test.mts
+++ b/apps/commons-courses/lib/live-session-parts.test.mts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  activityStatusesForParts,
+  effectiveActivityPace,
+  isActivityPartOpen,
+} from "./live-session-parts.ts";
+import type { LiveActivity, LiveSessionPart } from "../types/live-session.ts";
+
+const activities = [
+  activity("discover-1"),
+  activity("capture-1"),
+  activity("capture-2"),
+];
+const parts: LiveSessionPart[] = [
+  {
+    id: "discover",
+    title: "Discover",
+    status: "open",
+    pace: "learner",
+    activityIds: ["discover-1"],
+  },
+  {
+    id: "capture",
+    title: "Capture",
+    status: "closed",
+    pace: "facilitator",
+    activityIds: ["capture-1", "capture-2"],
+  },
+];
+
+test("uses per-session pace and blocks activities in a closed programme session", () => {
+  const session = { pace: "facilitator" as const, parts };
+  assert.equal(effectiveActivityPace(session, "discover-1"), "learner");
+  assert.equal(effectiveActivityPace(session, "capture-1"), "facilitator");
+  assert.equal(isActivityPartOpen(session, "discover-1"), true);
+  assert.equal(isActivityPartOpen(session, "capture-1"), false);
+});
+
+test("opens every activity in a learner-guided part and hides a closed part", () => {
+  assert.deepEqual(
+    activityStatusesForParts({
+      activities,
+      parts,
+      currentActivityId: "discover-1",
+    }),
+    {
+      "discover-1": "open",
+      "capture-1": "draft",
+      "capture-2": "draft",
+    },
+  );
+});
+
+test("an educator-guided open part exposes only the presented activity", () => {
+  const educatorGuided = parts.map((part) => ({
+    ...part,
+    status: part.id === "capture" ? ("open" as const) : ("closed" as const),
+  }));
+  assert.deepEqual(
+    activityStatusesForParts({
+      activities,
+      parts: educatorGuided,
+      currentActivityId: "capture-2",
+    }),
+    {
+      "discover-1": "draft",
+      "capture-1": "closed",
+      "capture-2": "open",
+    },
+  );
+});
+
+function activity(id: string): LiveActivity {
+  return {
+    id,
+    type: "content",
+    title: id,
+    status: "draft",
+    required: false,
+    randomizeOptions: false,
+    showResults: false,
+    points: 0,
+    options: [],
+  };
+}

--- a/apps/commons-courses/lib/live-session-parts.ts
+++ b/apps/commons-courses/lib/live-session-parts.ts
@@ -1,0 +1,69 @@
+import type {
+  LiveActivity,
+  LiveActivityStatus,
+  LiveSessionPace,
+  LiveSessionPart,
+} from "@/types/live-session";
+
+type PartAwareSession = {
+  pace: LiveSessionPace;
+  parts?: LiveSessionPart[];
+};
+
+export function partForActivity(
+  session: PartAwareSession,
+  activityId?: string,
+) {
+  if (!activityId) return undefined;
+  return session.parts?.find((part) => part.activityIds.includes(activityId));
+}
+
+export function effectiveActivityPace(
+  session: PartAwareSession,
+  activityId?: string,
+) {
+  return partForActivity(session, activityId)?.pace || session.pace;
+}
+
+export function isActivityPartOpen(
+  session: PartAwareSession,
+  activityId?: string,
+) {
+  const part = partForActivity(session, activityId);
+  return !part || part.status === "open";
+}
+
+export function activityStatusesForParts({
+  activities,
+  parts,
+  currentActivityId,
+}: {
+  activities: LiveActivity[];
+  parts: LiveSessionPart[];
+  currentActivityId?: string;
+}) {
+  const statuses: Record<string, LiveActivityStatus> = {};
+  for (const activity of activities) {
+    const part = parts.find((candidate) =>
+      candidate.activityIds.includes(activity.id),
+    );
+    if (!part || part.status === "closed") {
+      statuses[activity.id] = "draft";
+    } else {
+      statuses[activity.id] =
+        part.pace === "learner" || activity.id === currentActivityId
+          ? "open"
+          : "closed";
+    }
+  }
+  return statuses;
+}
+
+export function firstActivityIdForPart(
+  activities: LiveActivity[],
+  part?: LiveSessionPart,
+) {
+  return part?.activityIds.find((id) =>
+    activities.some((activity) => activity.id === id),
+  );
+}

--- a/apps/commons-courses/models/LiveSession.ts
+++ b/apps/commons-courses/models/LiveSession.ts
@@ -3,6 +3,7 @@ import type {
   LiveActivity,
   LiveSessionAccess,
   LiveSessionPace,
+  LiveSessionPart,
   LiveSessionSettings,
   LiveSessionStatus,
 } from "@/types/live-session";
@@ -19,8 +20,10 @@ export interface ILiveSession extends Document {
   invitedEmails: string[];
   scheduledStart?: Date;
   currentActivityId?: string;
+  currentPartId?: string;
   stateVersion: number;
   activities: LiveActivity[];
+  parts: LiveSessionPart[];
   settings: LiveSessionSettings;
   createdBy: mongoose.Types.ObjectId;
   createdAt: Date;
@@ -151,6 +154,26 @@ const LiveSessionSettingsSchema = new Schema<LiveSessionSettings>(
   { _id: false },
 );
 
+const LiveSessionPartSchema = new Schema<LiveSessionPart>(
+  {
+    id: { type: String, required: true, trim: true },
+    title: { type: String, required: true, trim: true },
+    description: { type: String, trim: true },
+    status: {
+      type: String,
+      enum: ["open", "closed"],
+      default: "closed",
+    },
+    pace: {
+      type: String,
+      enum: ["facilitator", "learner"],
+      default: "facilitator",
+    },
+    activityIds: { type: [String], default: [] },
+  },
+  { _id: false },
+);
+
 const LiveSessionSchema = new Schema<ILiveSession>(
   {
     courseId: { type: Schema.Types.ObjectId, ref: "Course", required: true },
@@ -176,8 +199,10 @@ const LiveSessionSchema = new Schema<ILiveSession>(
     invitedEmails: { type: [String], default: [] },
     scheduledStart: Date,
     currentActivityId: String,
+    currentPartId: String,
     stateVersion: { type: Number, default: 0, min: 0 },
     activities: { type: [LiveActivitySchema], default: [] },
+    parts: { type: [LiveSessionPartSchema], default: [] },
     settings: { type: LiveSessionSettingsSchema, default: () => ({}) },
     createdBy: { type: Schema.Types.ObjectId, ref: "User", required: true },
   },

--- a/apps/commons-courses/scripts/seed-ai-quick-wins-workshop.mjs
+++ b/apps/commons-courses/scripts/seed-ai-quick-wins-workshop.mjs
@@ -17,20 +17,170 @@ const slug = "ai-quick-wins-for-leaders";
 const ownerEmail = "bashybaranaba@gmail.com";
 const dryRun = process.argv.includes("--dry-run");
 const force = process.argv.includes("--force");
+const captureMode = process.argv.includes("--capture");
 const previewDir = argument("preview-dir");
 let cachedPdfTools;
-const inputs = {
-  deck: requiredArgument("deck"),
-  workbook: requiredArgument("workbook"),
-  cards: argument("cards"),
-  guide: argument("guide"),
-};
+const inputs = captureMode
+  ? {
+      deck: requiredArgument("deck"),
+      workbook: requiredArgument("workbook"),
+      workbookDocx: requiredArgument("workbook-docx"),
+    }
+  : {
+      deck: requiredArgument("deck"),
+      workbook: requiredArgument("workbook"),
+      cards: argument("cards"),
+      guide: argument("guide"),
+    };
 
 if (!dryRun && !process.env.MONGODB_URI) {
   throw new Error("MONGODB_URI is required.");
 }
 
-await main();
+await (captureMode ? captureMain() : main());
+
+async function captureMain() {
+  const workDir = await mkdtemp(path.join(os.tmpdir(), "quick-wins-capture-"));
+  try {
+    const assets = await prepareCaptureAssets(inputs, workDir);
+    if (dryRun) {
+      console.log(
+        JSON.stringify({
+          dryRun,
+          mode: "capture",
+          files: Object.values(assets).map((asset) => ({
+            name: asset.name,
+            bytes: asset.bytes.length,
+            pages: asset.pages.length,
+          })),
+          activities: createCaptureActivities("preview-material").length,
+        }),
+      );
+      return;
+    }
+    await mongoose.connect(process.env.MONGODB_URI);
+    try {
+      const db = mongoose.connection.db;
+      if (!db) throw new Error("MongoDB connection is unavailable.");
+      const [owner, course] = await Promise.all([
+        db.collection("users").findOne({ email: ownerEmail }),
+        db.collection("courses").findOne({ slug }),
+      ]);
+      if (!owner) throw new Error(`Owner not found: ${ownerEmail}`);
+      if (!course) throw new Error(`Course not found: ${slug}`);
+      if (!owner.identityUserId) {
+        throw new Error(`${ownerEmail} is not connected to Commons Identity.`);
+      }
+      const session = await db.collection("livesessions").findOne({
+        courseId: course._id,
+      });
+      if (!session)
+        throw new Error("AI Quick Wins live programme was not found.");
+      const now = new Date();
+      const commonsFiles = await uploadToCommonsLibrary(
+        Object.values(assets),
+        owner.identityUserId,
+        owner.identityWorkspaceId,
+      );
+      const bucket = new mongo.GridFSBucket(db, {
+        bucketName: "courseMaterials",
+      });
+      const materialByKey = {};
+      for (const asset of Object.values(assets)) {
+        materialByKey[asset.key] = await syncMaterial({
+          db,
+          bucket,
+          course,
+          owner,
+          principalId: owner.identityUserId,
+          asset,
+          commonsFile: commonsFiles.get(asset.key),
+          now,
+        });
+      }
+      const discoverActivities = (session.activities || []).filter(
+        (activity) => !activity.id.startsWith("capture-"),
+      );
+      const captureActivities = createCaptureActivities(
+        String(materialByKey.captureDeck._id),
+      );
+      const activities = [...discoverActivities, ...captureActivities];
+      const discoverPart = {
+        id: "discover",
+        title: "Day 1 · Discover",
+        description:
+          "Map recurring work, unpack task anatomy, and choose the first useful task to offload.",
+        status: "open",
+        pace: "learner",
+        activityIds: discoverActivities.map((activity) => activity.id),
+      };
+      const capturePart = {
+        id: "capture",
+        title: "Day 2 · Capture",
+        description:
+          "Turn the chosen task into a reusable procedure, run it, automate it, and evaluate what breaks.",
+        status: "closed",
+        pace: "facilitator",
+        activityIds: captureActivities.map((activity) => activity.id),
+      };
+      await Promise.all([
+        db.collection("livesessions").updateOne(
+          { _id: session._id },
+          {
+            $set: {
+              title: "AI Quick Wins for Leaders · Live programme",
+              description:
+                "One live programme for Discover, Capture, Expand, and Secure. Educators open each session when the group is ready.",
+              pace: "learner",
+              currentPartId: "discover",
+              activities: activities.map((activity) => ({
+                ...activity,
+                status: activity.id.startsWith("capture-") ? "draft" : "open",
+              })),
+              parts: [discoverPart, capturePart],
+              updatedAt: now,
+            },
+            $inc: { stateVersion: 1 },
+          },
+        ),
+        db.collection("courses").updateOne(
+          { _id: course._id },
+          {
+            $set: {
+              "modules.1.lessons.0.description":
+                "Build a reusable procedure, add a trigger, test it twice, classify failures, and prepare a live demonstration.",
+              updatedAt: now,
+            },
+          },
+        ),
+      ]);
+      console.log(
+        JSON.stringify(
+          {
+            courseId: String(course._id),
+            liveSessionId: String(session._id),
+            joinCode: session.joinCode,
+            discoverActivities: discoverActivities.length,
+            captureActivities: captureActivities.length,
+            parts: [discoverPart, capturePart],
+            materials: Object.fromEntries(
+              Object.entries(materialByKey).map(([key, value]) => [
+                key,
+                { id: String(value._id), name: value.name },
+              ]),
+            ),
+          },
+          null,
+          2,
+        ),
+      );
+    } finally {
+      await mongoose.disconnect();
+    }
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+}
 
 async function main() {
   const workDir = await mkdtemp(path.join(os.tmpdir(), "quick-wins-workshop-"));
@@ -697,6 +847,531 @@ function createDiscoverActivities(materialId) {
       2,
     ),
   ];
+}
+
+function createCaptureActivities(materialId) {
+  const field = (id, label, type = "long_text", extra = {}) => ({
+    id,
+    label,
+    type,
+    required: false,
+    ...extra,
+  });
+  const base = (id, title, prompt, slide, minutes, extra = {}) => ({
+    id,
+    type: "content",
+    title,
+    prompt,
+    materialId,
+    materialStartSlide: slide,
+    estimatedMinutes: minutes,
+    status: "draft",
+    required: false,
+    randomizeOptions: false,
+    showResults: false,
+    points: 0,
+    options: [],
+    ...extra,
+  });
+  const worksheet = (
+    id,
+    title,
+    prompt,
+    slide,
+    minutes,
+    worksheetFields,
+    extra = {},
+  ) => ({
+    ...base(id, title, prompt, slide, minutes),
+    type: "worksheet",
+    required: true,
+    worksheetFields,
+    ...extra,
+  });
+  const scale = (id, label) =>
+    field(id, label, "scale", {
+      required: true,
+      min: 0,
+      max: 1,
+      lowLabel: "Not yet",
+      highLabel: "Yes",
+    });
+
+  return [
+    base(
+      "capture-recap",
+      "Where we left off",
+      "Reconnect with the task you selected in Discover and see how its anatomy card becomes an automated task.",
+      1,
+      8,
+      {
+        facilitatorNotes:
+          "Ask learners to keep their Discover task cards available. Tonight they build, test, and demonstrate one real task.",
+      },
+    ),
+    base(
+      "capture-standard",
+      "What good looks like",
+      "Understand the three moves—capture, run, automate—and the seven-test standard for tonight’s build.",
+      8,
+      12,
+    ),
+    worksheet(
+      "capture-extraction",
+      "Extraction prompt and tacit-knowledge questions",
+      "Use your recording transcript to create a draft procedure, then capture the questions that expose what was left unsaid.",
+      12,
+      10,
+      [
+        field(
+          "task-from-discover",
+          "The task I selected in Discover",
+          "short_text",
+          { required: true, section: "Starting point" },
+        ),
+        field(
+          "question-1",
+          "Question 1 the assistant asked that I could not answer immediately",
+          "long_text",
+          { required: true, section: "Tacit knowledge" },
+        ),
+        field("question-2", "Question 2 the assistant asked", "long_text", {
+          section: "Tacit knowledge",
+        }),
+        field("question-3", "Question 3 the assistant asked", "long_text", {
+          section: "Tacit knowledge",
+        }),
+        field(
+          "corrections",
+          "What did the assistant infer incorrectly, and how did you correct it?",
+          "long_text",
+          { section: "Tacit knowledge" },
+        ),
+      ],
+      {
+        sourceActivityId: "discover-final-choice",
+        instructions:
+          "Paste your anatomy card and transcript into your assistant with the extraction prompt shown in the deck. Answer every question in full sentences. If the answer is ‘it depends’, finish the sentence with exactly what it depends on.",
+        successCriteria:
+          "You have a draft procedure plus an explicit record of uncertain assumptions and corrections.",
+      },
+    ),
+    worksheet(
+      "capture-canvas",
+      "The automated-task canvas",
+      "Turn the selected routine into instructions that a colleague—or an automated task—could actually run.",
+      13,
+      20,
+      [
+        field("name", "1. Name it—short and about the task", "short_text", {
+          required: true,
+          section: "Definition",
+        }),
+        field(
+          "preconditions",
+          "2. What must be true before it can start?",
+          "long_text",
+          {
+            required: true,
+            section: "Definition",
+          },
+        ),
+        field(
+          "inputs",
+          "3. Inputs, and where they actually live",
+          "long_text",
+          {
+            required: true,
+            section: "Procedure",
+          },
+        ),
+        field("steps", "4. Steps, in order", "long_text", {
+          required: true,
+          section: "Procedure",
+        }),
+        field("not-use", "5. When should it not be used?", "long_text", {
+          required: true,
+          section: "Boundaries",
+        }),
+        field("never", "6. What must it never do?", "long_text", {
+          required: true,
+          section: "Boundaries",
+        }),
+        field(
+          "decisions",
+          "7. Decision points, and what you weigh at each",
+          "long_text",
+          {
+            required: true,
+            section: "Judgment",
+          },
+        ),
+        field(
+          "exceptions",
+          "8. Exceptions, and what triggers them",
+          "long_text",
+          {
+            required: true,
+            section: "Judgment",
+          },
+        ),
+        field(
+          "quality",
+          "9. Quality bar—what done well looks like",
+          "long_text",
+          {
+            required: true,
+            section: "Quality and control",
+          },
+        ),
+        field(
+          "escalation",
+          "10. What stops and waits for a person—and whom?",
+          "long_text",
+          {
+            required: true,
+            section: "Quality and control",
+          },
+        ),
+        field(
+          "example",
+          "11. One worked example, start to finish",
+          "long_text",
+          {
+            required: true,
+            section: "Example and trigger",
+          },
+        ),
+        field(
+          "description",
+          "12. Description—when should this run?",
+          "long_text",
+          {
+            required: true,
+            section: "Example and trigger",
+            description:
+              "Write this last, after the rest of the procedure is honest.",
+          },
+        ),
+      ],
+      {
+        sourceActivityId: "discover-final-choice",
+        instructions:
+          "Copy the six fields already captured in your Discover anatomy card, then spend your time on the never list, quality bar, escalation, and precise trigger.",
+        successCriteria:
+          "All twelve fields are concrete enough for another person to follow without guessing.",
+      },
+    ),
+    worksheet(
+      "capture-run-and-trigger",
+      "Run it, then put a trigger on it",
+      "Watch the procedure work once on live input before you automate it, then choose where it starts, lands, and stops.",
+      15,
+      20,
+      [
+        field(
+          "live-input",
+          "What fresh, live input did you test it on?",
+          "long_text",
+          {
+            required: true,
+            section: "Run it by hand",
+          },
+        ),
+        field(
+          "observed-output",
+          "What did you observe in the full output?",
+          "long_text",
+          {
+            required: true,
+            section: "Run it by hand",
+          },
+        ),
+        field(
+          "trigger",
+          "The time or event that will trigger it",
+          "long_text",
+          {
+            required: true,
+            section: "Automate it",
+          },
+        ),
+        field(
+          "destination",
+          "Where will the output land—somewhere you already look?",
+          "long_text",
+          {
+            required: true,
+            section: "Automate it",
+          },
+        ),
+        field(
+          "stop",
+          "How do you stop it, and how many seconds does that take?",
+          "long_text",
+          {
+            required: true,
+            section: "Automate it",
+          },
+        ),
+      ],
+      {
+        instructions:
+          "Never automate something you have not watched work once. If you only reach the manual run tonight, record that honestly.",
+      },
+    ),
+    worksheet(
+      "capture-library",
+      "Where this procedure lives",
+      "Make the build organisational knowledge rather than a personal trick on one laptop.",
+      16,
+      5,
+      [
+        field(
+          "location",
+          "Shared folder, workspace, or repository",
+          "long_text",
+          {
+            required: true,
+          },
+        ),
+        field("owner", "Named owner", "short_text", { required: true }),
+        field("author", "Who wrote it?", "short_text"),
+        field("purpose", "What does it do?", "long_text"),
+      ],
+      {
+        successCriteria:
+          "The location is shared and an accountable owner is named.",
+      },
+    ),
+    worksheet(
+      "capture-evaluation",
+      "Score the task and classify what broke",
+      "Run the task twice on live work, score it honestly, then change one thing only before the second run.",
+      17,
+      18,
+      [
+        scale("starts", "It starts itself"),
+        scale("judgment", "It uses my judgment"),
+        scale("consistent", "The output is consistent"),
+        scale("catch-bad", "I would catch a bad output within a day"),
+        scale("lands", "It lands somewhere I already look"),
+        scale("colleague", "Someone else could run it"),
+        scale("stop", "I can stop it in seconds"),
+        field("missed", "Which tests did you miss?", "long_text", {
+          required: true,
+          section: "Failure",
+        }),
+        field(
+          "failure-class",
+          "Failure class: context, constraint, verification, or planning",
+          "short_text",
+          { required: true, section: "Failure" },
+        ),
+        field("run-one", "What failed on run 1?", "long_text", {
+          required: true,
+          section: "Two runs, one change",
+        }),
+        field("change", "The one change you made", "long_text", {
+          required: true,
+          section: "Two runs, one change",
+        }),
+        field("run-two", "Was run 2 better? What changed?", "long_text", {
+          required: true,
+          section: "Two runs, one change",
+        }),
+      ],
+      {
+        instructions:
+          "Five out of seven is a good first build. Context and constraint failures can usually be fixed in the procedure tonight; verification and planning failures become inputs to later sessions.",
+      },
+    ),
+    {
+      ...base(
+        "capture-run-log",
+        "Run log",
+        "Log both runs tonight, then add one card for every daily run or human intervention before Session 3.",
+        18,
+        8,
+      ),
+      type: "card_collection",
+      required: true,
+      minItems: 2,
+      itemTitleFieldId: "date",
+      entryLabel: "Add a run",
+      worksheetFields: [
+        field("date", "Date or run label", "short_text", { required: true }),
+        field(
+          "failure-class",
+          "Class: context, constraint, verification, or planning",
+          "short_text",
+        ),
+        field(
+          "failure",
+          "What failed, or where did you step in?",
+          "long_text",
+          {
+            required: true,
+          },
+        ),
+        field("change", "What did you change?", "long_text"),
+      ],
+      instructions:
+        "The interventions are data, not embarrassment. Add another run whenever the task needs a human to step in.",
+    },
+    worksheet(
+      "capture-demo",
+      "Your three-minute demo card",
+      "Prepare the plain-language story, the actual output, and the honest failure you will show the room.",
+      20,
+      10,
+      [
+        field(
+          "task-cost",
+          "The task, how often it happens, and what it used to cost",
+          "long_text",
+          {
+            required: true,
+          },
+        ),
+        field(
+          "evidence",
+          "What actual run or output will you show?",
+          "long_text",
+          {
+            required: true,
+          },
+        ),
+        field(
+          "failure-fix",
+          "What broke, its class, and whether run 2 improved",
+          "long_text",
+          {
+            required: true,
+          },
+        ),
+        field("question", "One thing you want to ask the room", "long_text"),
+      ],
+      {
+        successCriteria:
+          "The demo shows the output itself and names an honest failure—not just the model or tool used.",
+      },
+    ),
+    base(
+      "capture-what-breaks-next",
+      "What breaks next",
+      "Connect the limits you hit to loops, tools, context, and controls—the components Session 3 adds around your procedure.",
+      24,
+      12,
+    ),
+    worksheet(
+      "capture-assignment",
+      "Let it run, then bring back the wall you hit",
+      "Commit to daily runs and capture the access and information gaps that Session 3 needs to solve.",
+      28,
+      8,
+      [
+        field("start-date", "I will start the daily run on", "date", {
+          required: true,
+          section: "Commitment",
+        }),
+        field(
+          "cannot-reach",
+          "What could the task not do because it could not reach something?",
+          "long_text",
+          {
+            required: true,
+            section: "Questions for Session 3",
+          },
+        ),
+        field(
+          "information-lives",
+          "Where does the information it needs live right now?",
+          "long_text",
+          {
+            required: true,
+            section: "Questions for Session 3",
+          },
+        ),
+        field(
+          "second-task",
+          "Which second task card will you turn into a task?",
+          "short_text",
+          {
+            section: "Build",
+          },
+        ),
+        field(
+          "wall",
+          "The one thing I could not get working tonight",
+          "long_text",
+          {
+            required: true,
+            section: "Bring this back",
+          },
+        ),
+      ],
+      {
+        instructions:
+          "Keep adding to the run log until Session 3. If the information lives in someone’s head, write that down—it is a useful answer.",
+      },
+    ),
+    base(
+      "capture-close",
+      "Commitment and close",
+      "Name the score, the shared location and owner, and the daily-run commitment before leaving the room.",
+      29,
+      2,
+    ),
+  ];
+}
+
+async function prepareCaptureAssets(source, workDir) {
+  const deckBytes = await readFile(source.deck);
+  const deckPdf = await convertToPdf(source.deck, workDir, "capture-deck");
+  const workbookPdf = await readFile(source.workbook);
+  const workbookDocx = await readFile(source.workbookDocx);
+  return {
+    captureDeck: {
+      key: "captureDeck",
+      name: path.basename(source.deck),
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      kind: "presentation",
+      visibility: "course",
+      bytes: deckBytes,
+      pages: await renderPdfPages(deckPdf),
+      textPreview: await extractPresentationText(deckBytes),
+      aliases: ["AI Quick Wins Session 2.pptx"],
+    },
+    captureWorkbookPdf: {
+      key: "captureWorkbookPdf",
+      name: "Session 2 Participant Workbook.pdf",
+      mimeType: "application/pdf",
+      kind: "pdf",
+      visibility: "course",
+      bytes: workbookPdf,
+      pages: [],
+      textPreview: await extractPdfText(workbookPdf),
+    },
+    captureWorkbookDocx: {
+      key: "captureWorkbookDocx",
+      name: "Session 2 Participant Workbook.docx",
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      kind: "document",
+      visibility: "course",
+      bytes: workbookDocx,
+      pages: [],
+      textPreview: await extractPdfText(
+        await convertToPdf(
+          source.workbookDocx,
+          workDir,
+          "capture-workbook-docx",
+        ),
+      ),
+    },
+  };
 }
 
 async function prepareAssets(source, workDir) {

--- a/apps/commons-courses/types/live-session.ts
+++ b/apps/commons-courses/types/live-session.ts
@@ -2,6 +2,17 @@ export type LiveSessionStatus = "draft" | "lobby" | "live" | "ended";
 
 export type LiveSessionPace = "facilitator" | "learner";
 
+export type LiveSessionPartStatus = "open" | "closed";
+
+export type LiveSessionPart = {
+  id: string;
+  title: string;
+  description?: string;
+  status: LiveSessionPartStatus;
+  pace: LiveSessionPace;
+  activityIds: string[];
+};
+
 export type LiveSessionAccess = "enrolled" | "invited" | "open";
 
 export type LiveActivityType =
@@ -168,8 +179,10 @@ export type LiveSessionRecord = {
   invitedEmails: string[];
   scheduledStart?: string;
   currentActivityId?: string;
+  currentPartId?: string;
   stateVersion: number;
   activities: LiveActivity[];
+  parts: LiveSessionPart[];
   settings: LiveSessionSettings;
   participantCount: number;
   responseCounts: Record<string, number>;
@@ -181,7 +194,9 @@ export type LiveSessionState = {
   status: LiveSessionStatus;
   pace: LiveSessionPace;
   currentActivityId?: string;
+  currentPartId?: string;
   currentActivity?: LiveActivity;
+  parts: LiveSessionPart[];
   learnerCopilot: LiveLearnerCopilotPolicy;
   stateVersion: number;
   activityStatuses: Record<string, LiveActivityStatus>;


### PR DESCRIPTION
## Summary
- add programme parts with independent open/closed state and learner- or educator-guided pacing
- add educator controls and learner session navigation on the existing live link
- add the 12-activity AI Quick Wins Capture workbook plus production material migration
- enforce per-part response access and live-state synchronization

## Verification
- `pnpm test` (43 tests)
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm build` with production environment
- Capture seed dry run: 30 deck slides, 3 materials, 12 activities