### PR TITLE
Fix generated UI plugin embedding and add Customize hub

### DIFF
--- a/apps/commons-api-gateway/scripts/smoke.ts
+++ b/apps/commons-api-gateway/scripts/smoke.ts
@@ -43,6 +43,8 @@ const publicRoutes: Array<[string, RequestInit?]> = [
   ["/v1/oauth/providers/google"],
   ["/v1/oauth/callback/google"],
   ["/v1/billing/webhook", { method: "POST" }],
+  ["/v1/previews/example-project/"],
+  ["/v1/previews/example-project/assets/index.js"],
 ];
 
 for (const [path, init] of publicRoutes) {
@@ -59,6 +61,11 @@ const protectedRoutes = [
 
 for (const path of protectedRoutes) {
   await expectStatus(`protected GET ${path}`, app.request(path), 401);
+}
+
+const previewResponse = await app.request("/v1/previews/example-project/");
+if (previewResponse.headers.has("x-frame-options")) {
+  failures.push("public preview: gateway must not add x-frame-options");
 }
 
 if (failures.length > 0) {

--- a/apps/commons-api-gateway/src/index.ts
+++ b/apps/commons-api-gateway/src/index.ts
@@ -14,7 +14,15 @@ export function createGatewayApp() {
   const app = new Hono<{ Variables: Variables }>();
   const counters = new Map<string, { minute: number; count: number }>();
 
-  app.use("*", secureHeaders());
+  const securityHeaders = secureHeaders();
+  app.use("*", (c, next) => {
+    // Published code-project previews provide their own deliberately strict
+    // sandbox policy. The gateway default includes X-Frame-Options:
+    // SAMEORIGIN, which prevents these cross-origin previews from loading in
+    // the Commons plugin iframe.
+    if (isPreviewPath(c.req.path)) return next();
+    return securityHeaders(c, next);
+  });
   app.use(
     "*",
     cors({
@@ -135,6 +143,19 @@ export function createGatewayApp() {
   // stripe-signature header, verified downstream). Pass it through publicly,
   // preserving the raw body for signature verification.
   app.post("/v1/billing/webhook", (c) =>
+    publicProxy(
+      c,
+      "agent-commons",
+      process.env.AGENT_COMMONS_INTERNAL_URL,
+      c.req.path,
+    ),
+  );
+  // Published code projects are intentionally public, unguessable preview
+  // assets. The upstream only serves projects whose visibility is public and
+  // whose latest deployment is ready. They must bypass credential auth so an
+  // isolated iframe can load HTML and relative assets without receiving a
+  // Commons bearer token.
+  app.get("/v1/previews/*", (c) =>
     publicProxy(
       c,
       "agent-commons",
@@ -355,6 +376,10 @@ if (process.env.COMMONS_GATEWAY_NO_LISTEN !== "true") {
 }
 
 export default app;
+
+function isPreviewPath(path: string) {
+  return path === "/v1/previews" || path.startsWith("/v1/previews/");
+}
 
 function requiredScope(method: string, path: string) {
   if (path.includes("/activity")) return "activity:read";

--- a/apps/commons-api/platform-skills/build-commons-ui-plugin/SKILL.md
+++ b/apps/commons-api/platform-skills/build-commons-ui-plugin/SKILL.md
@@ -11,14 +11,20 @@ try to reach into its DOM.
 1. Clarify the smallest useful page, widget, or both from the user's request.
 2. Use `createCodeProject` and `writeCodeProjectFiles` to build an accessible,
    responsive React interface that follows the Commons visual language.
-3. Use `publishCodeProject`, then `testCodeProject`. Fix failures before moving
-   on.
-4. Call `registerUiPlugin` with the published project. Request only the minimum
+3. Use `publishCodeProject`, then `testCodeProject` with actions that exercise
+   every important control. Treat a successful build as untested: inspect all
+   console, page, network, action, responsive, and embedding failures.
+4. If any check fails, use `readCodeProject`, fix the project files, publish a
+   new deployment, and test it again. Repeat until `testCodeProject` returns
+   `passed: true`. Never register or describe a plugin as working before that.
+5. Call `registerUiPlugin` with the verified deployment. Registration is
+   rejected unless the latest deployment passed browser testing. Request only
+   the minimum
    permissions needed:
    - `theme.read` receives the current light/dark theme.
    - `navigation` may ask the host to navigate to a safe internal path.
-5. Tell the user the plugin is a draft and must be reviewed and enabled in
-   Studio Apps.
+6. Tell the user the plugin is a draft and must be reviewed and enabled in
+   Studio Customize → Apps.
 
 The plugin can post `{ type: "commons:ready" }` to its parent. The host replies
 with `{ type: "commons:context", theme, pluginId }`. With the `navigation`

--- a/apps/commons-api/src/code-project/code-project.verifier.spec.ts
+++ b/apps/commons-api/src/code-project/code-project.verifier.spec.ts
@@ -1,0 +1,31 @@
+import { getEmbeddingError } from './code-project.verifier';
+
+describe('code project embedding policy', () => {
+  it('accepts an explicit cross-origin frame policy', () => {
+    expect(
+      getEmbeddingError({
+        'content-security-policy':
+          "default-src 'self'; frame-ancestors https://agentcommons.io https://*.agentcommons.io",
+      }),
+    ).toBeNull();
+  });
+
+  it('rejects X-Frame-Options even when the page otherwise loads', () => {
+    expect(
+      getEmbeddingError({ 'x-frame-options': 'SAMEORIGIN' }),
+    ).toContain('X-Frame-Options is SAMEORIGIN');
+  });
+
+  it('rejects self-only and disabled CSP embedding', () => {
+    expect(
+      getEmbeddingError({
+        'content-security-policy': "default-src 'self'; frame-ancestors 'self'",
+      }),
+    ).toContain("frame-ancestors 'self'");
+    expect(
+      getEmbeddingError({
+        'content-security-policy': "frame-ancestors 'none'",
+      }),
+    ).toContain("frame-ancestors 'none'");
+  });
+});

--- a/apps/commons-api/src/code-project/code-project.verifier.ts
+++ b/apps/commons-api/src/code-project/code-project.verifier.ts
@@ -9,9 +9,12 @@ export class CodeProjectVerifier {
     const pageErrors: string[] = [];
     const requestFailures: string[] = [];
     const actionErrors: string[] = [];
+    const embeddingErrors: string[] = [];
     const checks: Array<{
       viewport: string;
       passed: boolean;
+      status: number | null;
+      embeddable: boolean;
       title: string;
       bodyText: string;
     }> = [];
@@ -45,10 +48,15 @@ export class CodeProjectVerifier {
           );
         });
 
-        await page.goto(url, {
+        const navigation = await page.goto(url, {
           waitUntil: 'domcontentloaded',
           timeout: 45_000,
         });
+        const status = navigation?.status() ?? null;
+        const embeddingError = getEmbeddingError(
+          navigation?.headers() ?? {},
+        );
+        if (embeddingError) embeddingErrors.push(embeddingError);
         await page
           .waitForLoadState('networkidle', { timeout: 15_000 })
           .catch(() => undefined);
@@ -72,7 +80,15 @@ export class CodeProjectVerifier {
         const rootChildren = await page.locator('#root > *').count();
         checks.push({
           viewport: viewport.name,
-          passed: bodyText.length > 0 && rootChildren > 0,
+          passed:
+            status !== null &&
+            status >= 200 &&
+            status < 300 &&
+            !embeddingError &&
+            bodyText.length > 0 &&
+            rootChildren > 0,
+          status,
+          embeddable: !embeddingError,
           title,
           bodyText: bodyText.slice(0, 2_000),
         });
@@ -83,7 +99,12 @@ export class CodeProjectVerifier {
     }
 
     const unique = (values: string[]) => [...new Set(values)].slice(0, 30);
-    const errors = unique([...pageErrors, ...consoleErrors, ...actionErrors]);
+    const errors = unique([
+      ...pageErrors,
+      ...consoleErrors,
+      ...actionErrors,
+      ...embeddingErrors,
+    ]);
     return {
       passed:
         checks.every((check) => check.passed) &&
@@ -95,10 +116,32 @@ export class CodeProjectVerifier {
       consoleErrors: unique(consoleErrors),
       pageErrors: unique(pageErrors),
       actionErrors: unique(actionErrors),
+      embeddingErrors: unique(embeddingErrors),
       requestFailures: unique(requestFailures),
       screenshot,
     };
   }
+}
+
+export function getEmbeddingError(headers: Record<string, string>) {
+  const frameOptions = headers['x-frame-options']?.trim();
+  if (frameOptions) {
+    return `Preview cannot be embedded because X-Frame-Options is ${frameOptions}`;
+  }
+  const policy = headers['content-security-policy'] || '';
+  const frameAncestors = policy
+    .split(';')
+    .map((directive) => directive.trim())
+    .find((directive) => directive.toLowerCase().startsWith('frame-ancestors'));
+  if (!frameAncestors) return null;
+  const sources = frameAncestors.split(/\s+/).slice(1);
+  if (
+    sources.includes("'none'") ||
+    (sources.length === 1 && sources[0] === "'self'")
+  ) {
+    return `Preview cannot be embedded because CSP is ${frameAncestors}`;
+  }
+  return null;
 }
 
 async function runAction(

--- a/apps/commons-api/src/tool/tools/common-tool.service.ts
+++ b/apps/commons-api/src/tool/tools/common-tool.service.ts
@@ -1879,7 +1879,7 @@ export class CommonToolService {
       ...plugin,
       reviewRequired: true,
       message:
-        'The UI plugin is registered as a draft. Its owner must review and enable it in Studio Apps.',
+        'The UI plugin is registered as a draft. Its owner must review and enable it in Studio Customize → Apps.',
     };
   }
 

--- a/apps/commons-api/src/ui-plugin/ui-plugin.service.spec.ts
+++ b/apps/commons-api/src/ui-plugin/ui-plugin.service.spec.ts
@@ -8,6 +8,7 @@ describe('UiPluginService manifest boundary', () => {
       projectId: 'project-1',
       workspaceId: null,
       publicUrl: 'https://previews.example.com/weather/',
+      verification: { passed: true },
     });
   });
 
@@ -64,5 +65,26 @@ describe('UiPluginService manifest boundary', () => {
         }),
       }),
     );
+  });
+
+  it('rejects a deployment that has not passed browser verification', async () => {
+    jest.spyOn(service as any, 'assertPublishedProject').mockRestore();
+    const limit = jest.fn().mockResolvedValue([
+      {
+        projectId: 'project-1',
+        workspaceId: null,
+        publicUrl: 'https://previews.example.com/weather/',
+        deploymentStatus: 'ready',
+        verification: { passed: false },
+      },
+    ]);
+    const where = jest.fn().mockReturnValue({ limit });
+    const leftJoin = jest.fn().mockReturnValue({ where });
+    const from = jest.fn().mockReturnValue({ leftJoin });
+    (service as any).db = { select: jest.fn().mockReturnValue({ from }) };
+
+    await expect(
+      (service as any).assertPublishedProject('user-1', 'project-1'),
+    ).rejects.toThrow('must pass testCodeProject');
   });
 });

--- a/apps/commons-api/src/ui-plugin/ui-plugin.service.ts
+++ b/apps/commons-api/src/ui-plugin/ui-plugin.service.ts
@@ -163,6 +163,7 @@ export class UiPluginService {
         workspaceId: schema.codeProject.workspaceId,
         publicUrl: schema.codeProjectDeployment.publicUrl,
         deploymentStatus: schema.codeProjectDeployment.status,
+        verification: schema.codeProjectDeployment.verification,
       })
       .from(schema.codeProject)
       .leftJoin(
@@ -183,6 +184,11 @@ export class UiPluginService {
     if (row.deploymentStatus !== 'ready' || !row.publicUrl) {
       throw new BadRequestException(
         'Publish and verify the code project before registering it as UI',
+      );
+    }
+    if (row.verification?.passed !== true) {
+      throw new BadRequestException(
+        'The latest deployment must pass testCodeProject before it can be registered as UI',
       );
     }
     return { ...row, publicUrl: row.publicUrl };

--- a/apps/commons-app/app/apps/[slug]/page.tsx
+++ b/apps/commons-app/app/apps/[slug]/page.tsx
@@ -37,10 +37,10 @@ export default function CustomAppPage() {
           <h1 className="font-semibold">Custom app unavailable</h1>
           <p className="mt-2 text-sm text-muted-foreground">{error}</p>
           <Link
-            href="/studio/apps"
+            href="/studio/customize/apps"
             className="mt-5 inline-flex items-center gap-2 text-sm underline"
           >
-            <ArrowLeft className="h-4 w-4" /> Back to Studio Apps
+            <ArrowLeft className="h-4 w-4" /> Back to Customize Apps
           </Link>
         </div>
       </main>
@@ -57,8 +57,8 @@ export default function CustomAppPage() {
     <main className="flex h-screen flex-col bg-page">
       <header className="flex h-14 items-center gap-3 border-b bg-background px-4">
         <Link
-          href="/studio/apps"
-          aria-label="Back to Studio Apps"
+          href="/studio/customize/apps"
+          aria-label="Back to Customize Apps"
           className="rounded-md p-2 hover:bg-muted"
         >
           <ArrowLeft className="h-4 w-4" />

--- a/apps/commons-app/app/studio/[tab]/page.tsx
+++ b/apps/commons-app/app/studio/[tab]/page.tsx
@@ -24,6 +24,7 @@ import { CreateButton, PageHeader } from "@/components/layout/page-header";
 import { useRouter } from "next/navigation";
 import { useAgents } from "@/hooks/use-agents";
 import { normalizePrincipalId } from "@/lib/principal-id";
+import { CustomizeTabs } from "@/components/customize/customize-tabs";
 
 const StudioPage: NextPage = () => {
   const { tab } = useParams() as { tab: string };
@@ -32,7 +33,13 @@ const StudioPage: NextPage = () => {
   const { authState } = useAuth();
   const userAddress = normalizePrincipalId(authState.walletAddress);
 
-  const activeTab = (tab as string) || pathname?.split("/")[2] || "agents";
+  const activeTab =
+    (tab as string) ||
+    (pathname?.startsWith("/studio/customize/")
+      ? pathname.split("/")[3]
+      : pathname?.split("/")[2]) ||
+    "agents";
+  const isCustomize = pathname?.startsWith("/studio/customize/") ?? false;
 
   const [showCreateWorkflowDialog, setShowCreateWorkflowDialog] =
     useState(false);
@@ -301,6 +308,8 @@ const StudioPage: NextPage = () => {
         <CreditsMenu />
         <CreateButton label={createLabel} onClick={handleCreateClick} />
       </PageHeader>
+
+      {isCustomize && <CustomizeTabs />}
 
       <div className="min-h-0 flex-1 overflow-y-auto">{mainContent}</div>
 

--- a/apps/commons-app/app/studio/agents/[agent]/page.tsx
+++ b/apps/commons-app/app/studio/agents/[agent]/page.tsx
@@ -1455,7 +1455,7 @@ function SkillsView({
             <Button
               size="sm"
               variant="outline"
-              onClick={() => router.push("/studio/skills")}
+              onClick={() => router.push("/studio/customize/skills")}
             >
               Manage skills
               <ExternalLink className="ml-1.5 h-3.5 w-3.5" />
@@ -1495,7 +1495,9 @@ function SkillsView({
               >
                 <button
                   type="button"
-                  onClick={() => router.push(`/studio/skills/${skill.skillId}`)}
+                  onClick={() =>
+                    router.push(`/studio/customize/skills/${skill.skillId}`)
+                  }
                   className="flex min-w-0 flex-1 items-start gap-3 text-left"
                 >
                   <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-100 text-base dark:bg-amber-300/15">

--- a/apps/commons-app/app/studio/customize/[tab]/page.tsx
+++ b/apps/commons-app/app/studio/customize/[tab]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../[tab]/page";

--- a/apps/commons-app/app/studio/customize/page.tsx
+++ b/apps/commons-app/app/studio/customize/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
-export default function LegacyAppsPage() {
+export default function CustomizePage() {
   redirect("/studio/customize/apps");
 }

--- a/apps/commons-app/app/studio/customize/skills/[skillId]/page.tsx
+++ b/apps/commons-app/app/studio/customize/skills/[skillId]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../../skills/[skillId]/page";

--- a/apps/commons-app/app/studio/skills/[skillId]/page.tsx
+++ b/apps/commons-app/app/studio/skills/[skillId]/page.tsx
@@ -52,7 +52,7 @@ export default function SkillDetailPage({
     return (
       <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
         Skill not found.
-        <Button variant="outline" size="sm" onClick={() => router.push("/studio/skills")}>
+        <Button variant="outline" size="sm" onClick={() => router.push("/studio/customize/skills")}>
           <ArrowLeft className="h-4 w-4" />
           Back to skills
         </Button>
@@ -68,7 +68,7 @@ export default function SkillDetailPage({
             variant="ghost"
             size="icon"
             className="h-8 w-8 shrink-0"
-            onClick={() => router.push("/studio/skills")}
+            onClick={() => router.push("/studio/customize/skills")}
             aria-label="Back to skills"
           >
             <ArrowLeft className="h-4 w-4" />

--- a/apps/commons-app/app/studio/skills/page.tsx
+++ b/apps/commons-app/app/studio/skills/page.tsx
@@ -1,1 +1,5 @@
-export { default } from "../[tab]/page";
+import { redirect } from "next/navigation";
+
+export default function LegacySkillsPage() {
+  redirect("/studio/customize/skills");
+}

--- a/apps/commons-app/components/customize/customize-tabs.tsx
+++ b/apps/commons-app/components/customize/customize-tabs.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { AppWindow, Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const tabs = [
+  {
+    label: "Apps",
+    href: "/studio/customize/apps",
+    segment: "/studio/customize/apps",
+    icon: AppWindow,
+  },
+  {
+    label: "Skills",
+    href: "/studio/customize/skills",
+    segment: "/studio/customize/skills",
+    icon: Sparkles,
+  },
+] as const;
+
+export function CustomizeTabs() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      aria-label="Customize sections"
+      className="border-b border-border/70 px-4 sm:px-6"
+    >
+      <div className="flex items-center gap-1">
+        {tabs.map(({ label, href, segment, icon: Icon }) => {
+          const active = pathname?.startsWith(segment);
+          return (
+            <Link
+              key={href}
+              href={href}
+              aria-current={active ? "page" : undefined}
+              className={cn(
+                "relative flex h-11 items-center gap-2 px-3 text-sm text-muted-foreground transition-colors hover:text-foreground",
+                active &&
+                  "font-medium text-foreground after:absolute after:inset-x-2 after:bottom-0 after:h-0.5 after:rounded-full after:bg-foreground",
+              )}
+            >
+              <Icon className="h-4 w-4" strokeWidth={1.75} />
+              {label}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/apps/commons-app/components/layout/dashboard-bar.tsx
+++ b/apps/commons-app/components/layout/dashboard-bar.tsx
@@ -9,7 +9,7 @@ import {
   LibraryBig,
   Wrench,
   Workflow,
-  AppWindow,
+  Settings2,
 } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
@@ -46,7 +46,12 @@ export const DashboardBar: FC<DashboardBarProps> = ({
       path: "/studio/workflows",
     },
     { key: "library", label: "Library", icon: LibraryBig, path: "/library" },
-    { key: "apps", label: "Apps", icon: AppWindow, path: "/studio/apps" },
+    {
+      key: "customize",
+      label: "Customize",
+      icon: Settings2,
+      path: "/studio/customize/apps",
+    },
   ];
 
   return (

--- a/apps/commons-app/components/layout/dashboard-side-bar.tsx
+++ b/apps/commons-app/components/layout/dashboard-side-bar.tsx
@@ -14,7 +14,7 @@ import {
   Loader2,
   Wrench,
   Workflow,
-  AppWindow,
+  Settings2,
 } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { DashboardBar } from "./dashboard-bar";
@@ -39,8 +39,10 @@ export function DashboardSideBar({ username }: { username: string }) {
     if (!pathname) return false;
     // Detail pages ([id] routes) collapse the sidebar; create pages keep the
     // normal expanded sidebar like the studio list pages.
-    return /^\/studio\/(agents|tools|workflows|skills)\/(?!create(?:\/|$))[^/]+/.test(
-      pathname
+    return (
+      /^\/studio\/(agents|tools|workflows|skills)\/(?!create(?:\/|$))[^/]+/.test(
+        pathname
+      ) || /^\/studio\/customize\/skills\/[^/]+/.test(pathname)
     );
   }, [pathname]);
   const sidebarOpen = isOpen && !isLockedDetailRoute;
@@ -58,7 +60,12 @@ export function DashboardSideBar({ username }: { username: string }) {
     if (pathname.startsWith("/studio/tools")) return "tools";
     if (pathname.startsWith("/studio/tasks")) return "tasks";
     if (pathname.startsWith("/studio/workflows")) return "workflows";
-    if (pathname.startsWith("/studio/apps")) return "apps";
+    if (
+      pathname.startsWith("/studio/customize") ||
+      pathname.startsWith("/studio/apps") ||
+      pathname.startsWith("/studio/skills")
+    )
+      return "customize";
     if (pathname.startsWith("/library")) return "library";
     if (pathname.startsWith("/logs")) return "logs";
     if (pathname.startsWith("/spaces")) return "spaces";
@@ -170,10 +177,10 @@ export function DashboardSideBar({ username }: { username: string }) {
                   label: "Library",
                 },
                 {
-                  key: "apps",
-                  icon: AppWindow,
-                  path: "/studio/apps",
-                  label: "Apps",
+                  key: "customize",
+                  icon: Settings2,
+                  path: "/studio/customize/apps",
+                  label: "Customize",
                 },
               ].map(({ key, icon: Icon, path, label }) => (
                 <button

--- a/apps/commons-app/components/skills/skills-marketplace-view.tsx
+++ b/apps/commons-app/components/skills/skills-marketplace-view.tsx
@@ -634,7 +634,9 @@ export function SkillsMarketplaceView({
               key={skill.skillId}
               skill={skill}
               onDelete={handleDelete}
-              onOpen={(id) => router.push(`/studio/skills/${id}`)}
+              onOpen={(id) =>
+                router.push(`/studio/customize/skills/${id}`)
+              }
               onManageAgents={setSelectedSkill}
               isOwner={skill.ownerId === userAddress}
             />


### PR DESCRIPTION
## Summary
- expose only ready public code-project previews through the API gateway without frame-blocking gateway headers
- make browser verification validate HTTP and iframe embedding policy, and require a passing latest deployment before UI plugin registration
- teach the Commons Copilot UI-plugin skill to iterate on browser and action failures until verification passes
- move Apps and Skills into /studio/customize with shared top navigation and legacy redirects

## Verification
- pnpm --filter commons-api-gateway test
- pnpm --filter commons-api-gateway build
- focused code-project verifier and UI-plugin service tests
- pnpm --filter commons-api build
- Commons app TypeScript check against the workspace SDK source
- staging CI and Vercel deployment